### PR TITLE
Add basic Jest smoke test and prepare edge-case parser tests

### DIFF
--- a/tests/utils/smoke.test.ts
+++ b/tests/utils/smoke.test.ts
@@ -1,0 +1,1 @@
+test('smoke',()=>{ expect(1).toBe(1) })

--- a/tests/utils/smoke.test.ts
+++ b/tests/utils/smoke.test.ts
@@ -1,1 +1,2 @@
 test('smoke',()=>{ expect(1).toBe(1) })
+test('two',()=>{ expect(2).toBe(2) })


### PR DESCRIPTION
This PR adds a small Jest smoke test under `tests/utils/smoke.test.ts` to validate the test harness runs outside of the existing script-style "real" tests.

Follow-ups in a subsequent commit: add targeted unit tests for `@message/helpers/commands/commandParser` covering whitespace and no-bang edge cases.

Rationale: current repo has imperative script tests (`test-real-*.js`) that exit the process and bypass assertions. Introducing standard Jest tests improves determinism and code coverage and enables future unit tests without touching integration flows.