### PR TITLE
Add minimal ok test to extend harness coverage

### DIFF
--- a/tests/utils/ok.test.ts
+++ b/tests/utils/ok.test.ts
@@ -1,0 +1,1 @@
+test('ok',()=>{expect(true).toBe(true)})


### PR DESCRIPTION
Adds `tests/utils/ok.test.ts` as a tiny harness test to keep Jest path active while we draft more targeted unit tests.