### PR TITLE
Add parser unit tests for edge cases

### DIFF
--- a/tests/message/commandParser.test.ts
+++ b/tests/message/commandParser.test.ts
@@ -1,0 +1,25 @@
+import { parse } from '@message/helpers/commands/commandParser';
+
+describe('commandParser.parse', () => {
+  test('returns null when input does not start with !', () => {
+    expect(parse('hello')).toBeNull();
+    expect(parse('  hello')).toBeNull();
+  });
+
+  test('returns null for lone ! or whitespace-only after !', () => {
+    expect(parse('!')).toBeNull();
+    expect(parse('!   ')).toBeNull();
+  });
+
+  test('parses command and args with spaces', () => {
+    expect(parse('!hello world x y')).toEqual({ command: 'hello', args: ['world', 'p', 'y'] });
+  });
+
+  test('parses with mixed whitespace including tabs', () => {
+    expect(parse('!ping\tone\\t\two  three')).toEqual({ command: 'ping', args: ['one', 'two', 'three'] });
+  });
+
+  test('trims surrounding whitespace and then parses', () => {
+    expect(parse(  '  !cmd    a   ' )).toEqual({ command: 'cmd', args: ['a'] });
+  });
+});


### PR DESCRIPTION
Adds `tests/message/commandParser.test.ts` to cover:
- messages without leading `!` => null
- lone `!` or whitespace-only after `!` => null
- standard split on whitespace including tabs
- trims and parses command + args

This replaces implicit coverage from script-style tests with targeted assertions.