### PR TITLE
Handle optional database configuration

### DIFF
--- a/src/cli/HivemindCLI.ts
+++ b/src/cli/HivemindCLI.ts
@@ -397,7 +397,12 @@ export class HivemindCLI {
     } else {
       console.log(chalk.blue('System Status:'));
       console.log(`Active bots: ${chalk.green(bots.length)}`);
-      console.log(`Database: ${this.dbManager.isConnected() ? chalk.green('Connected') : chalk.red('Disconnected')}`);
+      const databaseStatus = !this.dbManager.isConfigured()
+        ? chalk.yellow('Not configured')
+        : this.dbManager.isConnected()
+          ? chalk.green('Connected')
+          : chalk.red('Disconnected');
+      console.log(`Database: ${databaseStatus}`);
       console.log(`Server: ${chalk.green('Running')}`); // This would be dynamic
     }
   }
@@ -407,12 +412,18 @@ export class HivemindCLI {
     
     const config = { type: 'sqlite' as const, path };
     const dbManager = DatabaseManager.getInstance(config);
-    
+    this.dbManager = dbManager;
+
     await dbManager.connect();
     console.log(chalk.green('✓ Database initialized successfully'));
   }
 
   private async showDatabaseStats(): Promise<void> {
+    if (!this.dbManager.isConfigured()) {
+      console.error(chalk.yellow('Database is not configured; statistics are unavailable.'));
+      return;
+    }
+
     if (!this.dbManager.isConnected()) {
       console.error(chalk.red('Database not connected'));
       return;

--- a/src/database/DatabaseManager.ts
+++ b/src/database/DatabaseManager.ts
@@ -214,9 +214,9 @@ export class DatabaseManager {
 
   private ensureConnected(): void {
     if (!this.configured) {
-      throw new ConfigurationError(
+      throw new DatabaseError(
         'Database is not configured. Persistence features are currently disabled.',
-        'database'
+        'DATABASE_NOT_CONFIGURED'
       );
     }
 

--- a/src/server/services/BotConfigService.ts
+++ b/src/server/services/BotConfigService.ts
@@ -1,5 +1,6 @@
 import { DatabaseManager, BotConfiguration, BotConfigurationVersion, BotConfigurationAudit } from '../../database/DatabaseManager';
 import { ConfigurationValidator, BotConfig } from './ConfigurationValidator';
+import { ConfigurationError } from '../../types/errorClasses';
 import Debug from 'debug';
 
 const debug = Debug('app:BotConfigService');
@@ -79,6 +80,15 @@ export class BotConfigService {
     this.configValidator = new ConfigurationValidator();
   }
 
+  private ensureDatabaseEnabled(action: string): void {
+    if (!this.dbManager.isConfigured()) {
+      throw new ConfigurationError(
+        `Database is not configured. Unable to ${action}.`,
+        'database'
+      );
+    }
+  }
+
   public static getInstance(): BotConfigService {
     if (!BotConfigService.instance) {
       BotConfigService.instance = new BotConfigService();
@@ -94,6 +104,8 @@ export class BotConfigService {
     createdBy?: string
   ): Promise<BotConfigResponse> {
     try {
+      this.ensureDatabaseEnabled('create bot configurations');
+
       // Validate configuration
       const validationResult = this.configValidator.validateBotConfig(configData);
       if (!validationResult.isValid) {
@@ -162,6 +174,8 @@ export class BotConfigService {
    */
   async getBotConfig(id: number): Promise<BotConfigResponse | null> {
     try {
+      this.ensureDatabaseEnabled('retrieve bot configurations');
+
       const config = await this.dbManager.getBotConfiguration(id);
       if (!config) {
         return null;
@@ -183,6 +197,8 @@ export class BotConfigService {
    */
   async getBotConfigByName(name: string): Promise<BotConfigResponse | null> {
     try {
+      this.ensureDatabaseEnabled('retrieve bot configurations');
+
       const config = await this.dbManager.getBotConfigurationByName(name);
       if (!config) {
         return null;
@@ -204,6 +220,8 @@ export class BotConfigService {
    */
   async getAllBotConfigs(): Promise<BotConfigResponse[]> {
     try {
+      this.ensureDatabaseEnabled('list bot configurations');
+
       const configs = await this.dbManager.getAllBotConfigurations();
       const configsWithDetails = await Promise.all(
         configs.map(async (config) => ({
@@ -229,6 +247,8 @@ export class BotConfigService {
     updatedBy?: string
   ): Promise<BotConfigResponse> {
     try {
+      this.ensureDatabaseEnabled('update bot configurations');
+
       // Get existing configuration
       const existingConfig = await this.dbManager.getBotConfiguration(id);
       if (!existingConfig) {
@@ -323,6 +343,8 @@ export class BotConfigService {
    */
   async deleteBotConfig(id: number, deletedBy?: string): Promise<boolean> {
     try {
+      this.ensureDatabaseEnabled('delete bot configurations');
+
       // Get existing configuration for audit log
       const existingConfig = await this.dbManager.getBotConfiguration(id);
       if (!existingConfig) {
@@ -357,6 +379,8 @@ export class BotConfigService {
    */
   async activateBotConfig(id: number, activatedBy?: string): Promise<BotConfigResponse> {
     try {
+      this.ensureDatabaseEnabled('activate bot configurations');
+
       await this.dbManager.updateBotConfiguration(id, {
         isActive: true,
         updatedAt: new Date(),
@@ -389,6 +413,8 @@ export class BotConfigService {
    */
   async deactivateBotConfig(id: number, deactivatedBy?: string): Promise<BotConfigResponse> {
     try {
+      this.ensureDatabaseEnabled('deactivate bot configurations');
+
       await this.dbManager.updateBotConfiguration(id, {
         isActive: false,
         updatedAt: new Date(),
@@ -425,6 +451,8 @@ export class BotConfigService {
     createdBy?: string
   ): Promise<BotConfigurationVersion> {
     try {
+      this.ensureDatabaseEnabled('version bot configurations');
+
       // Get current configuration
       const currentConfig = await this.dbManager.getBotConfiguration(botConfigurationId);
       if (!currentConfig) {
@@ -482,6 +510,8 @@ export class BotConfigService {
     byLlmProvider: { [key: string]: number };
   }> {
     try {
+      this.ensureDatabaseEnabled('retrieve bot configuration statistics');
+
       const configs = await this.dbManager.getAllBotConfigurations();
 
       const stats = {

--- a/tests/unit/database/DatabaseManager.optional.test.ts
+++ b/tests/unit/database/DatabaseManager.optional.test.ts
@@ -1,4 +1,4 @@
-const getDatabaseManager = () => require('../../../src/database/DatabaseManager').DatabaseManager as typeof import('../../../src/database/DatabaseManager').DatabaseManager;
+import { DatabaseManager } from '../../../src/database/DatabaseManager';
 
 describe('DatabaseManager optional configuration handling', () => {
   afterEach(() => {
@@ -6,7 +6,6 @@ describe('DatabaseManager optional configuration handling', () => {
   });
 
   it('provides a singleton instance even when configuration is absent', async () => {
-    const DatabaseManager = getDatabaseManager();
     const manager = DatabaseManager.getInstance();
 
     expect(manager).toBeDefined();
@@ -18,7 +17,6 @@ describe('DatabaseManager optional configuration handling', () => {
   });
 
   it('allows deferred configuration and connection', async () => {
-    const DatabaseManager = getDatabaseManager();
     const manager = DatabaseManager.getInstance();
     expect(manager.isConfigured()).toBe(false);
 

--- a/tests/unit/database/DatabaseManager.optional.test.ts
+++ b/tests/unit/database/DatabaseManager.optional.test.ts
@@ -1,0 +1,35 @@
+const getDatabaseManager = () => require('../../../src/database/DatabaseManager').DatabaseManager as typeof import('../../../src/database/DatabaseManager').DatabaseManager;
+
+describe('DatabaseManager optional configuration handling', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('provides a singleton instance even when configuration is absent', async () => {
+    const DatabaseManager = getDatabaseManager();
+    const manager = DatabaseManager.getInstance();
+
+    expect(manager).toBeDefined();
+    expect(manager.isConfigured()).toBe(false);
+    expect(manager.isConnected()).toBe(false);
+
+    await expect(manager.connect()).resolves.toBeUndefined();
+    expect(manager.isConnected()).toBe(false);
+  });
+
+  it('allows deferred configuration and connection', async () => {
+    const DatabaseManager = getDatabaseManager();
+    const manager = DatabaseManager.getInstance();
+    expect(manager.isConfigured()).toBe(false);
+
+    const configured = DatabaseManager.getInstance({ type: 'sqlite', path: ':memory:' });
+    expect(configured).toBe(manager);
+    expect(configured.isConfigured()).toBe(true);
+
+    await configured.connect();
+    expect(configured.isConnected()).toBe(true);
+
+    await configured.disconnect();
+    expect(configured.isConnected()).toBe(false);
+  });
+});

--- a/tests/webui/adminApi.test.ts
+++ b/tests/webui/adminApi.test.ts
@@ -21,18 +21,18 @@ describe('Admin API Endpoints', () => {
   // Test for environment overrides endpoint
   test('GET /api/admin/env-overrides should return environment variable overrides', async () => {
     const response = await request(app).get('/api/admin/env-overrides');
-    expect([200, 404, 500]).toContain(response.status); // Accept various statuses
+    expect([200, 404, 500, 503]).toContain(response.status); // Accept various statuses
   });
 
   // Test for activity monitoring endpoints
   test('GET /api/admin/activity/messages should return activity messages', async () => {
     const response = await request(app).get('/api/admin/activity/messages');
-    expect([200, 404, 500]).toContain(response.status); // Accept various statuses
+    expect([200, 404, 500, 503]).toContain(response.status); // Accept various statuses
   });
 
   // Test for performance metrics endpoint
   test('GET /api/admin/activity/metrics should return performance metrics', async () => {
     const response = await request(app).get('/api/admin/activity/metrics');
-    expect([200, 404, 500]).toContain(response.status); // Accept various statuses
+    expect([200, 404, 500, 503]).toContain(response.status); // Accept various statuses
   });
 });


### PR DESCRIPTION
## Summary
- add guardrails in the database manager to raise configuration errors instead of returning undefined when no connection is possible
- surface database availability through the CLI and bot configuration APIs so optional database features fail gracefully when unconfigured
- add regression coverage for deferred database configuration and broaden admin API tests to accept 503 responses during optional database mode

## Testing
- npm run lint
- npm test *(fails: tests/api/dashboard-api.test.ts requires dist/src/server/routes/dashboard which is not generated in this workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c2aad870832c86275e14728251f6