### PR TITLE
feat(ui): add missing DaisyUI v5 wrapper components

### DIFF
--- a/src/client/src/components/DaisyUI/Figure.tsx
+++ b/src/client/src/components/DaisyUI/Figure.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import classNames from 'classnames';
+
+export interface FigureProps extends React.HTMLAttributes<HTMLElement> {
+  /** Image source URL */
+  src?: string;
+  /** Image alt text */
+  alt?: string;
+  /** Caption text displayed below the image */
+  caption?: React.ReactNode;
+  /** Additional CSS classes */
+  className?: string;
+  children?: React.ReactNode;
+}
+
+const Figure: React.FC<FigureProps> = React.memo(({
+  src,
+  alt = '',
+  caption,
+  className,
+  children,
+  ...props
+}) => {
+  const classes = classNames('figure', className);
+
+  return (
+    <figure className={classes} {...props}>
+      {src && <img src={src} alt={alt} />}
+      {children}
+      {caption && <figcaption>{caption}</figcaption>}
+    </figure>
+  );
+});
+
+Figure.displayName = 'Figure';
+
+export default Figure;

--- a/src/client/src/components/DaisyUI/Filter.tsx
+++ b/src/client/src/components/DaisyUI/Filter.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import classNames from 'classnames';
+
+export interface FilterProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Additional CSS classes */
+  className?: string;
+  children?: React.ReactNode;
+}
+
+const Filter: React.FC<FilterProps> = React.memo(({
+  className,
+  children,
+  ...props
+}) => {
+  const classes = classNames('filter', className);
+
+  return (
+    <div className={classes} {...props}>
+      {children}
+    </div>
+  );
+});
+
+Filter.displayName = 'Filter';
+
+export interface FilterResetProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> {
+  /** Additional CSS classes */
+  className?: string;
+}
+
+export const FilterReset: React.FC<FilterResetProps> = React.memo(({
+  className,
+  ...props
+}) => {
+  const classes = classNames('filter-reset', className);
+
+  return (
+    <input type="radio" className={classes} aria-label="Reset filter" {...props} />
+  );
+});
+
+FilterReset.displayName = 'FilterReset';
+
+export default Filter;

--- a/src/client/src/components/DaisyUI/Footer.tsx
+++ b/src/client/src/components/DaisyUI/Footer.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import classNames from 'classnames';
+
+export interface FooterProps extends React.HTMLAttributes<HTMLElement> {
+  /** Center the footer content */
+  center?: boolean;
+  /** Additional CSS classes */
+  className?: string;
+  children?: React.ReactNode;
+}
+
+const Footer: React.FC<FooterProps> = React.memo(({
+  center = false,
+  className,
+  children,
+  ...props
+}) => {
+  const classes = classNames(
+    'footer',
+    {
+      'footer-center': center,
+    },
+    className,
+  );
+
+  return (
+    <footer className={classes} {...props}>
+      {children}
+    </footer>
+  );
+});
+
+Footer.displayName = 'Footer';
+
+export default Footer;

--- a/src/client/src/components/DaisyUI/Link.tsx
+++ b/src/client/src/components/DaisyUI/Link.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import classNames from 'classnames';
+
+export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  /** Color variant */
+  color?: 'primary' | 'secondary' | 'accent' | 'neutral' | 'info' | 'success' | 'warning' | 'error';
+  /** Only show underline on hover */
+  hover?: boolean;
+  /** Render as a custom component (e.g., react-router Link) */
+  as?: React.ElementType;
+  /** Additional CSS classes */
+  className?: string;
+  children?: React.ReactNode;
+}
+
+const Link: React.FC<LinkProps> = React.memo(({
+  color,
+  hover = false,
+  as: Component = 'a',
+  className,
+  children,
+  ...props
+}) => {
+  const classes = classNames(
+    'link',
+    {
+      'link-hover': hover,
+      [`link-${color}`]: color,
+    },
+    className,
+  );
+
+  return (
+    <Component className={classes} {...props}>
+      {children}
+    </Component>
+  );
+});
+
+Link.displayName = 'Link';
+
+export default Link;

--- a/src/client/src/components/DaisyUI/List.tsx
+++ b/src/client/src/components/DaisyUI/List.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import classNames from 'classnames';
+
+export interface ListRowProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Additional CSS classes */
+  className?: string;
+  children?: React.ReactNode;
+}
+
+export const ListRow: React.FC<ListRowProps> = React.memo(({
+  className,
+  children,
+  ...props
+}) => {
+  const classes = classNames('list-row', className);
+
+  return (
+    <div className={classes} {...props}>
+      {children}
+    </div>
+  );
+});
+
+ListRow.displayName = 'ListRow';
+
+export interface ListColGrowProps extends React.HTMLAttributes<HTMLDivElement> {
+  className?: string;
+  children?: React.ReactNode;
+}
+
+export const ListColGrow: React.FC<ListColGrowProps> = React.memo(({
+  className,
+  children,
+  ...props
+}) => {
+  const classes = classNames('list-col-grow', className);
+
+  return (
+    <div className={classes} {...props}>
+      {children}
+    </div>
+  );
+});
+
+ListColGrow.displayName = 'ListColGrow';
+
+export interface ListColWrapProps extends React.HTMLAttributes<HTMLDivElement> {
+  className?: string;
+  children?: React.ReactNode;
+}
+
+export const ListColWrap: React.FC<ListColWrapProps> = React.memo(({
+  className,
+  children,
+  ...props
+}) => {
+  const classes = classNames('list-col-wrap', className);
+
+  return (
+    <div className={classes} {...props}>
+      {children}
+    </div>
+  );
+});
+
+ListColWrap.displayName = 'ListColWrap';
+
+export interface ListProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Additional CSS classes */
+  className?: string;
+  children?: React.ReactNode;
+}
+
+const List: React.FC<ListProps> = React.memo(({
+  className,
+  children,
+  ...props
+}) => {
+  const classes = classNames('list', className);
+
+  return (
+    <div className={classes} {...props}>
+      {children}
+    </div>
+  );
+});
+
+List.displayName = 'List';
+
+export default List;

--- a/src/client/src/components/DaisyUI/RadialProgress.tsx
+++ b/src/client/src/components/DaisyUI/RadialProgress.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import classNames from 'classnames';
+
+export interface RadialProgressProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Progress value from 0 to 100 */
+  value: number;
+  /** Size of the radial progress (CSS size string, e.g., '4rem') */
+  size?: string;
+  /** Thickness of the progress ring (CSS size string, e.g., '0.25rem') */
+  thickness?: string;
+  /** Color variant */
+  color?: 'primary' | 'secondary' | 'accent' | 'neutral' | 'info' | 'success' | 'warning' | 'error';
+  /** Label content displayed in the center */
+  children?: React.ReactNode;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+const RadialProgress: React.FC<RadialProgressProps> = React.memo(({
+  value,
+  size,
+  thickness,
+  color,
+  children,
+  className,
+  style,
+  ...props
+}) => {
+  const classes = classNames(
+    'radial-progress',
+    {
+      [`text-${color}`]: color,
+    },
+    className,
+  );
+
+  const progressStyle: React.CSSProperties = {
+    ...style,
+    '--value': value,
+    ...(size ? { '--size': size } : {}),
+    ...(thickness ? { '--thickness': thickness } : {}),
+  } as React.CSSProperties;
+
+  return (
+    <div
+      className={classes}
+      style={progressStyle}
+      role="progressbar"
+      aria-valuenow={value}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+});
+
+RadialProgress.displayName = 'RadialProgress';
+
+export default RadialProgress;

--- a/src/client/src/components/DaisyUI/Stack.tsx
+++ b/src/client/src/components/DaisyUI/Stack.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import classNames from 'classnames';
+
+export interface StackProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Additional CSS classes */
+  className?: string;
+  children?: React.ReactNode;
+}
+
+const Stack: React.FC<StackProps> = React.memo(({
+  className,
+  children,
+  ...props
+}) => {
+  const classes = classNames('stack', className);
+
+  return (
+    <div className={classes} {...props}>
+      {children}
+    </div>
+  );
+});
+
+Stack.displayName = 'Stack';
+
+export default Stack;

--- a/src/client/src/components/DaisyUI/Swap.tsx
+++ b/src/client/src/components/DaisyUI/Swap.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import classNames from 'classnames';
+
+export interface SwapProps extends Omit<React.HTMLAttributes<HTMLLabelElement>, 'onChange'> {
+  /** Whether the swap is in the "on" state */
+  checked?: boolean;
+  /** Callback when the swap state changes */
+  onChange?: (checked: boolean) => void;
+  /** Content shown when checked/active */
+  onContent: React.ReactNode;
+  /** Content shown when unchecked/inactive */
+  offContent: React.ReactNode;
+  /** Apply rotate animation on swap */
+  rotate?: boolean;
+  /** Apply flip animation on swap */
+  flip?: boolean;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+const Swap: React.FC<SwapProps> = React.memo(({
+  checked,
+  onChange,
+  onContent,
+  offContent,
+  rotate = false,
+  flip = false,
+  className,
+  ...props
+}) => {
+  const classes = classNames(
+    'swap',
+    {
+      'swap-rotate': rotate,
+      'swap-flip': flip,
+    },
+    className,
+  );
+
+  return (
+    <label className={classes} {...props}>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={onChange ? (e) => onChange(e.target.checked) : undefined}
+      />
+      <div className="swap-on">{onContent}</div>
+      <div className="swap-off">{offContent}</div>
+    </label>
+  );
+});
+
+Swap.displayName = 'Swap';
+
+export default Swap;

--- a/src/client/src/components/DaisyUI/Validator.tsx
+++ b/src/client/src/components/DaisyUI/Validator.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import classNames from 'classnames';
+
+export interface ValidatorProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Additional CSS classes */
+  className?: string;
+  children?: React.ReactNode;
+}
+
+const Validator: React.FC<ValidatorProps> = React.memo(({
+  className,
+  children,
+  ...props
+}) => {
+  const classes = classNames('validator', className);
+
+  return (
+    <div className={classes} {...props}>
+      {children}
+    </div>
+  );
+});
+
+Validator.displayName = 'Validator';
+
+export interface ValidatorHintProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Additional CSS classes */
+  className?: string;
+  children?: React.ReactNode;
+}
+
+export const ValidatorHint: React.FC<ValidatorHintProps> = React.memo(({
+  className,
+  children,
+  ...props
+}) => {
+  const classes = classNames('validator-hint', className);
+
+  return (
+    <div className={classes} {...props}>
+      {children}
+    </div>
+  );
+});
+
+ValidatorHint.displayName = 'ValidatorHint';
+
+export default Validator;

--- a/src/client/src/components/DaisyUI/index.ts
+++ b/src/client/src/components/DaisyUI/index.ts
@@ -59,12 +59,34 @@ export { default as Textarea } from './Textarea';
 export { default as Toggle } from './Toggle';
 export { default as Divider } from './Divider';
 
+// Layout Components
+export { default as Footer } from './Footer';
+export type { FooterProps } from './Footer';
+export { default as Stack } from './Stack';
+export type { StackProps } from './Stack';
+export { default as Figure } from './Figure';
+export type { FigureProps } from './Figure';
+
 // Utility Components
 export { default as Kbd } from './Kbd';
 export { default as Tooltip } from './Tooltip';
 export { default as ProgressBar } from './ProgressBar';
+export { default as RadialProgress } from './RadialProgress';
+export type { RadialProgressProps } from './RadialProgress';
 export { default as Countdown } from './Countdown';
 export { default as Mockup } from './Mockup';
+export { default as Swap } from './Swap';
+export type { SwapProps } from './Swap';
+export { default as Link } from './Link';
+export type { LinkProps } from './Link';
+
+// v5 Components
+export { default as List, ListRow, ListColGrow, ListColWrap } from './List';
+export type { ListProps, ListRowProps, ListColGrowProps, ListColWrapProps } from './List';
+export { default as Filter, FilterReset } from './Filter';
+export type { FilterProps, FilterResetProps } from './Filter';
+export { default as Validator, ValidatorHint } from './Validator';
+export type { ValidatorProps, ValidatorHintProps } from './Validator';
 
 // Advanced Components
 export { default as AdvancedThemeSwitcher } from './AdvancedThemeSwitcher';


### PR DESCRIPTION
## Summary
- Add 9 new DaisyUI wrapper components: **Swap**, **Link**, **Footer**, **Stack**, **Figure**, **RadialProgress**, **List**, **Filter**, **Validator**
- All follow existing codebase conventions (classnames, React.memo, displayName, barrel exports)
- Includes v5-specific components (List, Filter, Validator) with sub-components (ListRow, ListColGrow, ListColWrap, FilterReset, ValidatorHint)
- Tree and Color Picker were skipped as they don't exist in the installed daisyui@5.5.19

## Test plan
- [x] TypeScript type check passes (`npx tsc --noEmit` -- no new errors)
- [ ] Visually verify components render correctly when used in pages
- [ ] Confirm barrel exports are importable from `components/DaisyUI`

🤖 Generated with [Claude Code](https://claude.com/claude-code)