### PR TITLE
feat(ui): integrate RadialProgress into dashboard widgets

### DIFF
--- a/src/client/src/components/DaisyUI/DashboardWidgetSystem.tsx
+++ b/src/client/src/components/DaisyUI/DashboardWidgetSystem.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import Debug from 'debug';
 import Card from './Card';
+import RadialProgress from './RadialProgress';
 const debug = Debug('app:client:components:DaisyUI:DashboardWidgetSystem');
 
 interface Widget {
@@ -173,6 +174,12 @@ const QuickActionsWidget: React.FC<WidgetProps> = ({ widget, isEditing, onUpdate
   );
 };
 
+const getHealthColor = (value: number): 'success' | 'warning' | 'error' => {
+  if (value > 80) return 'error';
+  if (value > 60) return 'warning';
+  return 'success';
+};
+
 const SystemHealthWidget: React.FC<WidgetProps> = ({ widget, isEditing, onUpdate: _onUpdate, onRemove, onConfigure }) => {
   const health = widget.data?.health || {
     cpu: 45,
@@ -191,21 +198,19 @@ const SystemHealthWidget: React.FC<WidgetProps> = ({ widget, isEditing, onUpdate
         </ul>
       </div>
     ) : undefined}>
-      <div className="space-y-3">
+      <div className="grid grid-cols-2 gap-4 justify-items-center">
         {Object.entries(health).map(([key, value]) => (
-          <div key={key} className="flex items-center gap-3">
-            <div className="w-16 text-sm capitalize">{key}</div>
-            <div className="flex-1">
-              <progress
-                className={`progress w-full ${
-                  Number(value) > 80 ? 'progress-error' :
-                    Number(value) > 60 ? 'progress-warning' : 'progress-success'
-                }`}
-                value={Number(value)}
-                max="100"
-              />
-            </div>
-            <div className="w-12 text-sm text-right">{Number(value)}%</div>
+          <div key={key} className="flex flex-col items-center gap-1">
+            <RadialProgress
+              value={Number(value)}
+              size="3.5rem"
+              thickness="0.3rem"
+              color={getHealthColor(Number(value))}
+              className="text-sm font-bold"
+            >
+              {Number(value)}%
+            </RadialProgress>
+            <div className="text-xs capitalize text-base-content/70">{key}</div>
           </div>
         ))}
       </div>

--- a/src/client/src/components/Dashboard.tsx
+++ b/src/client/src/components/Dashboard.tsx
@@ -4,6 +4,7 @@ import { Alert } from './DaisyUI/Alert';
 import Button from './DaisyUI/Button';
 import Card from './DaisyUI/Card';
 import Hero from './DaisyUI/Hero';
+import RadialProgress from './DaisyUI/RadialProgress';
 import { SkeletonCard } from './DaisyUI/Skeleton';
 import { Stat, Stats } from './DaisyUI/Stat';
 import DashboardBotCard from './DashboardBotCard';
@@ -272,9 +273,20 @@ const Dashboard: React.FC = () => {
         {/* System Status Footer */}
         {status && (
           <Card title="🖥️ System Information">
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+              <div className="flex items-center gap-4">
+                <RadialProgress
+                  value={bots.length > 0 ? Math.round((activeBots / bots.length) * 100) : 0}
+                  size="4rem"
+                  thickness="0.3rem"
+                  color={activeBots === bots.length ? 'success' : activeBots > 0 ? 'warning' : 'error'}
+                  className="text-sm font-bold flex-shrink-0"
+                >
+                  {bots.length > 0 ? Math.round((activeBots / bots.length) * 100) : 0}%
+                </RadialProgress>
+                <Stat title="Active Bots" value={`${activeBots}/${bots.length}`} valueClassName="text-lg" description="currently active" />
+              </div>
               <Stat title="Uptime" value={<>{uptimeHours}h {uptimeMinutes}m</>} valueClassName="text-lg" description="System running smoothly" />
-              <Stat title="Total Bots" value={bots.length} valueClassName="text-lg" description={`${activeBots} currently active`} />
               <Stat title="Message Volume" value={totalMessages.toLocaleString()} valueClassName="text-lg" description="processed successfully" />
             </div>
           </Card>

--- a/src/client/src/components/Dashboard/HealthCheckWidget.tsx
+++ b/src/client/src/components/Dashboard/HealthCheckWidget.tsx
@@ -4,6 +4,7 @@ import Card from '../DaisyUI/Card';
 import Badge from '../DaisyUI/Badge';
 import { Alert } from '../DaisyUI/Alert';
 import { SkeletonList } from '../DaisyUI/Skeleton';
+import RadialProgress from '../DaisyUI/RadialProgress';
 import {
   CheckCircle,
   AlertTriangle,
@@ -13,6 +14,7 @@ import {
   RefreshCw,
   Activity,
 } from 'lucide-react';
+import Swap from '../DaisyUI/Swap';
 import { apiService } from '../../services/api';
 
 interface ServiceStatus {
@@ -174,9 +176,17 @@ const HealthCheckWidget: React.FC<HealthCheckWidgetProps> = ({
 
         {/* Overall Summary */}
         <div
-          className={`flex items-center gap-3 p-3 rounded-lg mb-4 ${summaryConfig.bg} border ${summaryConfig.border}`}
+          className={`flex items-center gap-4 p-3 rounded-lg mb-4 ${summaryConfig.bg} border ${summaryConfig.border}`}
         >
-          <SummaryIcon className={`w-5 h-5 ${summaryConfig.color}`} />
+          <RadialProgress
+            value={totalCount > 0 ? Math.round((healthyCount / totalCount) * 100) : 0}
+            size="3.5rem"
+            thickness="0.3rem"
+            color={summaryConfig.badge === 'success' ? 'success' : summaryConfig.badge === 'warning' ? 'warning' : 'error'}
+            className="text-xs font-bold flex-shrink-0"
+          >
+            {totalCount > 0 ? Math.round((healthyCount / totalCount) * 100) : 0}%
+          </RadialProgress>
           <div className="flex-1">
             <span className="font-medium text-sm">
               {healthyCount}/{totalCount} services healthy
@@ -218,11 +228,12 @@ const HealthCheckWidget: React.FC<HealthCheckWidgetProps> = ({
                       {formatLatency(service.latencyMs)} latency
                     </div>
                   </div>
-                  {isExpanded ? (
-                    <ChevronUp className="w-4 h-4 text-base-content/40" />
-                  ) : (
-                    <ChevronDown className="w-4 h-4 text-base-content/40" />
-                  )}
+                  <Swap
+                    checked={isExpanded}
+                    onContent={<ChevronUp className="w-4 h-4 text-base-content/40" />}
+                    offContent={<ChevronDown className="w-4 h-4 text-base-content/40" />}
+                    rotate
+                  />
                 </button>
 
                 {isExpanded && (

--- a/src/client/src/components/DashboardBotCard.tsx
+++ b/src/client/src/components/DashboardBotCard.tsx
@@ -6,6 +6,7 @@ import Button from './DaisyUI/Button';
 import { Alert } from './DaisyUI/Alert';
 import Dropdown from './DaisyUI/Dropdown';
 import { Stat } from './DaisyUI/Stat';
+import RadialProgress from './DaisyUI/RadialProgress';
 import type { Bot, StatusResponse } from '../services/api';
 
 interface DashboardBotCardProps {
@@ -79,17 +80,31 @@ const DashboardBotCard: React.FC<DashboardBotCardProps> = memo(({
         </div>
 
         {/* Stats */}
-        <div className="grid grid-cols-2 gap-2 mb-4">
-          <Stat className="bg-base-200 rounded-lg p-3">
-            <div className="stat-title text-xs">Messages</div>
-            <div className="stat-value text-lg">{messageCount.toLocaleString()}</div>
-          </Stat>
-          <Stat className="bg-base-200 rounded-lg p-3">
-            <div className="stat-title text-xs">Status</div>
-            <div className={`stat-value text-lg ${connected ? 'text-success' : 'text-error'}`}>
-              {connected ? '🟢' : '🔴'}
-            </div>
-          </Stat>
+        <div className="grid grid-cols-3 gap-2 mb-4 items-center">
+          <Stat
+            className="bg-base-200 rounded-lg p-3"
+            title="Messages"
+            value={messageCount.toLocaleString()}
+            valueClassName="text-lg"
+          />
+          <Stat
+            className="bg-base-200 rounded-lg p-3"
+            title="Status"
+            value={connected ? '🟢' : '🔴'}
+            valueClassName={`text-lg ${connected ? 'text-success' : 'text-error'}`}
+          />
+          <div className="flex flex-col items-center gap-1">
+            <RadialProgress
+              value={messageCount > 0 ? Math.round(((messageCount - errorCount) / messageCount) * 100) : 100}
+              size="3rem"
+              thickness="0.25rem"
+              color={errorCount === 0 ? 'success' : errorCount / Math.max(messageCount, 1) > 0.1 ? 'error' : 'warning'}
+              className="text-xs font-bold"
+            >
+              {messageCount > 0 ? Math.round(((messageCount - errorCount) / messageCount) * 100) : 100}%
+            </RadialProgress>
+            <div className="text-xs text-base-content/60">Success</div>
+          </div>
         </div>
 
         {errorCount > 0 && (


### PR DESCRIPTION
## Summary
- **SystemHealthWidget**: Replaced linear progress bars with radial progress gauges for CPU, memory, disk, and network metrics in a 2x2 grid layout -- much more visually impactful
- **HealthCheckWidget**: Added radial progress gauge showing overall service health percentage (healthy/total) in the summary banner
- **DashboardBotCard**: Added per-bot success rate radial gauge (messages minus errors / messages) with color-coded thresholds
- **Dashboard footer**: Added active bots percentage radial progress indicator alongside the existing stats

## Test plan
- [ ] Verify SystemHealthWidget renders radial gauges instead of linear bars in the widget dashboard layout
- [ ] Verify HealthCheckWidget summary banner shows radial health percentage
- [ ] Verify DashboardBotCard shows success rate gauge that changes color based on error rate
- [ ] Verify Dashboard System Information footer shows active bots percentage radial
- [ ] Run `cd src/client && npx tsc --noEmit` -- passes with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)