### PR TITLE
feat(ui): integrate Swap component for animated toggle states

### DIFF
--- a/src/client/src/components/DaisyUI/HamburgerMenu.tsx
+++ b/src/client/src/components/DaisyUI/HamburgerMenu.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Swap from './Swap';
 
 interface HamburgerMenuProps {
   onClick: () => void;
@@ -6,42 +7,63 @@ interface HamburgerMenuProps {
   className?: string;
 }
 
+const HamburgerIcon = () => (
+  <svg
+    className="w-6 h-6"
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M4 6h16M4 12h16M4 18h16"
+    />
+  </svg>
+);
+
+const CloseIcon = () => (
+  <svg
+    className="w-6 h-6"
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M6 18L18 6M6 6l12 12"
+    />
+  </svg>
+);
+
 const HamburgerMenu: React.FC<HamburgerMenuProps> = ({
   onClick,
   isOpen = false,
   className = '',
 }) => {
   return (
-    <button
+    <div
       className={`btn btn-ghost btn-circle lg:hidden min-h-[44px] min-w-[44px] ${className}`}
       onClick={onClick}
+      role="button"
+      tabIndex={0}
       aria-label={isOpen ? 'Close menu' : 'Open menu'}
       aria-expanded={isOpen}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } }}
     >
-      <svg
-        className="w-6 h-6"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        {isOpen ? (
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M6 18L18 6M6 6l12 12"
-          />
-        ) : (
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M4 6h16M4 12h16M4 18h16"
-          />
-        )}
-      </svg>
-    </button>
+      <Swap
+        checked={isOpen}
+        onContent={<CloseIcon />}
+        offContent={<HamburgerIcon />}
+        rotate
+        className="swap-active-inherit"
+      />
+    </div>
   );
 };
 

--- a/src/client/src/components/Dashboard/HealthCheckWidget.tsx
+++ b/src/client/src/components/Dashboard/HealthCheckWidget.tsx
@@ -13,6 +13,7 @@ import {
   RefreshCw,
   Activity,
 } from 'lucide-react';
+import Swap from '../DaisyUI/Swap';
 import { apiService } from '../../services/api';
 
 interface ServiceStatus {
@@ -218,11 +219,12 @@ const HealthCheckWidget: React.FC<HealthCheckWidgetProps> = ({
                       {formatLatency(service.latencyMs)} latency
                     </div>
                   </div>
-                  {isExpanded ? (
-                    <ChevronUp className="w-4 h-4 text-base-content/40" />
-                  ) : (
-                    <ChevronDown className="w-4 h-4 text-base-content/40" />
-                  )}
+                  <Swap
+                    checked={isExpanded}
+                    onContent={<ChevronUp className="w-4 h-4 text-base-content/40" />}
+                    offContent={<ChevronDown className="w-4 h-4 text-base-content/40" />}
+                    rotate
+                  />
                 </button>
 
                 {isExpanded && (

--- a/src/client/src/components/ProviderConfig.tsx
+++ b/src/client/src/components/ProviderConfig.tsx
@@ -7,6 +7,7 @@ import { Badge } from './DaisyUI/Badge';
 import Card from './DaisyUI/Card';
 import Input from './DaisyUI/Input';
 import Select from './DaisyUI/Select';
+import Swap from './DaisyUI/Swap';
 import Textarea from './DaisyUI/Textarea';
 import Tooltip from './DaisyUI/Tooltip';
 
@@ -128,7 +129,12 @@ const ProviderConfig: React.FC<ProviderConfigProps> = ({
                 onClick={() => toggleSensitiveData(key)}
                 aria-label={showData ? `Hide ${label}` : `Show ${label}`}
               >
-                {showData ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                <Swap
+                  checked={showData}
+                  onContent={<EyeOff className="w-4 h-4" />}
+                  offContent={<Eye className="w-4 h-4" />}
+                  flip
+                />
               </button>
             </span>
           )}
@@ -169,7 +175,12 @@ const ProviderConfig: React.FC<ProviderConfigProps> = ({
                 onClick={() => toggleSensitiveData(key)}
                 aria-label={showData ? `Hide ${label}` : `Show ${label}`}
               >
-                {showData ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                <Swap
+                  checked={showData}
+                  onContent={<EyeOff className="w-4 h-4" />}
+                  offContent={<Eye className="w-4 h-4" />}
+                  flip
+                />
               </button>
             )}
           </div>

--- a/src/client/src/pages/BotsPage/BotListGrid.tsx
+++ b/src/client/src/pages/BotsPage/BotListGrid.tsx
@@ -13,6 +13,7 @@ interface BotListGridProps {
   handleToggleBotStatus: (bot: BotConfig) => void;
   bulk: any;
   isMobile: boolean;
+  compactView?: boolean;
   onBotDragStart: (index: number) => (e: React.DragEvent) => void;
   onBotDragOver: (index: number) => (e: React.DragEvent) => void;
   onBotDragEnd: () => void;
@@ -31,6 +32,7 @@ export const BotListGrid: React.FC<BotListGridProps> = ({
   handleToggleBotStatus,
   bulk,
   isMobile,
+  compactView = false,
   onBotDragStart,
   onBotDragOver,
   onBotDragEnd,
@@ -40,7 +42,7 @@ export const BotListGrid: React.FC<BotListGridProps> = ({
   onBotMoveDown,
 }) => {
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+    <div className={compactView ? 'grid grid-cols-1 gap-2' : 'grid grid-cols-1 md:grid-cols-2 gap-4'}>
       {filteredBots.map((bot, index) => (
         <div
           key={bot.id}

--- a/src/client/src/pages/BotsPage/index.tsx
+++ b/src/client/src/pages/BotsPage/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Download, RefreshCw, Trash2 } from 'lucide-react';
+import { Download, LayoutGrid, List, RefreshCw, Trash2 } from 'lucide-react';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { CreateBotWizard } from '../../components/BotManagement/CreateBotWizard';
@@ -8,6 +8,7 @@ import { BotSettingsModal } from '../../components/BotSettingsModal';
 import BulkActionBar from '../../components/BulkActionBar';
 import Button from '../../components/DaisyUI/Button';
 import { SkeletonPage } from '../../components/DaisyUI/Skeleton';
+import Swap from '../../components/DaisyUI/Swap';
 import { useErrorToast, useSuccessToast } from '../../components/DaisyUI/ToastNotification';
 import SearchFilterBar from '../../components/SearchFilterBar';
 import Tooltip from '../../components/DaisyUI/Tooltip';
@@ -48,6 +49,7 @@ const BotsPage: React.FC = () => {
   const [, setDeletingBot] = useState<BotConfig | null>(null);
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
   const [bulkDeleting, setBulkDeleting] = useState(false);
+  const [compactView, setCompactView] = useState(false);
 
   const toastSuccess = useSuccessToast();
   const toastError = useErrorToast();
@@ -182,6 +184,23 @@ const BotsPage: React.FC = () => {
                 <option value="active">Active Only</option>
                 <option value="inactive">Inactive Only</option>
               </Select>
+              <Tooltip content={compactView ? 'Switch to grid view' : 'Switch to compact view'}>
+                <div
+                  className="btn btn-ghost btn-sm btn-square"
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => setCompactView(!compactView)}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setCompactView(!compactView); } }}
+                  aria-label={compactView ? 'Switch to grid view' : 'Switch to compact view'}
+                >
+                  <Swap
+                    checked={compactView}
+                    onContent={<LayoutGrid className="w-4 h-4" />}
+                    offContent={<List className="w-4 h-4" />}
+                    rotate
+                  />
+                </div>
+              </Tooltip>
               <Tooltip content="Refresh list">
                 <Button
                   variant="ghost"
@@ -247,6 +266,7 @@ const BotsPage: React.FC = () => {
                 handleToggleBotStatus={handleToggleBotStatus}
                 bulk={bulk}
                 isMobile={isMobile}
+                compactView={compactView}
                 onBotDragStart={onBotDragStart}
                 onBotDragOver={onBotDragOver}
                 onBotDragEnd={onBotDragEnd}

--- a/src/client/src/pages/ChatPage.tsx
+++ b/src/client/src/pages/ChatPage.tsx
@@ -13,6 +13,7 @@ import { useMediaQuery } from '../hooks/useBreakpoint';
 import Drawer from '../components/DaisyUI/Drawer';
 import { BotListItem } from '../components/BotListItem';
 import Tooltip from '../components/DaisyUI/Tooltip';
+import Swap from '../components/DaisyUI/Swap';
 
 // Define Bot type based on API response
 export interface BotData {
@@ -289,7 +290,12 @@ const ChatPage: React.FC = () => {
               aria-label={sidebarOpen ? 'Close sidebar' : 'Open sidebar'}
               aria-expanded={sidebarOpen}
             >
-              {sidebarOpen ? <X className="w-5 h-5" /> : <LucideMenuIcon className="w-5 h-5" />}
+              <Swap
+                checked={sidebarOpen}
+                onContent={<X className="w-5 h-5" />}
+                offContent={<LucideMenuIcon className="w-5 h-5" />}
+                rotate
+              />
             </Button>
           </Tooltip>
         )}


### PR DESCRIPTION
## Summary
- **HamburgerMenu**: Replaced manual SVG path toggling with `<Swap rotate>` for smooth hamburger-to-X animation
- **ChatPage sidebar toggle**: Replaced ternary `Menu`/`X` icon switch with `<Swap rotate>` inside the existing button
- **HealthCheckWidget**: Replaced `ChevronDown`/`ChevronUp` ternary with `<Swap rotate>` for service expand/collapse
- **ProviderConfig**: Replaced `Eye`/`EyeOff` ternary (2 instances) with `<Swap flip>` for sensitive data visibility toggle
- **BotsPage (NEW feature)**: Added a compact/grid view toggle using `<Swap rotate>` with `LayoutGrid`/`List` icons, switching between 2-column grid and single-column compact layout

## Test plan
- [ ] Verify hamburger menu in mobile nav animates between hamburger and X icons
- [ ] Verify ChatPage sidebar toggle rotates between menu and close icons
- [ ] Verify HealthCheckWidget chevron animates on service expand/collapse
- [ ] Verify ProviderConfig eye icons flip when toggling sensitive data visibility
- [ ] Verify BotsPage compact view toggle switches layout between grid and list
- [ ] Run `cd src/client && npx tsc --noEmit` -- passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)