### PR TITLE
refactor: adopt Validator, Link, Steps, and Stat components

### DIFF
--- a/src/client/src/components/BotChatTimeline.tsx
+++ b/src/client/src/components/BotChatTimeline.tsx
@@ -2,55 +2,71 @@
 import React from 'react';
 import { Check, MessageSquare, Bot, User, Clock } from 'lucide-react';
 import { Alert } from './DaisyUI/Alert';
+import Steps from './DaisyUI/Steps';
 
 export const BotChatTimeline: React.FC = () => {
     return (
         <div className="w-full max-w-2xl bg-base-100 p-6 rounded-box shadow-md">
             <h3 className="text-lg font-bold mb-6">Interaction Timeline</h3>
-            <ul className="steps steps-vertical w-full">
-                <li className="step step-primary">
-                    <div className="flex flex-col text-left w-full ml-4 mb-6">
-                        <div className="flex items-center gap-2 font-bold opacity-70 text-xs uppercase tracking-wider mb-1">
-                            <Clock className="w-3 h-3" /> 10:42:15 AM
-                        </div>
-                        <div className="bg-base-200 p-3 rounded-lg rounded-tl-none border border-base-300 relative">
-                            <div className="absolute -left-2 top-0 w-0 h-0 border-t-[10px] border-t-base-300 border-l-[10px] border-l-transparent border-b-[0px] border-b-transparent"></div>
-                            <p className="font-semibold text-sm mb-1 flex items-center gap-2"><User className="w-3 h-3" /> User</p>
-                            <p className="text-sm">"Hello, can you check the server status?"</p>
-                        </div>
-                    </div>
-                </li>
-                <li className="step step-primary">
-                    <div className="flex flex-col text-left w-full ml-4 mb-6">
-                        <div className="flex items-center gap-2 font-bold opacity-70 text-xs uppercase tracking-wider mb-1">
-                            <Clock className="w-3 h-3" /> 10:42:16 AM
-                        </div>
-                        <Alert status="info" className="py-2 px-3 text-sm">
-                            <Check className="w-4 h-4" /> Message received and processed
-                        </Alert>
-                    </div>
-                </li>
-                <li className="step step-primary">
-                    <div className="flex flex-col text-left w-full ml-4 mb-6">
-                        <div className="flex items-center gap-2 font-bold opacity-70 text-xs uppercase tracking-wider mb-1">
-                            <Clock className="w-3 h-3" /> 10:42:18 AM
-                        </div>
-                        <div className="bg-primary/10 p-3 rounded-lg rounded-tl-none border border-primary/20 relative">
-                            <p className="font-semibold text-sm mb-1 flex items-center gap-2"><Bot className="w-3 h-3" /> Assistant</p>
-                            <p className="text-sm">"I'm checking the system metrics now. Please hold on..."</p>
-                        </div>
-                        <div className="mt-2 text-xs opacity-50 font-mono">Thought process: Retrieve health metrics from API...</div>
-                    </div>
-                </li>
-                <li className="step">
-                    <div className="flex flex-col text-left w-full ml-4">
-                        <div className="flex items-center gap-2 font-bold opacity-50 text-xs uppercase tracking-wider mb-1">
-                            <Clock className="w-3 h-3" /> Pending
-                        </div>
-                        <div className="skeleton h-12 w-full rounded-lg"></div>
-                    </div>
-                </li>
-            </ul>
+            <Steps
+                variant="vertical"
+                className="w-full"
+                items={[
+                    {
+                        color: 'primary',
+                        content: (
+                            <div className="flex flex-col text-left w-full ml-4 mb-6">
+                                <div className="flex items-center gap-2 font-bold opacity-70 text-xs uppercase tracking-wider mb-1">
+                                    <Clock className="w-3 h-3" /> 10:42:15 AM
+                                </div>
+                                <div className="bg-base-200 p-3 rounded-lg rounded-tl-none border border-base-300 relative">
+                                    <div className="absolute -left-2 top-0 w-0 h-0 border-t-[10px] border-t-base-300 border-l-[10px] border-l-transparent border-b-[0px] border-b-transparent"></div>
+                                    <p className="font-semibold text-sm mb-1 flex items-center gap-2"><User className="w-3 h-3" /> User</p>
+                                    <p className="text-sm">"Hello, can you check the server status?"</p>
+                                </div>
+                            </div>
+                        ),
+                    },
+                    {
+                        color: 'primary',
+                        content: (
+                            <div className="flex flex-col text-left w-full ml-4 mb-6">
+                                <div className="flex items-center gap-2 font-bold opacity-70 text-xs uppercase tracking-wider mb-1">
+                                    <Clock className="w-3 h-3" /> 10:42:16 AM
+                                </div>
+                                <Alert status="info" className="py-2 px-3 text-sm">
+                                    <Check className="w-4 h-4" /> Message received and processed
+                                </Alert>
+                            </div>
+                        ),
+                    },
+                    {
+                        color: 'primary',
+                        content: (
+                            <div className="flex flex-col text-left w-full ml-4 mb-6">
+                                <div className="flex items-center gap-2 font-bold opacity-70 text-xs uppercase tracking-wider mb-1">
+                                    <Clock className="w-3 h-3" /> 10:42:18 AM
+                                </div>
+                                <div className="bg-primary/10 p-3 rounded-lg rounded-tl-none border border-primary/20 relative">
+                                    <p className="font-semibold text-sm mb-1 flex items-center gap-2"><Bot className="w-3 h-3" /> Assistant</p>
+                                    <p className="text-sm">"I'm checking the system metrics now. Please hold on..."</p>
+                                </div>
+                                <div className="mt-2 text-xs opacity-50 font-mono">Thought process: Retrieve health metrics from API...</div>
+                            </div>
+                        ),
+                    },
+                    {
+                        content: (
+                            <div className="flex flex-col text-left w-full ml-4">
+                                <div className="flex items-center gap-2 font-bold opacity-50 text-xs uppercase tracking-wider mb-1">
+                                    <Clock className="w-3 h-3" /> Pending
+                                </div>
+                                <div className="skeleton h-12 w-full rounded-lg"></div>
+                            </div>
+                        ),
+                    },
+                ]}
+            />
         </div>
     );
 };

--- a/src/client/src/components/DaisyUI/Steps.tsx
+++ b/src/client/src/components/DaisyUI/Steps.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import classNames from 'classnames';
+
+export interface StepItem {
+  /** Content rendered inside the step indicator */
+  content?: React.ReactNode;
+  /** Text label rendered after the step indicator */
+  label?: React.ReactNode;
+  /** Color variant for the step */
+  color?: 'primary' | 'secondary' | 'accent' | 'neutral' | 'info' | 'success' | 'warning' | 'error';
+  /** Override the data-content attribute (e.g. checkmark character) */
+  dataContent?: string;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+export interface StepsProps extends React.HTMLAttributes<HTMLUListElement> {
+  /** Step items to render */
+  items: StepItem[];
+  /** Layout direction */
+  variant?: 'horizontal' | 'vertical';
+  /** Additional CSS classes */
+  className?: string;
+}
+
+const Steps: React.FC<StepsProps> = ({
+  items,
+  variant = 'horizontal',
+  className,
+  ...props
+}) => {
+  const classes = classNames(
+    'steps',
+    { 'steps-vertical': variant === 'vertical' },
+    className,
+  );
+
+  return (
+    <ul className={classes} {...props}>
+      {items.map((item, index) => {
+        const stepClasses = classNames(
+          'step',
+          { [`step-${item.color}`]: item.color },
+          item.className,
+        );
+
+        return (
+          <li
+            key={index}
+            className={stepClasses}
+            {...(item.dataContent !== undefined ? { 'data-content': item.dataContent } : {})}
+          >
+            {item.content || item.label}
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+Steps.displayName = 'Steps';
+
+export default Steps;

--- a/src/client/src/components/DaisyUI/index.ts
+++ b/src/client/src/components/DaisyUI/index.ts
@@ -27,6 +27,8 @@ export type { StatProps, StatsProps } from './Stat';
 export { default as Tabs } from './Tabs';
 export type { TabItem, TabsProps } from './Tabs';
 export { default as StepWizard } from './StepWizard';
+export { default as Steps } from './Steps';
+export type { StepItem, StepsProps } from './Steps';
 export { default as Timeline } from './Timeline';
 export { default as ToastNotification } from './ToastNotification';
 export { default as VisualFeedback } from './VisualFeedback';

--- a/src/client/src/components/DaisyUIComponentTracker.tsx
+++ b/src/client/src/components/DaisyUIComponentTracker.tsx
@@ -10,6 +10,7 @@ import { Alert } from './DaisyUI/Alert';
 import Modal from './DaisyUI/Modal';
 import Tabs from './DaisyUI/Tabs';
 import { Stat } from './DaisyUI/Stat';
+import Link from './DaisyUI/Link';
 import Accordion from './DaisyUI/Accordion';
 
 interface Props {
@@ -148,9 +149,9 @@ const DaisyUIComponentTracker: React.FC<Props> = ({ isOpen = true, onClose }) =>
                       <Badge variant="primary" size="xs">{usage.usageCount} uses</Badge>
                     </div>
                     <div className="text-sm text-base-content/60">
-                      <a href={usage.uri} className="link link-primary" target="_blank" rel="noopener noreferrer">
+                      <Link href={usage.uri} color="primary" target="_blank" rel="noopener noreferrer">
                         View in code
-                      </a>
+                      </Link>
                     </div>
                   </div>
                 ))}

--- a/src/client/src/components/DashboardBotCard.tsx
+++ b/src/client/src/components/DashboardBotCard.tsx
@@ -80,16 +80,18 @@ const DashboardBotCard: React.FC<DashboardBotCardProps> = memo(({
 
         {/* Stats */}
         <div className="grid grid-cols-2 gap-2 mb-4">
-          <Stat className="bg-base-200 rounded-lg p-3">
-            <div className="stat-title text-xs">Messages</div>
-            <div className="stat-value text-lg">{messageCount.toLocaleString()}</div>
-          </Stat>
-          <Stat className="bg-base-200 rounded-lg p-3">
-            <div className="stat-title text-xs">Status</div>
-            <div className={`stat-value text-lg ${connected ? 'text-success' : 'text-error'}`}>
-              {connected ? '🟢' : '🔴'}
-            </div>
-          </Stat>
+          <Stat
+            className="bg-base-200 rounded-lg p-3"
+            title="Messages"
+            value={messageCount.toLocaleString()}
+            valueClassName="text-lg"
+          />
+          <Stat
+            className="bg-base-200 rounded-lg p-3"
+            title="Status"
+            value={connected ? '🟢' : '🔴'}
+            valueClassName={`text-lg ${connected ? 'text-success' : 'text-error'}`}
+          />
         </div>
 
         {errorCount > 0 && (

--- a/src/client/src/components/Login.tsx
+++ b/src/client/src/components/Login.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import Card from './DaisyUI/Card';
 import Input from './DaisyUI/Input';
 import Button from './DaisyUI/Button';
+import Validator, { ValidatorHint } from './DaisyUI/Validator';
 import { Alert } from './DaisyUI/Alert';
 import { Loading, LoadingSpinner } from './DaisyUI/Loading';
 import { useNavigate } from 'react-router-dom';
@@ -73,34 +74,41 @@ const Login: React.FC = () => {
               <label htmlFor="login-username" className="label">
                 <span className="label-text">Username *</span>
               </label>
-              <Input
-                id="login-username"
-                name="username"
-                type="text"
-                value={formData.username}
-                onChange={handleInputChange}
-                placeholder="Enter 'admin'"
-                disabled={isLoading}
-                required
-                autoComplete="username"
-              />
+              <Validator>
+                <Input
+                  id="login-username"
+                  name="username"
+                  type="text"
+                  value={formData.username}
+                  onChange={handleInputChange}
+                  placeholder="Enter 'admin'"
+                  disabled={isLoading}
+                  required
+                  autoComplete="username"
+                />
+                <ValidatorHint>Username is required</ValidatorHint>
+              </Validator>
             </div>
 
             <div className="form-control">
               <label htmlFor="login-password" className="label">
                 <span className="label-text">Password *</span>
               </label>
-              <Input
-                id="login-password"
-                name="password"
-                type="password"
-                value={formData.password}
-                onChange={handleInputChange}
-                placeholder="Enter password"
-                disabled={isLoading}
-                required
-                autoComplete="current-password"
-              />
+              <Validator>
+                <Input
+                  id="login-password"
+                  name="password"
+                  type="password"
+                  value={formData.password}
+                  onChange={handleInputChange}
+                  placeholder="Enter password"
+                  disabled={isLoading}
+                  required
+                  minLength={1}
+                  autoComplete="current-password"
+                />
+                <ValidatorHint>Password is required</ValidatorHint>
+              </Validator>
             </div>
 
             <Button

--- a/src/client/src/components/Personas/PersonaModal.tsx
+++ b/src/client/src/components/Personas/PersonaModal.tsx
@@ -3,6 +3,7 @@ import { AlertTriangle, Copy, Shield, Info } from 'lucide-react';
 import Modal from '../DaisyUI/Modal';
 import Button from '../DaisyUI/Button';
 import Input from '../DaisyUI/Input';
+import Validator, { ValidatorHint } from '../DaisyUI/Validator';
 import { Persona } from './usePersonasLogic';
 import type { Bot } from '../../services/api';
 import Checkbox from '../DaisyUI/Checkbox';
@@ -111,16 +112,23 @@ export const PersonaModal: React.FC<PersonaModalProps> = ({
           </Alert>
         )}
 
-        <Input
-          label="Persona Name"
-          value={personaName}
-          onChange={(e) => setPersonaName(e.target.value)}
-          placeholder="e.g., Helpful Assistant"
-          required
-          disabled={!!isEnvLocked || isViewMode}
-          error={!personaName.trim() ? 'Name is required' : undefined}
-          autoFocus={!isViewMode}
-        />
+        <Validator>
+          <Input
+            label="Persona Name"
+            value={personaName}
+            onChange={(e) => setPersonaName(e.target.value)}
+            placeholder="e.g., Helpful Assistant"
+            required
+            minLength={2}
+            maxLength={100}
+            disabled={!!isEnvLocked || isViewMode}
+            error={!personaName.trim() ? 'Name is required' : undefined}
+            autoFocus={!isViewMode}
+          />
+          <ValidatorHint>
+            {!personaName.trim() ? 'A persona name is required' : 'Must be between 2 and 100 characters'}
+          </ValidatorHint>
+        </Validator>
 
         <div className="form-control w-full">
           <label className="label" htmlFor="persona-category">

--- a/src/client/src/components/Settings/SettingsIntegrations.tsx
+++ b/src/client/src/components/Settings/SettingsIntegrations.tsx
@@ -157,18 +157,24 @@ const SettingsIntegrations: React.FC = () => {
 
       {/* Stats */}
       <div className="grid grid-cols-3 gap-4">
-        <Stat className="bg-base-200/50 rounded-lg p-3">
-          <div className="stat-title text-xs">Total</div>
-          <div className="stat-value text-2xl">{integrations.length}</div>
-        </Stat>
-        <Stat className="bg-base-200/50 rounded-lg p-3">
-          <div className="stat-title text-xs">Connected</div>
-          <div className="stat-value text-2xl text-success">{connectedCount}</div>
-        </Stat>
-        <Stat className="bg-base-200/50 rounded-lg p-3">
-          <div className="stat-title text-xs">Configured</div>
-          <div className="stat-value text-2xl text-info">{configuredCount}</div>
-        </Stat>
+        <Stat
+          className="bg-base-200/50 rounded-lg p-3"
+          title="Total"
+          value={integrations.length}
+          valueClassName="text-2xl"
+        />
+        <Stat
+          className="bg-base-200/50 rounded-lg p-3"
+          title="Connected"
+          value={connectedCount}
+          valueClassName="text-2xl text-success"
+        />
+        <Stat
+          className="bg-base-200/50 rounded-lg p-3"
+          title="Configured"
+          value={configuredCount}
+          valueClassName="text-2xl text-info"
+        />
       </div>
 
       {/* Integration Groups */}

--- a/src/client/src/pages/BotCreatePage.tsx
+++ b/src/client/src/pages/BotCreatePage.tsx
@@ -14,6 +14,8 @@ import { useLlmStatus } from '../hooks/useLlmStatus';
 import AIAssistButton from '../components/AIAssistButton';
 import { apiService } from '../services/api';
 import Card from '../components/DaisyUI/Card';
+import Link from '../components/DaisyUI/Link';
+import Validator, { ValidatorHint } from '../components/DaisyUI/Validator';
 import Debug from 'debug';
 import Checkbox from '../components/DaisyUI/Checkbox';
 const debug = Debug('app:client:pages:BotCreatePage');
@@ -170,13 +172,22 @@ const BotCreatePage: React.FC = () => {
                         onSuccess={(result) => handleInputChange('name', result)}
                       />
                     </label>
-                    <Input
-                      placeholder="e.g. HelpBot"
-                      value={formData.name}
-                      onChange={(e) => handleInputChange('name', e.target.value)}
-                      required
-                      className="input-bordered"
-                    />
+                    <Validator>
+                      <Input
+                        placeholder="e.g. HelpBot"
+                        value={formData.name}
+                        onChange={(e) => handleInputChange('name', e.target.value)}
+                        required
+                        minLength={CONFIG_LIMITS.BOT_NAME_MIN_LENGTH}
+                        maxLength={CONFIG_LIMITS.BOT_NAME_MAX_LENGTH}
+                        className="input-bordered"
+                      />
+                      <ValidatorHint>
+                        {formData.name.length > 0 && formData.name.length < CONFIG_LIMITS.BOT_NAME_MIN_LENGTH
+                          ? `Name must be at least ${CONFIG_LIMITS.BOT_NAME_MIN_LENGTH} characters`
+                          : `${CONFIG_LIMITS.BOT_NAME_MIN_LENGTH}-${CONFIG_LIMITS.BOT_NAME_MAX_LENGTH} characters required`}
+                      </ValidatorHint>
+                    </Validator>
                   </div>
 
                   <div className="form-control w-full">
@@ -319,7 +330,7 @@ const BotCreatePage: React.FC = () => {
                       <span className="label-text font-medium">
                         LLM Provider {defaultLlmConfigured ? '(optional)' : <span className="text-error">*</span>}
                       </span>
-                      <a href="/admin/integrations/llm" target="_blank" rel="noopener noreferrer" className="link link-primary text-xs">Manage Providers</a>
+                      <Link href="/admin/integrations/llm" target="_blank" rel="noopener noreferrer" color="primary" className="text-xs">Manage Providers</Link>
                     </label>
                     <Select
                       value={formData.llmProvider}
@@ -357,7 +368,7 @@ const BotCreatePage: React.FC = () => {
                 <div className="form-control w-full">
                   <label className="label">
                     <span className="label-text font-medium">MCP Servers</span>
-                    <a href="/admin/mcp/servers" target="_blank" rel="noopener noreferrer" className="link link-primary text-xs">Manage MCP Servers</a>
+                    <Link href="/admin/mcp/servers" target="_blank" rel="noopener noreferrer" color="primary" className="text-xs">Manage MCP Servers</Link>
                   </label>
                   <div className="text-sm text-base-content/70 mb-3">
                     Select the Model Context Protocol (MCP) servers this bot can access to use external tools and data.

--- a/src/client/src/pages/BotsPage/BotPreviewSidebar.tsx
+++ b/src/client/src/pages/BotsPage/BotPreviewSidebar.tsx
@@ -121,20 +121,18 @@ export const BotPreviewSidebar: React.FC<BotPreviewSidebarProps> = ({
           </div>
 
           <Stats className="bg-base-200 w-full shadow-sm">
-            <Stat className="p-3">
-              <div className="stat-title text-xs uppercase font-bold">Messages</div>
-              <div className="stat-value text-xl text-primary">{previewBot.messageCount ?? 0}</div>
-            </Stat>
-            <Stat className="p-3">
-              <div className="stat-title text-xs uppercase font-bold">Errors</div>
-              <div
-                className={`stat-value text-xl ${
-                  (previewBot.errorCount ?? 0) > 0 ? 'text-error' : ''
-                }`}
-              >
-                {previewBot.errorCount ?? 0}
-              </div>
-            </Stat>
+            <Stat
+              className="p-3"
+              title={<span className="text-xs uppercase font-bold">Messages</span>}
+              value={previewBot.messageCount ?? 0}
+              valueClassName="text-xl text-primary"
+            />
+            <Stat
+              className="p-3"
+              title={<span className="text-xs uppercase font-bold">Errors</span>}
+              value={previewBot.errorCount ?? 0}
+              valueClassName={`text-xl ${(previewBot.errorCount ?? 0) > 0 ? 'text-error' : ''}`}
+            />
           </Stats>
 
           {/* Tabs Navigation */}

--- a/src/client/src/pages/DaisyUIShowcase.tsx
+++ b/src/client/src/pages/DaisyUIShowcase.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from 'react';
+import Link from '../components/DaisyUI/Link';
 import Modal from '../components/DaisyUI/Modal';
 import Tabs from '../components/DaisyUI/Tabs';
 import type { TabItem } from '../components/DaisyUI/Tabs';
@@ -78,9 +79,9 @@ const DaisyUIShowcase: React.FC = () => {
         <h1 className="text-3xl font-bold">DaisyUI Component Reference</h1>
         <p className="text-base-content/60 mt-1">
           Official DaisyUI components using raw CSS classes -
-          <a href="https://daisyui.com/components/" target="_blank" rel="noopener noreferrer" className="link link-primary ml-1">
+          <Link href="https://daisyui.com/components/" target="_blank" rel="noopener noreferrer" color="primary" className="ml-1">
             View Official Docs
-          </a>
+          </Link>
         </p>
       </div>
 

--- a/src/client/src/pages/OnboardingPage.tsx
+++ b/src/client/src/pages/OnboardingPage.tsx
@@ -9,6 +9,8 @@ import {
   ArrowRight, ArrowLeft, SkipForward, Sparkles,
 } from 'lucide-react';
 import Input from '../components/DaisyUI/Input';
+import Validator, { ValidatorHint } from '../components/DaisyUI/Validator';
+import Steps from '../components/DaisyUI/Steps';
 import Button from '../components/DaisyUI/Button';
 import FormField from '../components/DaisyUI/FormField';
 import ProgressBar from '../components/DaisyUI/ProgressBar';
@@ -17,6 +19,7 @@ import { Alert } from '../components/DaisyUI/Alert';
 import { Badge } from '../components/DaisyUI/Badge';
 import { apiService } from '../services/api';
 import Card from '../components/DaisyUI/Card';
+import Link from '../components/DaisyUI/Link';
 import Select from '../components/DaisyUI/Select';
 import Textarea from '../components/DaisyUI/Textarea';
 
@@ -165,12 +168,16 @@ const ConfigureLlmStep: React.FC<ConfigureLlmStepProps> = ({ form, llmProfiles }
 
       {llmProvider && llmProvider !== 'ollama' && (
         <FormField label="API Key" error={errors.apiKey} hint="Your key is stored securely and never leaves this server.">
-          <Input
-            id="onboarding-api-key"
-            type="password"
-            placeholder={`Enter your ${llmProvider} API key`}
-            {...register('apiKey')}
-          />
+          <Validator>
+            <Input
+              id="onboarding-api-key"
+              type="password"
+              placeholder={`Enter your ${llmProvider} API key`}
+              required
+              {...register('apiKey')}
+            />
+            <ValidatorHint>An API key is required for {llmProvider}</ValidatorHint>
+          </Validator>
         </FormField>
       )}
 
@@ -217,12 +224,17 @@ const CreateBotStep: React.FC<CreateBotStepProps> = ({ form, llmProvider }) => {
       </div>
 
       <FormField label="Bot Name" error={errors.botName} required>
-        <Input
-          id="onboarding-bot-name"
-          placeholder="e.g. HelpBot, CodeAssistant, TeamBot"
-          autoFocus
-          {...register('botName')}
-        />
+        <Validator>
+          <Input
+            id="onboarding-bot-name"
+            placeholder="e.g. HelpBot, CodeAssistant, TeamBot"
+            required
+            minLength={2}
+            autoFocus
+            {...register('botName')}
+          />
+          <ValidatorHint>Bot name must be at least 2 characters</ValidatorHint>
+        </Validator>
       </FormField>
 
       <FormField
@@ -260,7 +272,7 @@ const ConnectMessengerStep: React.FC<ConnectMessengerStepProps> = ({ form }) => 
   const instructions: Record<string, React.ReactNode> = {
     discord: (
       <div className="space-y-2 text-sm">
-        <p>1. Go to the <a href="https://discord.com/developers/applications" target="_blank" rel="noreferrer" className="link link-primary">Discord Developer Portal</a></p>
+        <p>1. Go to the <Link href="https://discord.com/developers/applications" target="_blank" rel="noreferrer" color="primary">Discord Developer Portal</Link></p>
         <p>2. Create a New Application, then go to the Bot section</p>
         <p>3. Click &quot;Reset Token&quot; to generate a bot token</p>
         <p>4. Enable Message Content Intent under Privileged Gateway Intents</p>
@@ -269,7 +281,7 @@ const ConnectMessengerStep: React.FC<ConnectMessengerStepProps> = ({ form }) => 
     ),
     slack: (
       <div className="space-y-2 text-sm">
-        <p>1. Go to <a href="https://api.slack.com/apps" target="_blank" rel="noreferrer" className="link link-primary">Slack API Apps</a></p>
+        <p>1. Go to <Link href="https://api.slack.com/apps" target="_blank" rel="noreferrer" color="primary">Slack API Apps</Link></p>
         <p>2. Create a New App from scratch</p>
         <p>3. Under OAuth &amp; Permissions, add bot scopes: <Badge size="sm">chat:write</Badge>, <Badge size="sm">channels:read</Badge>, <Badge size="sm">app_mentions:read</Badge></p>
         <p>4. Install to your workspace and copy the Bot User OAuth Token</p>
@@ -555,22 +567,19 @@ const OnboardingPage: React.FC = () => {
 
       {/* Steps indicator (DaisyUI steps) */}
       <div className="px-6 py-4 max-w-4xl mx-auto w-full">
-        <ul className="steps w-full">
-          {stepMeta.map((s, i) => {
+        <Steps
+          className="w-full"
+          items={stepMeta.map((s, i) => {
             const stepNum = i + 1;
             const isCompleted = step > stepNum;
             const isActive = step === stepNum;
-            return (
-              <li
-                key={s.label}
-                className={`step ${isCompleted || isActive ? 'step-primary' : ''}`}
-                data-content={isCompleted ? '\u2713' : String(stepNum)}
-              >
-                <span className={`text-xs ${isActive ? 'font-bold' : ''}`}>{s.label}</span>
-              </li>
-            );
+            return {
+              color: isCompleted || isActive ? 'primary' : undefined,
+              dataContent: isCompleted ? '\u2713' : String(stepNum),
+              label: <span className={`text-xs ${isActive ? 'font-bold' : ''}`}>{s.label}</span>,
+            };
           })}
-        </ul>
+        />
       </div>
 
       {/* Step content */}


### PR DESCRIPTION
## Summary
- **Validator**: Wrapped form inputs with `<Validator>` + `<ValidatorHint>` in BotCreatePage (bot name), OnboardingPage (API key, bot name), PersonaModal (persona name), and Login (username, password) for native HTML validation feedback
- **Link**: Converted all 6 remaining raw `<a className="link link-primary">` to `<Link color="primary">` across BotCreatePage, OnboardingPage, DaisyUIShowcase, and DaisyUIComponentTracker
- **Steps**: Created lightweight `Steps` component for simple step displays (vs full StepWizard) and converted raw `className="steps"` in OnboardingPage progress indicator and BotChatTimeline vertical timeline
- **Stat**: Converted raw `stat-title`/`stat-value` div children to `Stat` component `title`/`value`/`valueClassName` props in BotPreviewSidebar (~2), DashboardBotCard (~2), and SettingsIntegrations (~3)

## Test plan
- [ ] Verify TypeScript compiles: `cd src/client && npx tsc --noEmit` (passes)
- [ ] Verify BotCreatePage bot name shows validation hint on submit with short name
- [ ] Verify Login form shows validation hints for empty username/password
- [ ] Verify OnboardingPage step indicators render correctly via Steps component
- [ ] Verify BotChatTimeline vertical timeline renders correctly via Steps component
- [ ] Verify all Link conversions render with proper primary color styling
- [ ] Verify Stat displays in BotPreviewSidebar, DashboardBotCard, SettingsIntegrations are unchanged visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)