### PR TITLE
feat(ui): integrate Footer, Stack, and Figure components

### DIFF
--- a/src/client/src/components/AppFooter.tsx
+++ b/src/client/src/components/AppFooter.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import Footer from './DaisyUI/Footer';
+import { Github, BookOpen, Palette } from 'lucide-react';
+
+const APP_VERSION = '1.0.0';
+
+const AppFooter: React.FC = () => {
+  return (
+    <Footer center className="py-4 px-6 text-base-content/50 text-xs border-t border-base-content/5">
+      <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1">
+        <span>Powered by Open Hivemind v{APP_VERSION}</span>
+        <span className="hidden sm:inline opacity-30">|</span>
+        <a
+          href="https://github.com/matthewhand/open-hivemind"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 hover:text-base-content/80 transition-colors"
+        >
+          <Github className="w-3 h-3" />
+          GitHub
+        </a>
+        <a
+          href="/admin/api-docs"
+          className="inline-flex items-center gap-1 hover:text-base-content/80 transition-colors"
+        >
+          <BookOpen className="w-3 h-3" />
+          API Docs
+        </a>
+        <a
+          href="/admin/showcase"
+          className="inline-flex items-center gap-1 hover:text-base-content/80 transition-colors"
+        >
+          <Palette className="w-3 h-3" />
+          UI Showcase
+        </a>
+      </div>
+    </Footer>
+  );
+};
+
+export default AppFooter;

--- a/src/client/src/components/DaisyUI/ResponsiveNavigation.tsx
+++ b/src/client/src/components/DaisyUI/ResponsiveNavigation.tsx
@@ -9,6 +9,7 @@ import Breadcrumbs from './Breadcrumbs';
 import RateLimitIndicator from './RateLimitIndicator';
 import { useRateLimitToast } from '../../hooks/useRateLimitToast';
 import Card from './Card';
+import AppFooter from '../AppFooter';
 
 interface NavItem {
   id: string;
@@ -102,6 +103,8 @@ const ResponsiveNavigation: React.FC<ResponsiveNavigationProps> = ({
             {children}
           </Card>
         </main>
+
+        <AppFooter />
       </div>
     </div>
   );

--- a/src/client/src/pages/BotsPage/BotPreviewSidebar.tsx
+++ b/src/client/src/pages/BotsPage/BotPreviewSidebar.tsx
@@ -11,6 +11,7 @@ import { Stat, Stats } from '../../components/DaisyUI/Stat';
 import Tooltip from '../../components/DaisyUI/Tooltip';
 import Card from '../../components/DaisyUI/Card';
 import Join from '../../components/DaisyUI/Join';
+import Figure from '../../components/DaisyUI/Figure';
 
 interface BotPreviewSidebarProps {
   previewBot: BotConfig | null;
@@ -73,9 +74,18 @@ export const BotPreviewSidebar: React.FC<BotPreviewSidebarProps> = ({
     <Card className="shadow-xl border border-base-200 sticky top-6 animate-in fade-in slide-in-from-right-4 duration-300">
         <div className="flex justify-between items-start mb-4">
           <div className="flex items-center gap-3">
-            <div className="p-2 rounded-lg bg-primary/10">
-              <Bot className="w-6 h-6 text-primary" />
-            </div>
+            <Figure
+              caption={
+                <span className="text-[10px] uppercase tracking-wider font-semibold opacity-60">
+                  {previewBot.status}
+                </span>
+              }
+              className="flex flex-col items-center"
+            >
+              <div className="p-2 rounded-lg bg-primary/10">
+                <Bot className="w-6 h-6 text-primary" />
+              </div>
+            </Figure>
             <div>
               <h3 className="font-bold text-lg">{previewBot.name}</h3>
               <div className="flex items-center gap-2">

--- a/src/client/src/pages/BotsPage/BotsPageHeader.tsx
+++ b/src/client/src/pages/BotsPage/BotsPageHeader.tsx
@@ -2,6 +2,24 @@ import React from 'react';
 import { Bot, Plus, Download, Upload } from 'lucide-react';
 import PageHeader from '../../components/DaisyUI/PageHeader';
 import QuickAddButton from '../../components/BotManagement/QuickAddButton';
+import Stack from '../../components/DaisyUI/Stack';
+
+/** Stacked bot avatars shown as a visual accent next to the page title */
+const SwarmAvatarStack: React.FC = () => {
+  const colors = ['bg-primary', 'bg-secondary', 'bg-accent'];
+  return (
+    <Stack className="mr-2">
+      {colors.map((color, i) => (
+        <div
+          key={i}
+          className={`${color} text-primary-content w-8 h-8 rounded-full flex items-center justify-center shadow-sm`}
+        >
+          <Bot className="w-4 h-4" />
+        </div>
+      ))}
+    </Stack>
+  );
+};
 
 interface BotsPageHeaderProps {
   onExportAll: () => void;
@@ -22,7 +40,7 @@ export const BotsPageHeader: React.FC<BotsPageHeaderProps> = ({
     <PageHeader
       title="AI Swarm Management"
       description="Configure, monitor, and deploy your specialized AI agents."
-      icon={<Bot className="w-8 h-8 text-primary" />}
+      icon={<SwarmAvatarStack />}
       actions={
         <div className="flex items-center gap-2">
           {onQuickAddMessage && (

--- a/src/client/src/pages/MarketplacePage.tsx
+++ b/src/client/src/pages/MarketplacePage.tsx
@@ -31,6 +31,7 @@ import PageHeader from '../components/DaisyUI/PageHeader';
 import { ConfirmModal } from '../components/DaisyUI/Modal';
 import { Alert } from '../components/DaisyUI/Alert';
 import Input from '../components/DaisyUI/Input';
+import Figure from '../components/DaisyUI/Figure';
 import { apiService } from '../services/api';
 
 // ---------------------------------------------------------------------------
@@ -451,9 +452,14 @@ const MarketplacePage: React.FC = () => {
                   <Card.Body className="p-4">
                     <div className="flex items-start justify-between mb-2">
                       <div className="flex items-center gap-2">
-                        <div className={`p-2 rounded-lg bg-${color}/10`}>
-                          <Icon className={`w-5 h-5 text-${color}`} />
-                        </div>
+                        <Figure
+                          caption={<span className="text-[10px] uppercase font-bold opacity-40">{pkg.type}</span>}
+                          className="flex flex-col items-center"
+                        >
+                          <div className={`p-2 rounded-lg bg-${color}/10`}>
+                            <Icon className={`w-5 h-5 text-${color}`} />
+                          </div>
+                        </Figure>
                         <div>
                           <h3 className="font-semibold">{pkg.displayName}</h3>
                           <p className="text-xs text-base-content/50 font-mono">{pkg.name}</p>

--- a/src/client/src/pages/OnboardingPage.tsx
+++ b/src/client/src/pages/OnboardingPage.tsx
@@ -19,6 +19,8 @@ import { apiService } from '../services/api';
 import Card from '../components/DaisyUI/Card';
 import Select from '../components/DaisyUI/Select';
 import Textarea from '../components/DaisyUI/Textarea';
+import Figure from '../components/DaisyUI/Figure';
+import Stack from '../components/DaisyUI/Stack';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -64,9 +66,17 @@ type MessengerStepValues = z.infer<typeof messengerStepSchema>;
 const WelcomeStep: React.FC = () => (
   <div className="text-center space-y-6 py-4">
     <div className="flex justify-center">
-      <div className="p-6 bg-primary/10 rounded-full">
-        <Sparkles className="w-16 h-16 text-primary" />
-      </div>
+      <Stack>
+        <div className="p-6 bg-primary/10 rounded-full">
+          <Sparkles className="w-16 h-16 text-primary" />
+        </div>
+        <div className="p-6 bg-secondary/10 rounded-full">
+          <Bot className="w-16 h-16 text-secondary" />
+        </div>
+        <div className="p-6 bg-accent/10 rounded-full">
+          <MessageSquare className="w-16 h-16 text-accent" />
+        </div>
+      </Stack>
     </div>
     <h2 className="text-3xl font-bold">Welcome to Open-Hivemind</h2>
     <p className="text-lg text-base-content/70 max-w-xl mx-auto">
@@ -74,21 +84,27 @@ const WelcomeStep: React.FC = () => (
       and connect them to messaging platforms like Discord, Slack, and Mattermost.
     </p>
     <div className="grid grid-cols-1 md:grid-cols-3 gap-4 max-w-2xl mx-auto pt-4">
-      <Card bgVariant="ghost" className="bg-base-200 text-center" compact>
+      <Figure
+        caption={<span className="text-xs text-base-content/60">Connect OpenAI, Anthropic, and more</span>}
+        className="bg-base-200 rounded-xl p-4 text-center"
+      >
         <Cpu className="w-8 h-8 mx-auto mb-2 text-primary" />
         <h4 className="font-semibold text-sm">LLM Providers</h4>
-        <p className="text-xs text-base-content/60">Connect OpenAI, Anthropic, and more</p>
-      </Card>
-      <Card bgVariant="ghost" className="bg-base-200 text-center" compact>
+      </Figure>
+      <Figure
+        caption={<span className="text-xs text-base-content/60">Create specialized agents</span>}
+        className="bg-base-200 rounded-xl p-4 text-center"
+      >
         <Bot className="w-8 h-8 mx-auto mb-2 text-secondary" />
         <h4 className="font-semibold text-sm">AI Bots</h4>
-        <p className="text-xs text-base-content/60">Create specialized agents</p>
-      </Card>
-      <Card bgVariant="ghost" className="bg-base-200 text-center" compact>
+      </Figure>
+      <Figure
+        caption={<span className="text-xs text-base-content/60">Discord, Slack, Mattermost</span>}
+        className="bg-base-200 rounded-xl p-4 text-center"
+      >
         <MessageSquare className="w-8 h-8 mx-auto mb-2 text-accent" />
         <h4 className="font-semibold text-sm">Messengers</h4>
-        <p className="text-xs text-base-content/60">Discord, Slack, Mattermost</p>
-      </Card>
+      </Figure>
     </div>
     <p className="text-sm text-base-content/50">
       This wizard will guide you through initial setup in just a few minutes.


### PR DESCRIPTION
## Summary
- **Footer**: Created `AppFooter` component using the DaisyUI `<Footer>` and integrated it into `ResponsiveNavigation` layout so it appears on every page. Shows app version, GitHub link, API docs link, and UI showcase link.
- **Stack**: Used in `BotsPageHeader` to display stacked bot avatar circles as a visual accent, and in `OnboardingPage` WelcomeStep hero to layer platform icons (Sparkles, Bot, MessageSquare).
- **Figure**: Used in `BotPreviewSidebar` to wrap the bot icon with a status caption, in `OnboardingPage` for the three feature cards (LLM Providers, AI Bots, Messengers), and in `MarketplacePage` for package type icon displays with type label captions.

## Test plan
- [ ] Verify footer appears on dashboard and all admin pages
- [ ] Check BotsPage header shows stacked avatar circles
- [ ] Confirm OnboardingPage welcome step shows stacked hero icons and Figure feature cards
- [ ] Verify BotPreviewSidebar shows Figure-wrapped bot icon with status caption
- [ ] Check MarketplacePage package cards show Figure-wrapped type icons
- [ ] Run `cd src/client && npx tsc --noEmit` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)