### PR TITLE
feat(config): bridge BOTS_* env config with ProviderConfigManager

### DIFF
--- a/src/config/ProviderConfigManager.ts
+++ b/src/config/ProviderConfigManager.ts
@@ -2,6 +2,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import Debug from 'debug';
 import { v4 as uuidv4 } from 'uuid';
+import { BotConfigurationManager } from './BotConfigurationManager';
+import type { BotConfig } from '@src/types/config';
 
 const debug = Debug('app:providerConfigManager');
 
@@ -39,6 +41,9 @@ class ProviderConfigManager {
     if (this.store.message.length === 0 && this.store.llm.length === 0) {
       this.migrateLegacyConfigs();
     }
+
+    // Note: BOTS_* env provider sync is triggered separately via syncBotProviders()
+    // because the ProviderConfigManager singleton may be created before dotenv loads.
   }
 
   public static getInstance(): ProviderConfigManager {
@@ -164,6 +169,249 @@ class ProviderConfigManager {
       this.saveConfig();
       debug('Migration complete');
     }
+  }
+
+  /**
+   * Check if a provider instance already exists by type, category, and a key config field.
+   * Returns the existing instance if found, or undefined.
+   */
+  private findExistingProvider(
+    category: 'message' | 'llm',
+    type: string,
+    configKey: string,
+    configValue: string,
+  ): ProviderInstance | undefined {
+    return this.store[category].find(
+      (p) => p.type === type && p.config[configKey] === configValue,
+    );
+  }
+
+  /**
+   * Sync provider instances from BOTS_* env-configured bots.
+   * For each bot with embedded credentials, creates a provider instance
+   * if one with the same type + credential doesn't already exist.
+   * This is idempotent and safe to call on every startup.
+   */
+  private migrateFromBotEnvConfig(): void {
+    let botConfigManager: BotConfigurationManager;
+    try {
+      botConfigManager = BotConfigurationManager.getInstance();
+    } catch {
+      debug('BotConfigurationManager not available, skipping BOTS_* migration');
+      return;
+    }
+
+    const bots = botConfigManager.getAllBots();
+    if (bots.length === 0) return;
+
+    debug(`Syncing provider instances from ${bots.length} BOTS_* configured bots`);
+    let changed = false;
+
+    for (const bot of bots) {
+      const botName = bot.name.toLowerCase();
+
+      // --- Message providers ---
+      changed = this.syncMessageProvider(bot, botName) || changed;
+
+      // --- LLM providers ---
+      changed = this.syncLlmProvider(bot, botName) || changed;
+    }
+
+    if (changed) {
+      this.saveConfig();
+      debug('BOTS_* provider migration complete');
+    }
+  }
+
+  /**
+   * Create a message provider instance from a bot's embedded config if not already present.
+   * Returns true if a new instance was created.
+   */
+  private syncMessageProvider(bot: BotConfig, botName: string): boolean {
+    const msgType = bot.messageProvider;
+    if (!msgType) return false;
+
+    if (msgType === 'discord' && bot.discord?.token) {
+      if (this.findExistingProvider('message', 'discord', 'token', bot.discord.token)) {
+        return false;
+      }
+      this.store.message.push({
+        id: `bot-${botName}-discord`,
+        type: 'discord',
+        category: 'message',
+        name: `${botName}-discord`,
+        enabled: true,
+        config: {
+          token: bot.discord.token,
+          clientId: bot.discord.clientId || '',
+          guildId: bot.discord.guildId || '',
+          channelId: bot.discord.channelId || '',
+        },
+      });
+      debug(`Created discord message provider for bot "${botName}"`);
+      return true;
+    }
+
+    if (msgType === 'slack' && bot.slack?.botToken) {
+      if (this.findExistingProvider('message', 'slack', 'botToken', bot.slack.botToken)) {
+        return false;
+      }
+      this.store.message.push({
+        id: `bot-${botName}-slack`,
+        type: 'slack',
+        category: 'message',
+        name: `${botName}-slack`,
+        enabled: true,
+        config: {
+          botToken: bot.slack.botToken,
+          appToken: bot.slack.appToken || '',
+          signingSecret: bot.slack.signingSecret || '',
+          joinChannels: bot.slack.joinChannels || '',
+          defaultChannelId: bot.slack.defaultChannelId || '',
+          mode: bot.slack.mode || 'socket',
+        },
+      });
+      debug(`Created slack message provider for bot "${botName}"`);
+      return true;
+    }
+
+    if (msgType === 'mattermost' && bot.mattermost?.token) {
+      if (this.findExistingProvider('message', 'mattermost', 'token', bot.mattermost.token)) {
+        return false;
+      }
+      this.store.message.push({
+        id: `bot-${botName}-mattermost`,
+        type: 'mattermost',
+        category: 'message',
+        name: `${botName}-mattermost`,
+        enabled: true,
+        config: {
+          serverUrl: bot.mattermost.serverUrl || '',
+          token: bot.mattermost.token,
+          channel: bot.mattermost.channel || '',
+        },
+      });
+      debug(`Created mattermost message provider for bot "${botName}"`);
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Create an LLM provider instance from a bot's embedded config if not already present.
+   * Returns true if a new instance was created.
+   */
+  private syncLlmProvider(bot: BotConfig, botName: string): boolean {
+    const llmType = bot.llmProvider;
+    if (!llmType) return false;
+
+    if (llmType === 'openai' && bot.openai?.apiKey) {
+      if (this.findExistingProvider('llm', 'openai', 'apiKey', bot.openai.apiKey)) {
+        return false;
+      }
+      this.store.llm.push({
+        id: `bot-${botName}-openai`,
+        type: 'openai',
+        category: 'llm',
+        name: `${botName}-openai`,
+        enabled: true,
+        config: {
+          apiKey: bot.openai.apiKey,
+          model: bot.openai.model || 'gpt-4o',
+          baseUrl: bot.openai.baseUrl || '',
+        },
+      });
+      debug(`Created openai LLM provider for bot "${botName}"`);
+      return true;
+    }
+
+    if (llmType === 'flowise' && bot.flowise?.apiKey) {
+      if (this.findExistingProvider('llm', 'flowise', 'apiKey', bot.flowise.apiKey)) {
+        return false;
+      }
+      this.store.llm.push({
+        id: `bot-${botName}-flowise`,
+        type: 'flowise',
+        category: 'llm',
+        name: `${botName}-flowise`,
+        enabled: true,
+        config: {
+          apiKey: bot.flowise.apiKey,
+          apiBaseUrl: bot.flowise.apiBaseUrl || '',
+        },
+      });
+      debug(`Created flowise LLM provider for bot "${botName}"`);
+      return true;
+    }
+
+    if (llmType === 'openwebui' && bot.openwebui?.apiKey) {
+      if (this.findExistingProvider('llm', 'openwebui', 'apiKey', bot.openwebui.apiKey)) {
+        return false;
+      }
+      this.store.llm.push({
+        id: `bot-${botName}-openwebui`,
+        type: 'openwebui',
+        category: 'llm',
+        name: `${botName}-openwebui`,
+        enabled: true,
+        config: {
+          apiKey: bot.openwebui.apiKey,
+          apiUrl: bot.openwebui.apiUrl || '',
+        },
+      });
+      debug(`Created openwebui LLM provider for bot "${botName}"`);
+      return true;
+    }
+
+    if (llmType === 'openswarm' && bot.openswarm?.apiKey) {
+      if (this.findExistingProvider('llm', 'openswarm', 'apiKey', bot.openswarm.apiKey)) {
+        return false;
+      }
+      this.store.llm.push({
+        id: `bot-${botName}-openswarm`,
+        type: 'openswarm',
+        category: 'llm',
+        name: `${botName}-openswarm`,
+        enabled: true,
+        config: {
+          baseUrl: bot.openswarm.baseUrl || '',
+          apiKey: bot.openswarm.apiKey,
+          team: bot.openswarm.team || '',
+        },
+      });
+      debug(`Created openswarm LLM provider for bot "${botName}"`);
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Get the provider instance ID for a given bot's message provider.
+   * Returns the ID if a matching provider was created from this bot's config.
+   */
+  public getMessageProviderIdForBot(botName: string): string | undefined {
+    const id = `bot-${botName.toLowerCase()}-`;
+    return this.store.message.find((p) => p.id.startsWith(id))?.id;
+  }
+
+  /**
+   * Get the provider instance ID for a given bot's LLM provider.
+   * Returns the ID if a matching provider was created from this bot's config.
+   */
+  public getLlmProviderIdForBot(botName: string): string | undefined {
+    const id = `bot-${botName.toLowerCase()}-`;
+    return this.store.llm.find((p) => p.id.startsWith(id))?.id;
+  }
+
+  /**
+   * Public entry point to sync BOTS_* env-configured providers.
+   * Must be called after dotenv is loaded and BotConfigurationManager is ready.
+   * Safe to call multiple times — idempotent.
+   */
+  public syncBotProviders(): void {
+    this.migrateFromBotEnvConfig();
   }
 
   // CRUD Operations

--- a/src/config/botConfigFactory.ts
+++ b/src/config/botConfigFactory.ts
@@ -150,6 +150,29 @@ export function createBotConfig(
     };
   }
 
+  // Add Slack configuration if bot token is provided
+  const slackBotToken = botConfig.get('SLACK_BOT_TOKEN');
+  if (slackBotToken) {
+    config.slack = {
+      botToken: slackBotToken,
+      appToken: botConfig.get('SLACK_APP_TOKEN'),
+      signingSecret: botConfig.get('SLACK_SIGNING_SECRET'),
+      joinChannels: botConfig.get('SLACK_JOIN_CHANNELS'),
+      defaultChannelId: botConfig.get('SLACK_DEFAULT_CHANNEL_ID'),
+      mode: botConfig.get('SLACK_MODE') as 'socket' | 'rtm',
+    };
+  }
+
+  // Add Mattermost configuration if token is provided
+  const mattermostToken = botConfig.get('MATTERMOST_TOKEN');
+  if (mattermostToken) {
+    config.mattermost = {
+      serverUrl: botConfig.get('MATTERMOST_SERVER_URL'),
+      token: mattermostToken,
+      channel: botConfig.get('MATTERMOST_CHANNEL'),
+    };
+  }
+
   // Add OpenAI configuration if API key is provided
   const openaiApiKey = botConfig.get('OPENAI_API_KEY');
   if (openaiApiKey) {

--- a/src/di/registration.ts
+++ b/src/di/registration.ts
@@ -57,9 +57,15 @@ export function registerServices(): void {
   });
 
   logger.debug('Registering ProviderConfigManager');
+  const providerConfigManager = ProviderConfigManager.getInstance();
   container.register(TOKENS.ProviderConfigManager, {
-    useValue: ProviderConfigManager.getInstance(),
+    useValue: providerConfigManager,
   });
+
+  // Reload BotConfigurationManager in case it was instantiated before dotenv loaded,
+  // then sync BOTS_* env-configured providers into ProviderConfigManager.
+  BotConfigurationManager.getInstance().reload();
+  providerConfigManager.syncBotProviders();
 
   logger.debug('Registering DatabaseManager');
   container.registerSingleton(TOKENS.DatabaseManager, DatabaseManager);

--- a/src/managers/BotManager.ts
+++ b/src/managers/BotManager.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import Debug from 'debug';
 import { injectable, singleton } from 'tsyringe';
 import { BotConfigurationManager } from '@config/BotConfigurationManager';
+import ProviderConfigManager from '@config/ProviderConfigManager';
 import { SecureConfigManager } from '@config/SecureConfigManager';
 import { UserConfigStore } from '@config/UserConfigStore';
 import { webUIStorage } from '../storage/webUIStorage';
@@ -33,6 +34,7 @@ const debug = Debug('app:BotManager');
 export class BotManager extends EventEmitter {
   private static instance: BotManager;
   private botConfigManager: BotConfigurationManager;
+  private providerConfigManager: ProviderConfigManager;
   private secureConfigManager: SecureConfigManager;
   private customBots = new Map<string, BotInstance>();
   private botsFilePath: string;
@@ -41,6 +43,7 @@ export class BotManager extends EventEmitter {
   constructor() {
     super();
     this.botConfigManager = BotConfigurationManager.getInstance();
+    this.providerConfigManager = ProviderConfigManager.getInstance();
     this.secureConfigManager = SecureConfigManager.getInstanceSync();
     this.botsFilePath = path.join(process.cwd(), 'config', 'user', 'custom-bots.json');
     // Note: loadCustomBots is now async but called from constructor
@@ -126,6 +129,8 @@ export class BotManager extends EventEmitter {
       mcpServers: bot.mcpServers || [],
       mcpGuard: bot.mcpGuard || { enabled: false, type: 'owner' },
       envOverrides: checkBotEnvOverrides(bot.name),
+      messageProviderInstanceId: this.providerConfigManager.getMessageProviderIdForBot(bot.name),
+      llmProviderInstanceId: this.providerConfigManager.getLlmProviderIdForBot(bot.name),
     };
   }
 

--- a/src/managers/botTypes.ts
+++ b/src/managers/botTypes.ts
@@ -15,6 +15,10 @@ export interface BotInstance {
   mcpServers?: MCPConfig[];
   mcpGuard?: MCPGuardConfig;
   envOverrides?: Record<string, { isOverridden: boolean; redactedValue?: string }>;
+  /** Provider instance ID for the message provider (from ProviderConfigManager) */
+  messageProviderInstanceId?: string;
+  /** Provider instance ID for the LLM provider (from ProviderConfigManager) */
+  llmProviderInstanceId?: string;
 }
 
 export interface CreateBotRequest {


### PR DESCRIPTION
## Summary
- Env-configured bots (BOTS_ALPHA_*, BOTS_BETA_*) now automatically create provider instances in ProviderConfigManager at startup, bridging the gap between env-based and WebUI-based provider management
- Added Slack and Mattermost config parsing to botConfigFactory (previously only Discord was parsed)
- BotInstance now exposes `messageProviderInstanceId` and `llmProviderInstanceId` so the WebUI can show which providers each bot uses
- Migration is idempotent: duplicate providers are detected by type + credential match and skipped on restart

## Changes
- **src/config/ProviderConfigManager.ts** — Added `migrateFromBotEnvConfig()` with per-provider sync methods and `syncBotProviders()` public API; added lookup helpers `getMessageProviderIdForBot()` / `getLlmProviderIdForBot()`
- **src/config/botConfigFactory.ts** — Added Slack and Mattermost config extraction from convict schema (was missing, only Discord was handled)
- **src/di/registration.ts** — After DI registration, reload BotConfigurationManager (in case it was instantiated before dotenv) and call `syncBotProviders()`
- **src/managers/BotManager.ts** — Import ProviderConfigManager and populate `messageProviderInstanceId` / `llmProviderInstanceId` on mapped bot instances
- **src/managers/botTypes.ts** — Added optional `messageProviderInstanceId` and `llmProviderInstanceId` fields to `BotInstance`

## Test plan
- [x] Server starts successfully with `npm run dev`
- [x] ALPHA (discord/openai) and BETA (slack/flowise) providers appear in `config/providers/instances.json`
- [x] No duplicate providers created on second startup (idempotency verified)
- [x] Frontend TypeScript compiles cleanly (`cd src/client && npx tsc --noEmit`)
- [x] Server-side TypeScript has no new errors (pre-existing TS7030 in index.ts only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)