### PR TITLE
feat(ui): add detail drawers to Templates and Marketplace pages

### DIFF
--- a/src/client/src/components/DaisyUI/DetailDrawer.tsx
+++ b/src/client/src/components/DaisyUI/DetailDrawer.tsx
@@ -1,0 +1,116 @@
+/**
+ * DetailDrawer -- a right-side slide-out panel for master-detail UIs.
+ *
+ * Slides in from the right edge of the viewport, showing full details
+ * for a selected item. Supports backdrop click and X button to close.
+ * Only one drawer is shown at a time.
+ */
+
+import React, { useEffect, useRef } from 'react';
+import { X } from 'lucide-react';
+
+export interface DetailDrawerProps {
+  /** Whether the drawer is open */
+  isOpen: boolean;
+  /** Called when the drawer should close */
+  onClose: () => void;
+  /** Title shown in the drawer header */
+  title?: React.ReactNode;
+  /** Optional subtitle below the title */
+  subtitle?: React.ReactNode;
+  /** Content to render inside the drawer body */
+  children: React.ReactNode;
+  /** Width class for desktop (default: w-[420px]) */
+  widthClass?: string;
+  /** Additional CSS classes on the drawer panel */
+  className?: string;
+}
+
+const DetailDrawer: React.FC<DetailDrawerProps> = ({
+  isOpen,
+  onClose,
+  title,
+  subtitle,
+  children,
+  widthClass = 'w-[420px]',
+  className = '',
+}) => {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Escape key dismiss
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [isOpen, onClose]);
+
+  // Prevent body scroll when drawer is open
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className={`fixed inset-0 z-40 bg-black/40 transition-opacity duration-300 ${
+          isOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+        }`}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Panel */}
+      <aside
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={typeof title === 'string' ? title : 'Detail panel'}
+        className={[
+          'fixed top-0 right-0 z-50 h-full bg-base-100 shadow-2xl flex flex-col',
+          'transition-transform duration-300 ease-in-out',
+          'w-full md:max-w-[420px]',
+          isOpen ? 'translate-x-0' : 'translate-x-full',
+          className,
+        ].join(' ')}
+        style={widthClass !== 'w-[420px]' ? undefined : undefined}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-base-200 shrink-0">
+          <div className="min-w-0 flex-1">
+            {title && (
+              <h2 className="text-lg font-bold truncate">{title}</h2>
+            )}
+            {subtitle && (
+              <p className="text-sm text-base-content/60 truncate">{subtitle}</p>
+            )}
+          </div>
+          <button
+            className="btn btn-ghost btn-sm btn-circle ml-2 shrink-0"
+            onClick={onClose}
+            aria-label="Close detail panel"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Body (scrollable) */}
+        <div className="flex-1 overflow-y-auto p-4">
+          {children}
+        </div>
+      </aside>
+    </>
+  );
+};
+
+export default DetailDrawer;

--- a/src/client/src/pages/MarketplacePage.tsx
+++ b/src/client/src/pages/MarketplacePage.tsx
@@ -9,6 +9,8 @@ import Modal from '../components/DaisyUI/Modal';
 import Tabs from '../components/DaisyUI/Tabs';
 import { LoadingSpinner } from '../components/DaisyUI/Loading';
 import Tooltip from '../components/DaisyUI/Tooltip';
+import Divider from '../components/DaisyUI/Divider';
+import DetailDrawer from '../components/DaisyUI/DetailDrawer';
 
 import {
   Store as StoreIcon,
@@ -26,6 +28,10 @@ import {
   AlertCircle as AlertIcon,
   CheckCircle as CheckIcon,
   X as CloseIcon,
+  ExternalLink as ExternalLinkIcon,
+  Info as InfoIcon,
+  Calendar as CalendarIcon,
+  Tag as TagIcon,
 } from 'lucide-react';
 import Carousel from '../components/DaisyUI/Carousel';
 import PageHeader from '../components/DaisyUI/PageHeader';
@@ -129,6 +135,8 @@ const MarketplacePage: React.FC = () => {
   const [confirmModal, setConfirmModal] = useState<{
     isOpen: boolean; title: string; message: string; onConfirm: () => void;
   }>({ isOpen: false, title: '', message: '', onConfirm: () => {} });
+  const [drawerPkg, setDrawerPkg] = useState<MarketplacePackage | null>(null);
+  const [drawerTab, setDrawerTab] = useState('overview');
 
   const fetchPackages = useCallback(async () => {
     setLoading(true);
@@ -375,7 +383,13 @@ const MarketplacePage: React.FC = () => {
                                       actionInProgress === `uninstall-${pkg.name}`;
 
                         return (
-              <Card key={pkg.name} className="bg-base-200 hover:bg-base-300 transition-colors">
+              <Card
+                key={pkg.name}
+                className={`bg-base-200 hover:bg-base-300 transition-colors cursor-pointer ${
+                  drawerPkg?.name === pkg.name ? 'ring-2 ring-primary/30 border-primary' : ''
+                }`}
+                onClick={() => { setDrawerPkg(pkg); setDrawerTab('overview'); }}
+              >
                 <Card.Body className="p-4">
                   <div className="flex items-start justify-between mb-2">
                     <div className="flex items-center gap-2">
@@ -402,7 +416,7 @@ const MarketplacePage: React.FC = () => {
                   </div>
 
                   {/* Actions */}
-                  <div className="flex gap-2">
+                  <div className="flex gap-2" onClick={(e) => e.stopPropagation()}>
                     {pkg.status === 'installed' && (
                       <>
                         <Button
@@ -475,7 +489,13 @@ const MarketplacePage: React.FC = () => {
                             actionInProgress === `uninstall-${pkg.name}`;
 
               return (
-                <Card key={pkg.name} className="bg-base-200 hover:bg-base-300 transition-colors">
+                <Card
+                  key={pkg.name}
+                  className={`bg-base-200 hover:bg-base-300 transition-colors cursor-pointer ${
+                    drawerPkg?.name === pkg.name ? 'ring-2 ring-primary/30 border-primary' : ''
+                  }`}
+                  onClick={() => { setDrawerPkg(pkg); setDrawerTab('overview'); }}
+                >
                   <Card.Body className="p-4">
                     <div className="flex items-start justify-between mb-2">
                       <div className="flex items-center gap-2">
@@ -507,7 +527,7 @@ const MarketplacePage: React.FC = () => {
                     </div>
 
                     {/* Actions */}
-                    <div className="flex gap-2">
+                    <div className="flex gap-2" onClick={(e) => e.stopPropagation()}>
                       {pkg.status === 'installed' && (
                         <>
                           <Button
@@ -606,6 +626,237 @@ const MarketplacePage: React.FC = () => {
         confirmText="Uninstall"
         cancelText="Cancel"
       />
+
+      {/* Package Detail Drawer */}
+      <DetailDrawer
+        isOpen={!!drawerPkg}
+        onClose={() => setDrawerPkg(null)}
+        title={drawerPkg?.displayName}
+        subtitle={drawerPkg ? `${drawerPkg.name} v${drawerPkg.version}` : undefined}
+      >
+        {drawerPkg && (() => {
+          const Icon = TYPE_ICONS[drawerPkg.type];
+          const color = TYPE_COLORS[drawerPkg.type];
+          const statusBadge = STATUS_BADGES[drawerPkg.status];
+          const isBusy = actionInProgress?.startsWith(drawerPkg.name) ||
+                        actionInProgress === `update-${drawerPkg.name}` ||
+                        actionInProgress === `uninstall-${drawerPkg.name}`;
+
+          return (
+            <div className="space-y-4">
+              {/* Drawer Tabs */}
+              <Tabs
+                tabs={[
+                  { key: 'overview', label: 'Overview' },
+                  { key: 'details', label: 'Details' },
+                ]}
+                activeTab={drawerTab}
+                onChange={setDrawerTab}
+                variant="boxed"
+                size="sm"
+              />
+
+              {drawerTab === 'overview' && (
+                <div className="space-y-4">
+                  {/* Type & Status */}
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <div className={`p-2 rounded-lg ${TYPE_COLOR_CLASSES[color]?.bg ?? 'bg-base-200'}`}>
+                      <Icon className={`w-5 h-5 ${TYPE_COLOR_CLASSES[color]?.text ?? ''}`} />
+                    </div>
+                    <Badge variant={statusBadge.color} size="sm">{statusBadge.label}</Badge>
+                    <span className="uppercase badge badge-sm badge-outline">{drawerPkg.type}</span>
+                  </div>
+
+                  {/* Description */}
+                  <div>
+                    <label className="text-xs font-bold uppercase opacity-50 mb-1 block">Description</label>
+                    <p className="text-sm whitespace-pre-wrap">{drawerPkg.description || 'No description available.'}</p>
+                  </div>
+
+                  <Divider />
+
+                  {/* Version & Dates */}
+                  <div className="space-y-2 text-sm">
+                    <div className="flex items-center gap-2 text-base-content/70">
+                      <TagIcon className="w-4 h-4" />
+                      <span>Version <strong>{drawerPkg.version}</strong></span>
+                    </div>
+                    {drawerPkg.installedAt && (
+                      <div className="flex items-center gap-2 text-base-content/70">
+                        <CalendarIcon className="w-4 h-4" />
+                        <span>Installed {new Date(drawerPkg.installedAt).toLocaleDateString()}</span>
+                      </div>
+                    )}
+                    {drawerPkg.updatedAt && (
+                      <div className="flex items-center gap-2 text-base-content/70">
+                        <UpdateIcon className="w-4 h-4" />
+                        <span>Updated {new Date(drawerPkg.updatedAt).toLocaleDateString()}</span>
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Repo Link */}
+                  {drawerPkg.repoUrl && (
+                    <>
+                      <Divider />
+                      <a
+                        href={drawerPkg.repoUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="btn btn-outline btn-sm btn-block gap-2"
+                      >
+                        <GitHubIcon className="w-4 h-4" />
+                        View on GitHub
+                        <ExternalLinkIcon className="w-3 h-3" />
+                      </a>
+                    </>
+                  )}
+
+                  <Divider />
+
+                  {/* Installation Status Indicator */}
+                  <div className={`rounded-lg p-3 text-sm ${
+                    drawerPkg.status === 'installed'
+                      ? 'bg-success/10 text-success'
+                      : drawerPkg.status === 'built-in'
+                        ? 'bg-neutral/10 text-base-content/70'
+                        : 'bg-info/10 text-info'
+                  }`}>
+                    <div className="flex items-center gap-2">
+                      {drawerPkg.status === 'installed' && <CheckIcon className="w-4 h-4" />}
+                      {drawerPkg.status === 'built-in' && <InfoIcon className="w-4 h-4" />}
+                      {drawerPkg.status === 'available' && <DownloadIcon className="w-4 h-4" />}
+                      <span className="font-medium">
+                        {drawerPkg.status === 'installed' && 'This package is installed'}
+                        {drawerPkg.status === 'built-in' && 'This package is built-in'}
+                        {drawerPkg.status === 'available' && 'This package is available for installation'}
+                      </span>
+                    </div>
+                  </div>
+
+                  {/* Action Buttons */}
+                  <div className="space-y-2">
+                    {drawerPkg.status === 'installed' && (
+                      <>
+                        <Button
+                          variant="primary"
+                          size="md"
+                          className="w-full"
+                          onClick={() => handleUpdate(drawerPkg.name)}
+                          disabled={isBusy}
+                        >
+                          {actionInProgress === `update-${drawerPkg.name}` ? (
+                            <LoadingSpinner size="xs" />
+                          ) : (
+                            <UpdateIcon className="w-4 h-4" />
+                          )}
+                          Update Package
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="md"
+                          className="w-full text-error"
+                          onClick={() => handleUninstall(drawerPkg.name)}
+                          disabled={isBusy}
+                        >
+                          {actionInProgress === `uninstall-${drawerPkg.name}` ? (
+                            <LoadingSpinner size="xs" />
+                          ) : (
+                            <UninstallIcon className="w-4 h-4" />
+                          )}
+                          Uninstall
+                        </Button>
+                      </>
+                    )}
+                    {drawerPkg.status === 'available' && (
+                      <Button
+                        variant="primary"
+                        size="md"
+                        className="w-full"
+                        onClick={() => {
+                          setDrawerPkg(null);
+                          setGithubUrl(drawerPkg.repoUrl || '');
+                          setInstallModalOpen(true);
+                        }}
+                        disabled={isBusy}
+                      >
+                        <DownloadIcon className="w-4 h-4" />
+                        Install Package
+                      </Button>
+                    )}
+                    {drawerPkg.status === 'built-in' && (
+                      <div className="text-center text-sm text-base-content/50 italic py-2">
+                        Built-in packages are managed by open-hivemind
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {drawerTab === 'details' && (
+                <div className="space-y-4">
+                  {/* Package Metadata */}
+                  <div>
+                    <label className="text-xs font-bold uppercase opacity-50 mb-1 block">Package Name</label>
+                    <p className="text-sm font-mono bg-base-200 rounded p-2">{drawerPkg.name}</p>
+                  </div>
+
+                  <div>
+                    <label className="text-xs font-bold uppercase opacity-50 mb-1 block">Display Name</label>
+                    <p className="text-sm">{drawerPkg.displayName}</p>
+                  </div>
+
+                  <div>
+                    <label className="text-xs font-bold uppercase opacity-50 mb-1 block">Type</label>
+                    <div className="flex items-center gap-2">
+                      <Icon className={`w-4 h-4 ${TYPE_COLOR_CLASSES[color]?.text ?? ''}`} />
+                      <span className="text-sm capitalize">{drawerPkg.type}</span>
+                    </div>
+                  </div>
+
+                  <div>
+                    <label className="text-xs font-bold uppercase opacity-50 mb-1 block">Version</label>
+                    <p className="text-sm">{drawerPkg.version}</p>
+                  </div>
+
+                  <div>
+                    <label className="text-xs font-bold uppercase opacity-50 mb-1 block">Status</label>
+                    <Badge variant={statusBadge.color} size="sm">{statusBadge.label}</Badge>
+                  </div>
+
+                  {drawerPkg.repoUrl && (
+                    <div>
+                      <label className="text-xs font-bold uppercase opacity-50 mb-1 block">Repository</label>
+                      <a
+                        href={drawerPkg.repoUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-sm link link-primary break-all"
+                      >
+                        {drawerPkg.repoUrl}
+                      </a>
+                    </div>
+                  )}
+
+                  {drawerPkg.installedAt && (
+                    <div>
+                      <label className="text-xs font-bold uppercase opacity-50 mb-1 block">Installed At</label>
+                      <p className="text-sm">{new Date(drawerPkg.installedAt).toLocaleString()}</p>
+                    </div>
+                  )}
+
+                  {drawerPkg.updatedAt && (
+                    <div>
+                      <label className="text-xs font-bold uppercase opacity-50 mb-1 block">Last Updated</label>
+                      <p className="text-sm">{new Date(drawerPkg.updatedAt).toLocaleString()}</p>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })()}
+      </DetailDrawer>
     </div>
   );
 };

--- a/src/client/src/pages/TemplatesPage.tsx
+++ b/src/client/src/pages/TemplatesPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import {
   FileText, Search, Filter, Plus, CheckCircle, Clock,
   Tag, Package, AlertCircle, RefreshCw, ChevronRight,
-  Download, Trash2, Copy, Eye
+  Download, Trash2, Copy, Eye, Edit3, User, Calendar
 } from 'lucide-react';
 import { useErrorToast, useSuccessToast } from '../components/DaisyUI/ToastNotification';
 import { usePageLifecycle } from '../hooks/usePageLifecycle';
@@ -19,6 +19,8 @@ import { Badge } from '../components/DaisyUI/Badge';
 import Card from '../components/DaisyUI/Card';
 import Input from '../components/DaisyUI/Input';
 import Textarea from '../components/DaisyUI/Textarea';
+import Divider from '../components/DaisyUI/Divider';
+import DetailDrawer from '../components/DaisyUI/DetailDrawer';
 import { apiService } from '../services/api';
 import { ErrorService } from '../services/ErrorService';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
@@ -60,6 +62,8 @@ const TemplatesPage: React.FC = () => {
   const [botName, setBotName] = useState('');
   const [botDescription, setBotDescription] = useState('');
   const [deletingTemplate, setDeletingTemplate] = useState<ConfigurationTemplate | null>(null);
+  const [drawerTemplate, setDrawerTemplate] = useState<ConfigurationTemplate | null>(null);
+  const [drawerTab, setDrawerTab] = useState('details');
 
   const toastError = useErrorToast();
   const toastSuccess = useSuccessToast();
@@ -169,6 +173,43 @@ const TemplatesPage: React.FC = () => {
     });
     return groups;
   }, [filteredTemplates]);
+
+  const handleOpenDrawer = (template: ConfigurationTemplate) => {
+    setDrawerTemplate(template);
+    setDrawerTab('details');
+  };
+
+  const handleCloseDrawer = () => {
+    setDrawerTemplate(null);
+  };
+
+  const handleExportTemplate = (template: ConfigurationTemplate) => {
+    const blob = new Blob([JSON.stringify(template.config, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${template.name.replace(/\s+/g, '-').toLowerCase()}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+    toastSuccess('Template exported as JSON');
+  };
+
+  const handleDuplicateTemplate = async (template: ConfigurationTemplate) => {
+    try {
+      await apiService.post('/api/admin/templates', {
+        name: `${template.name} (Copy)`,
+        description: template.description,
+        category: template.category,
+        tags: template.tags,
+        config: template.config,
+      });
+      toastSuccess(`Template duplicated as "${template.name} (Copy)"`);
+      await fetchTemplates();
+    } catch (err) {
+      ErrorService.report(err, { action: 'duplicateTemplate', templateId: template.id });
+      toastError(err instanceof Error ? err.message : 'Failed to duplicate template');
+    }
+  };
 
   const handlePreviewTemplate = (template: ConfigurationTemplate) => {
     setSelectedTemplate(template);
@@ -324,7 +365,12 @@ const TemplatesPage: React.FC = () => {
                 {categoryTemplates.map((template) => (
                   <Card
                     key={template.id}
-                    className="shadow-lg border border-base-300 hover:shadow-xl transition-shadow"
+                    className={`shadow-lg border hover:shadow-xl transition-shadow cursor-pointer ${
+                      drawerTemplate?.id === template.id
+                        ? 'border-primary ring-2 ring-primary/30'
+                        : 'border-base-300'
+                    }`}
+                    onClick={() => handleOpenDrawer(template)}
                   >
                       <div className="flex items-start justify-between mb-3">
                         <Card.Title tag="h3" className="text-lg">{template.name}</Card.Title>
@@ -366,7 +412,7 @@ const TemplatesPage: React.FC = () => {
                       <Card.Actions className="gap-2">
                         <button
                           className="btn btn-ghost btn-sm btn-square"
-                          onClick={() => handlePreviewTemplate(template)}
+                          onClick={(e) => { e.stopPropagation(); handlePreviewTemplate(template); }}
                           title="Preview template"
                           aria-label="Preview template"
                         >
@@ -375,7 +421,7 @@ const TemplatesPage: React.FC = () => {
                         {!template.isBuiltIn && (
                           <button
                             className="btn btn-ghost btn-sm btn-square text-error"
-                            onClick={() => setDeletingTemplate(template)}
+                            onClick={(e) => { e.stopPropagation(); setDeletingTemplate(template); }}
                             title="Delete template"
                             aria-label="Delete template"
                           >
@@ -384,7 +430,7 @@ const TemplatesPage: React.FC = () => {
                         )}
                         <button
                           className="btn btn-primary btn-sm"
-                          onClick={() => handleApplyTemplate(template)}
+                          onClick={(e) => { e.stopPropagation(); handleApplyTemplate(template); }}
                         >
                           Apply Template
                           <ChevronRight className="w-4 h-4" />
@@ -554,6 +600,170 @@ const TemplatesPage: React.FC = () => {
         onConfirm={handleDeleteTemplate}
         onClose={() => setDeletingTemplate(null)}
       />
+
+      {/* Template Detail Drawer */}
+      <DetailDrawer
+        isOpen={!!drawerTemplate}
+        onClose={handleCloseDrawer}
+        title={drawerTemplate?.name}
+        subtitle={drawerTemplate ? `${drawerTemplate.category} template` : undefined}
+      >
+        {drawerTemplate && (
+          <div className="space-y-4">
+            {/* Drawer Tabs */}
+            <Tabs
+              tabs={[
+                { key: 'details', label: 'Details' },
+                { key: 'config', label: 'Configuration' },
+              ]}
+              activeTab={drawerTab}
+              onChange={setDrawerTab}
+              variant="boxed"
+              size="sm"
+            />
+
+            {drawerTab === 'details' && (
+              <div className="space-y-4">
+                {/* Category & Built-in Badge */}
+                <div className="flex items-center gap-2 flex-wrap">
+                  <Badge variant="primary" className="capitalize">{drawerTemplate.category}</Badge>
+                  {drawerTemplate.isBuiltIn && (
+                    <Badge variant="info" size="sm">Built-in</Badge>
+                  )}
+                </div>
+
+                {/* Description */}
+                <div>
+                  <label className="text-xs font-bold uppercase opacity-50 mb-1 block">Description</label>
+                  <p className="text-sm">{drawerTemplate.description || 'No description provided.'}</p>
+                </div>
+
+                <Divider />
+
+                {/* Tags */}
+                <div>
+                  <label className="text-xs font-bold uppercase opacity-50 mb-1 block">Tags</label>
+                  {drawerTemplate.tags.length > 0 ? (
+                    <div className="flex flex-wrap gap-1">
+                      {drawerTemplate.tags.map((tag, idx) => (
+                        <Badge key={idx} variant="ghost" size="sm" className="gap-1">
+                          <Tag className="w-3 h-3" />
+                          {tag}
+                        </Badge>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-base-content/50 italic">No tags</p>
+                  )}
+                </div>
+
+                <Divider />
+
+                {/* Usage & Author Info */}
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="bg-base-200 rounded-lg p-3 text-center">
+                    <div className="text-2xl font-bold text-primary">{drawerTemplate.usageCount}</div>
+                    <div className="text-xs text-base-content/60">Bots Created</div>
+                  </div>
+                  <div className="bg-base-200 rounded-lg p-3 text-center">
+                    <div className="text-2xl font-bold text-secondary">
+                      {Object.keys(drawerTemplate.config || {}).length}
+                    </div>
+                    <div className="text-xs text-base-content/60">Config Keys</div>
+                  </div>
+                </div>
+
+                {/* Author / Creation Info */}
+                <div className="space-y-2 text-sm">
+                  {drawerTemplate.createdBy && (
+                    <div className="flex items-center gap-2 text-base-content/70">
+                      <User className="w-4 h-4" />
+                      <span>Created by <strong>{drawerTemplate.createdBy}</strong></span>
+                    </div>
+                  )}
+                  <div className="flex items-center gap-2 text-base-content/70">
+                    <Calendar className="w-4 h-4" />
+                    <span>Created {new Date(drawerTemplate.createdAt).toLocaleDateString()}</span>
+                  </div>
+                  <div className="flex items-center gap-2 text-base-content/70">
+                    <Clock className="w-4 h-4" />
+                    <span>Updated {new Date(drawerTemplate.updatedAt).toLocaleDateString()}</span>
+                  </div>
+                </div>
+
+                <Divider />
+
+                {/* Action Buttons */}
+                <div className="space-y-2">
+                  <button
+                    className="btn btn-primary btn-block"
+                    onClick={() => {
+                      handleCloseDrawer();
+                      handleApplyTemplate(drawerTemplate);
+                    }}
+                  >
+                    <Plus className="w-4 h-4" />
+                    Create Bot from Template
+                  </button>
+
+                  <button
+                    className="btn btn-outline btn-block"
+                    onClick={() => handleDuplicateTemplate(drawerTemplate)}
+                  >
+                    <Copy className="w-4 h-4" />
+                    Duplicate Template
+                  </button>
+
+                  {!drawerTemplate.isBuiltIn && (
+                    <button
+                      className="btn btn-outline btn-block"
+                      onClick={() => {
+                        handleCloseDrawer();
+                        handlePreviewTemplate(drawerTemplate);
+                      }}
+                    >
+                      <Edit3 className="w-4 h-4" />
+                      Edit Template
+                    </button>
+                  )}
+
+                  <button
+                    className="btn btn-outline btn-block"
+                    onClick={() => handleExportTemplate(drawerTemplate)}
+                  >
+                    <Download className="w-4 h-4" />
+                    Export as JSON
+                  </button>
+
+                  {!drawerTemplate.isBuiltIn && (
+                    <button
+                      className="btn btn-error btn-outline btn-block"
+                      onClick={() => {
+                        handleCloseDrawer();
+                        setDeletingTemplate(drawerTemplate);
+                      }}
+                    >
+                      <Trash2 className="w-4 h-4" />
+                      Delete Template
+                    </button>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {drawerTab === 'config' && (
+              <div className="space-y-3">
+                <label className="text-xs font-bold uppercase opacity-50 block">
+                  Full Configuration
+                </label>
+                <CodeBlock className="bg-base-200 p-4" maxHeight="max-h-[60vh]">
+                  {JSON.stringify(drawerTemplate.config, null, 2)}
+                </CodeBlock>
+              </div>
+            )}
+          </div>
+        )}
+      </DetailDrawer>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Add a reusable `DetailDrawer` component (`src/client/src/components/DaisyUI/DetailDrawer.tsx`) that slides from the right with backdrop/Escape dismiss and smooth transitions
- **TemplatesPage**: clicking a template card opens a drawer with Details/Configuration tabs showing description, tags, usage stats, author/date info, and action buttons (Create Bot, Duplicate, Edit, Export JSON, Delete)
- **MarketplacePage**: clicking a package card opens a drawer with Overview/Details tabs showing description, version, install status, repo link, and Install/Update/Uninstall actions
- Selected card is highlighted with a primary ring in both pages
- Action buttons on cards use `stopPropagation` to avoid opening the drawer

## Test plan
- [ ] Open TemplatesPage, click a template card -- drawer slides from right with full details
- [ ] Switch between Details and Configuration tabs in the drawer
- [ ] Click "Create Bot from Template" in the drawer -- apply modal opens
- [ ] Click "Export as JSON" -- downloads template config
- [ ] Close drawer via X button, Escape key, or backdrop click
- [ ] Card action buttons (Preview, Delete, Apply) still work without opening the drawer
- [ ] Open MarketplacePage, click a package card -- drawer slides from right
- [ ] Switch between Overview and Details tabs
- [ ] Install/Update/Uninstall buttons work from within the drawer
- [ ] GitHub link opens in new tab
- [ ] Drawer is full-width on mobile, ~450px on desktop
- [ ] Only one drawer open at a time; clicking a different card switches content

🤖 Generated with [Claude Code](https://claude.com/claude-code)