### PR TITLE
feat(ui): add detail drawers to GuardsPage and PersonasPage

### DIFF
--- a/src/client/src/components/DaisyUI/DetailDrawer.tsx
+++ b/src/client/src/components/DaisyUI/DetailDrawer.tsx
@@ -1,0 +1,116 @@
+/**
+ * DetailDrawer -- right-side slide-over panel for master-detail views.
+ *
+ * Designed for item detail panels that slide in from the right side
+ * when a user clicks an item in a list. Supports:
+ *   - Escape-key and backdrop-click dismiss
+ *   - Smooth slide-in/out transitions
+ *   - Responsive: full-width on mobile, fixed-width on desktop
+ *   - Custom header with close button
+ *   - Scrollable body content
+ */
+
+import React, { useEffect, useCallback } from 'react';
+import { X } from 'lucide-react';
+
+export interface DetailDrawerProps {
+  /** Whether the drawer is open */
+  isOpen: boolean;
+  /** Called when the drawer should close */
+  onClose: () => void;
+  /** Header title */
+  title?: React.ReactNode;
+  /** Optional subtitle shown below the title */
+  subtitle?: React.ReactNode;
+  /** Body content */
+  children?: React.ReactNode;
+  /** Additional CSS classes for the drawer panel */
+  className?: string;
+  /** Width class for desktop (default: "w-[28rem]") */
+  width?: string;
+}
+
+const DetailDrawer: React.FC<DetailDrawerProps> = ({
+  isOpen,
+  onClose,
+  title,
+  subtitle,
+  children,
+  className = '',
+  width = 'w-[28rem]',
+}) => {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, handleKeyDown]);
+
+  // Prevent body scroll when drawer is open on mobile
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className={`fixed inset-0 z-40 bg-black/30 transition-opacity duration-300 ${
+          isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'
+        }`}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Drawer panel */}
+      <aside
+        className={`fixed top-0 right-0 z-50 h-full ${width} max-w-full bg-base-100 shadow-2xl flex flex-col transition-transform duration-300 ease-in-out ${
+          isOpen ? 'translate-x-0' : 'translate-x-full'
+        } ${className}`}
+        role="dialog"
+        aria-modal="true"
+        aria-label={typeof title === 'string' ? title : 'Detail panel'}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between gap-3 p-4 border-b border-base-300 shrink-0">
+          <div className="min-w-0">
+            {title && (
+              <h2 className="text-lg font-bold truncate">{title}</h2>
+            )}
+            {subtitle && (
+              <p className="text-sm text-base-content/60 mt-0.5 line-clamp-2">
+                {subtitle}
+              </p>
+            )}
+          </div>
+          <button
+            type="button"
+            className="btn btn-ghost btn-sm btn-square shrink-0"
+            onClick={onClose}
+            aria-label="Close detail panel"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Scrollable body */}
+        <div className="flex-1 overflow-y-auto p-4">{children}</div>
+      </aside>
+    </>
+  );
+};
+
+export default DetailDrawer;

--- a/src/client/src/components/DaisyUI/index.ts
+++ b/src/client/src/components/DaisyUI/index.ts
@@ -43,6 +43,8 @@ export { default as HamburgerMenu } from './HamburgerMenu';
 export { default as Drawer } from './Drawer';
 export { EnhancedDrawer } from './Drawer';
 export type { DrawerNavItem, DrawerProps } from './Drawer';
+export { default as DetailDrawer } from './DetailDrawer';
+export type { DetailDrawerProps } from './DetailDrawer';
 export { default as Menu } from './Menu';
 
 // Form & Input Components

--- a/src/client/src/pages/GuardsPage.tsx
+++ b/src/client/src/pages/GuardsPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Shield, RefreshCw, AlertTriangle, Plus, Copy, Trash2, Edit2 } from 'lucide-react';
+import { Shield, RefreshCw, AlertTriangle, Plus, Copy, Trash2, Edit2, CheckCircle, XCircle } from 'lucide-react';
 import PageHeader from '../components/DaisyUI/PageHeader';
 import Card from '../components/DaisyUI/Card';
 import Divider from '../components/DaisyUI/Divider';
@@ -15,6 +15,7 @@ import { FormField } from '../components/DaisyUI/formTypes';
 import RangeSlider from '../components/DaisyUI/RangeSlider';
 import { Badge } from '../components/DaisyUI/Badge';
 import Accordion from '../components/DaisyUI/Accordion';
+import DetailDrawer from '../components/DaisyUI/DetailDrawer';
 import { GuardProfile } from '@shared/types/models/security';
 import { useToast } from '../components/DaisyUI/ToastNotification';
 import { LoadingSpinner } from '../components/DaisyUI/Loading';
@@ -117,11 +118,29 @@ const defaultNewProfile: Omit<GuardProfile, 'id' | 'createdAt' | 'updatedAt'> = 
   }
 };
 
+/** Read-only status row for the detail drawer */
+const GuardStatusRow: React.FC<{ icon: React.ReactNode; label: string; enabled: boolean; detail: string }> = ({ icon, label, enabled, detail }) => (
+  <div className="flex items-center justify-between py-2">
+    <span className="flex items-center gap-2 text-sm font-medium">
+      {icon} {label}
+    </span>
+    <div className="flex items-center gap-2">
+      {enabled ? (
+        <CheckCircle className="w-4 h-4 text-success" />
+      ) : (
+        <XCircle className="w-4 h-4 text-base-content/30" />
+      )}
+      <Badge variant={enabled ? 'primary' : 'ghost'} size="sm">{detail}</Badge>
+    </div>
+  </div>
+);
+
 const GuardsPage: React.FC = () => {
   const { addToast } = useToast();
   const queryClient = useQueryClient();
   const [editingProfile, setEditingProfile] = useState<Partial<GuardProfile> | null>(null);
   const [deleteConfirm, setDeleteConfirm] = useState<GuardProfile | null>(null);
+  const [selectedProfileId, setSelectedProfileId] = useState<string | null>(null);
 
   const { data: response, isLoading } = useQuery<{ data: GuardProfile[] }>({
     queryKey: ['guardProfiles'],
@@ -133,6 +152,7 @@ const GuardsPage: React.FC = () => {
   });
 
   const profiles = response?.data || [];
+  const selectedProfile = profiles.find(p => p.id === selectedProfileId) || null;
 
   const createMutation = useMutation({
     mutationFn: async (profile: Partial<GuardProfile>) => {
@@ -184,6 +204,7 @@ const GuardsPage: React.FC = () => {
       queryClient.invalidateQueries({ queryKey: ['guardProfiles'] });
       addToast({ type: 'success', message: 'Profile deleted successfully' });
       setDeleteConfirm(null);
+      setSelectedProfileId(null);
     },
     onError: (error) => {
       addToast({ type: 'error', message: error instanceof Error ? error.message : 'Failed to delete profile' });
@@ -192,6 +213,7 @@ const GuardsPage: React.FC = () => {
   });
 
   const handleDuplicate = (profile: GuardProfile) => {
+    setSelectedProfileId(null);
     setEditingProfile({
       ...profile,
       id: undefined,
@@ -439,7 +461,11 @@ const GuardsPage: React.FC = () => {
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {profiles.map(profile => (
-            <Card key={profile.id} className="hover:shadow-lg transition-shadow">
+            <Card
+              key={profile.id}
+              className="hover:shadow-lg transition-shadow cursor-pointer"
+              onClick={() => setSelectedProfileId(profile.id)}
+            >
               <div className="flex justify-between items-start mb-4">
                 <div>
                   <h3 className="text-lg font-bold">{profile.name}</h3>
@@ -482,7 +508,7 @@ const GuardsPage: React.FC = () => {
                 <Button
                   size="sm"
                   variant="ghost"
-                  onClick={() => handleDuplicate(profile)}
+                  onClick={(e) => { e.stopPropagation(); handleDuplicate(profile); }}
                   title="Duplicate Profile"
                   aria-label="Duplicate profile"
                 >
@@ -491,7 +517,7 @@ const GuardsPage: React.FC = () => {
                 <Button
                   size="sm"
                   variant="ghost"
-                  onClick={() => setEditingProfile(profile)}
+                  onClick={(e) => { e.stopPropagation(); setEditingProfile(profile); }}
                   title="Edit Profile"
                 >
                   <Edit2 className="w-4 h-4" />
@@ -500,7 +526,7 @@ const GuardsPage: React.FC = () => {
                   size="sm"
                   variant="ghost"
                   color="error"
-                  onClick={() => setDeleteConfirm(profile)}
+                  onClick={(e) => { e.stopPropagation(); setDeleteConfirm(profile); }}
                   title="Delete Profile"
                 >
                   <Trash2 className="w-4 h-4" />
@@ -510,6 +536,133 @@ const GuardsPage: React.FC = () => {
           ))}
         </div>
       )}
+
+      {/* Guard Profile Detail Drawer */}
+      <DetailDrawer
+        isOpen={!!selectedProfile}
+        onClose={() => setSelectedProfileId(null)}
+        title={selectedProfile?.name}
+        subtitle={selectedProfile?.description || 'No description'}
+      >
+        {selectedProfile && (
+          <div className="space-y-6">
+            {/* Guard Rules */}
+            <Card className="bg-base-200">
+              <h4 className="font-semibold text-sm uppercase tracking-wide text-base-content/60 mb-3">Guard Rules</h4>
+              <div className="divide-y divide-base-300">
+                <GuardStatusRow
+                  icon={<Shield className="w-4 h-4 text-primary" />}
+                  label="Access Control"
+                  enabled={selectedProfile.guards.mcpGuard.enabled}
+                  detail={selectedProfile.guards.mcpGuard.enabled ? selectedProfile.guards.mcpGuard.type : 'Disabled'}
+                />
+                {selectedProfile.guards.mcpGuard.enabled && (
+                  <div className="py-2 pl-6 space-y-2">
+                    {selectedProfile.guards.mcpGuard.type === 'custom' && (selectedProfile.guards.mcpGuard.allowedUsers?.length ?? 0) > 0 && (
+                      <div>
+                        <span className="text-xs text-base-content/50">Allowed Users</span>
+                        <div className="flex flex-wrap gap-1 mt-1">
+                          {selectedProfile.guards.mcpGuard.allowedUsers?.map((u: string) => (
+                            <Badge key={u} variant="neutral" size="sm">{u}</Badge>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                    {(selectedProfile.guards.mcpGuard.allowedTools?.length ?? 0) > 0 && (
+                      <div>
+                        <span className="text-xs text-base-content/50">Allowed Tools</span>
+                        <div className="flex flex-wrap gap-1 mt-1">
+                          {selectedProfile.guards.mcpGuard.allowedTools?.map((t: string) => (
+                            <Badge key={t} variant="info" size="sm">{t}</Badge>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                <GuardStatusRow
+                  icon={<RefreshCw className="w-4 h-4 text-primary" />}
+                  label="Rate Limit"
+                  enabled={!!selectedProfile.guards.rateLimit?.enabled}
+                  detail={
+                    selectedProfile.guards.rateLimit?.enabled
+                      ? `${selectedProfile.guards.rateLimit.maxRequests} req / ${selectedProfile.guards.rateLimit.windowMs / 1000}s`
+                      : 'Disabled'
+                  }
+                />
+
+                <GuardStatusRow
+                  icon={<AlertTriangle className="w-4 h-4 text-error" />}
+                  label="Content Filter"
+                  enabled={!!selectedProfile.guards.contentFilter?.enabled}
+                  detail={
+                    selectedProfile.guards.contentFilter?.enabled
+                      ? selectedProfile.guards.contentFilter.strictness
+                      : 'Disabled'
+                  }
+                />
+                {selectedProfile.guards.contentFilter?.enabled && (selectedProfile.guards.contentFilter.blockedTerms?.length ?? 0) > 0 && (
+                  <div className="py-2 pl-6">
+                    <span className="text-xs text-base-content/50">Blocked Terms</span>
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {selectedProfile.guards.contentFilter.blockedTerms?.map((t: string) => (
+                        <Badge key={t} variant="error" size="sm">{t}</Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </Card>
+
+            {/* Timestamps */}
+            {(selectedProfile.createdAt || selectedProfile.updatedAt) && (
+              <div className="text-xs text-base-content/50 space-y-1">
+                {selectedProfile.createdAt && (
+                  <p>Created: {new Date(selectedProfile.createdAt).toLocaleString()}</p>
+                )}
+                {selectedProfile.updatedAt && (
+                  <p>Updated: {new Date(selectedProfile.updatedAt).toLocaleString()}</p>
+                )}
+              </div>
+            )}
+
+            <Divider />
+
+            {/* Actions */}
+            <div className="flex flex-col gap-2">
+              <Button
+                color="primary"
+                className="w-full"
+                onClick={() => {
+                  setSelectedProfileId(null);
+                  setEditingProfile(selectedProfile);
+                }}
+              >
+                <Edit2 className="w-4 h-4 mr-2" /> Edit Profile
+              </Button>
+              <Button
+                variant="outline"
+                className="w-full"
+                onClick={() => handleDuplicate(selectedProfile)}
+              >
+                <Copy className="w-4 h-4 mr-2" /> Duplicate
+              </Button>
+              <Button
+                variant="outline"
+                color="error"
+                className="w-full"
+                onClick={() => {
+                  setSelectedProfileId(null);
+                  setDeleteConfirm(selectedProfile);
+                }}
+              >
+                <Trash2 className="w-4 h-4 mr-2" /> Delete
+              </Button>
+            </div>
+          </div>
+        )}
+      </DetailDrawer>
 
       {editingProfile && (
         <ModalForm

--- a/src/client/src/pages/PersonasPage/PersonaList.tsx
+++ b/src/client/src/pages/PersonasPage/PersonaList.tsx
@@ -4,6 +4,7 @@ import BulkActionBar from '../../components/BulkActionBar';
 import Button from '../../components/DaisyUI/Button';
 import Checkbox from '../../components/DaisyUI/Checkbox';
 import Card from '../../components/DaisyUI/Card';
+import { Badge } from '../../components/DaisyUI/Badge';
 import { type Persona } from './hooks/usePersonasData';
 
 interface PersonaListProps {
@@ -13,6 +14,7 @@ interface PersonaListProps {
   bulkDeleting: boolean;
   handleBulkDeletePersonas: () => void;
   openEditModal: (persona: Persona) => void;
+  onSelectPersona: (persona: Persona) => void;
   isMobile: boolean;
   onDragStart: (index: number) => (e: React.DragEvent) => void;
   onDragOver: (index: number) => (e: React.DragEvent) => void;
@@ -28,6 +30,7 @@ export const PersonaList: React.FC<PersonaListProps> = ({
   bulkDeleting,
   handleBulkDeletePersonas,
   openEditModal,
+  onSelectPersona,
   isMobile,
   onDragStart,
   onDragOver,
@@ -73,10 +76,24 @@ export const PersonaList: React.FC<PersonaListProps> = ({
             onDrop={onDrop(index)}
             style={getItemStyle(index)}
           >
-            <Card className="shadow-sm border border-base-200 h-full hover:shadow-md transition-shadow">
-                <Card.Title tag="h3" className="text-lg font-bold">{persona.name}</Card.Title>
+            <Card
+              className="shadow-sm border border-base-200 h-full hover:shadow-md transition-shadow cursor-pointer"
+              onClick={() => onSelectPersona(persona)}
+            >
+                <div className="flex items-start justify-between gap-2">
+                  <Card.Title tag="h3" className="text-lg font-bold">{persona.name}</Card.Title>
+                  {persona.isBuiltIn && <Badge variant="ghost" size="sm">Built-in</Badge>}
+                </div>
                 <p className="text-sm text-base-content/70 line-clamp-2">{persona.description}</p>
-                <Button variant="primary" size="sm" onClick={() => openEditModal(persona)}>
+                {persona.category && (
+                  <Badge variant="neutral" size="sm" className="w-fit">{persona.category}</Badge>
+                )}
+                <Button
+                  variant="primary"
+                  size="sm"
+                  className="w-fit"
+                  onClick={(e) => { e.stopPropagation(); openEditModal(persona); }}
+                >
                   Edit
                 </Button>
             </Card>

--- a/src/client/src/pages/PersonasPage/index.tsx
+++ b/src/client/src/pages/PersonasPage/index.tsx
@@ -1,20 +1,23 @@
-import { Filter, Plus, Users } from 'lucide-react';
+import { Copy, Edit2, Filter, Plus, Trash2, Users } from 'lucide-react';
 import React, { useState } from 'react';
 import { Alert } from '../../components/DaisyUI/Alert';
+import { Badge } from '../../components/DaisyUI/Badge';
 import Button from '../../components/DaisyUI/Button';
-import Select from '../../components/DaisyUI/Select';
+import Card from '../../components/DaisyUI/Card';
+import DetailDrawer from '../../components/DaisyUI/DetailDrawer';
+import Divider from '../../components/DaisyUI/Divider';
+import Join from '../../components/DaisyUI/Join';
 import PageHeader from '../../components/DaisyUI/PageHeader';
+import Select from '../../components/DaisyUI/Select';
 import { SkeletonPage } from '../../components/DaisyUI/Skeleton';
 import { useSuccessToast, useErrorToast, useInfoToast } from '../../components/DaisyUI/ToastNotification';
-import SearchFilterBar from '../../components/SearchFilterBar';
 import Tooltip from '../../components/DaisyUI/Tooltip';
-import Join from '../../components/DaisyUI/Join';
-import Card from '../../components/DaisyUI/Card';
+import SearchFilterBar from '../../components/SearchFilterBar';
 import { useIsBelowBreakpoint } from '../../hooks/useBreakpoint';
 import { useBulkSelection } from '../../hooks/useBulkSelection';
 import { useDragAndDrop } from '../../hooks/useDragAndDrop';
 import { usePersonaActions } from './hooks/usePersonaActions';
-import { usePersonasData } from './hooks/usePersonasData';
+import { usePersonasData, type Persona } from './hooks/usePersonasData';
 import { PersonaList } from './PersonaList';
 import { PersonaStats } from './PersonaStats';
 
@@ -33,6 +36,7 @@ const PersonasPage: React.FC = () => {
   const infoToast = useInfoToast();
   const isMobile = useIsBelowBreakpoint('md');
   const [error, setError] = useState<string | null>(null);
+  const [selectedPersona, setSelectedPersona] = useState<Persona | null>(null);
 
   const {
     bots,
@@ -57,6 +61,8 @@ const PersonasPage: React.FC = () => {
     handleBulkDeletePersonas,
     openCreateModal,
     openEditModal,
+    openCloneModal,
+    handleDeletePersona,
   } = usePersonaActions(
     personas,
     setPersonas as any,
@@ -127,6 +133,7 @@ const PersonasPage: React.FC = () => {
               bulkDeleting={bulkDeleting}
               handleBulkDeletePersonas={handleBulkDeletePersonas}
               openEditModal={openEditModal}
+              onSelectPersona={setSelectedPersona}
               isMobile={isMobile}
               onDragStart={onDragStart}
               onDragOver={onDragOver}
@@ -136,6 +143,93 @@ const PersonasPage: React.FC = () => {
             />
           )}
       </Card>
+
+      {/* Persona Detail Drawer */}
+      <DetailDrawer
+        isOpen={!!selectedPersona}
+        onClose={() => setSelectedPersona(null)}
+        title={selectedPersona?.name}
+        subtitle={selectedPersona?.description}
+      >
+        {selectedPersona && (
+          <div className="space-y-6">
+            {/* Category & Status */}
+            <div className="flex flex-wrap gap-2">
+              {selectedPersona.category && (
+                <Badge variant="neutral">{selectedPersona.category}</Badge>
+              )}
+              {selectedPersona.isBuiltIn && (
+                <Badge variant="info">Built-in</Badge>
+              )}
+            </div>
+
+            {/* Assigned Bots */}
+            {(selectedPersona.assignedBotNames?.length ?? 0) > 0 && (
+              <Card className="bg-base-200">
+                <h4 className="font-semibold text-sm uppercase tracking-wide text-base-content/60 mb-2">Assigned Bots</h4>
+                <div className="flex flex-wrap gap-2">
+                  {selectedPersona.assignedBotNames?.map((name) => (
+                    <Badge key={name} variant="primary" size="sm">{name}</Badge>
+                  ))}
+                </div>
+              </Card>
+            )}
+
+            {/* System Prompt */}
+            {selectedPersona.systemPrompt && (
+              <div>
+                <h4 className="font-semibold text-sm uppercase tracking-wide text-base-content/60 mb-2">System Prompt</h4>
+                <div className="bg-base-200 rounded-lg p-3 max-h-64 overflow-y-auto">
+                  <pre className="text-sm whitespace-pre-wrap break-words font-mono text-base-content/80">
+                    {selectedPersona.systemPrompt}
+                  </pre>
+                </div>
+              </div>
+            )}
+
+            <Divider />
+
+            {/* Actions */}
+            <div className="flex flex-col gap-2">
+              {!selectedPersona.isBuiltIn && (
+                <Button
+                  color="primary"
+                  className="w-full"
+                  onClick={() => {
+                    setSelectedPersona(null);
+                    openEditModal(selectedPersona);
+                  }}
+                >
+                  <Edit2 className="w-4 h-4 mr-2" /> Edit Persona
+                </Button>
+              )}
+              <Button
+                variant="outline"
+                className="w-full"
+                onClick={() => {
+                  setSelectedPersona(null);
+                  openCloneModal(selectedPersona);
+                }}
+              >
+                <Copy className="w-4 h-4 mr-2" /> Duplicate
+              </Button>
+              {!selectedPersona.isBuiltIn && (
+                <Button
+                  variant="outline"
+                  color="error"
+                  className="w-full"
+                  onClick={() => {
+                    setSelectedPersona(null);
+                    handleDeletePersona(selectedPersona.id, (msg) => setError(msg));
+                  }}
+                >
+                  <Trash2 className="w-4 h-4 mr-2" /> Delete
+                </Button>
+              )}
+            </div>
+          </div>
+        )}
+      </DetailDrawer>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Add a reusable `DetailDrawer` component (`src/client/src/components/DaisyUI/DetailDrawer.tsx`) that slides in from the right side with backdrop, Escape-key dismiss, and responsive sizing
- Integrate master-detail drawer into **GuardsPage**: clicking a guard profile card opens a drawer showing all guard rules (access control, rate limit, content filter) with badges, timestamps, and Edit/Duplicate/Delete actions
- Integrate master-detail drawer into **PersonasPage**: clicking a persona card opens a drawer showing category, assigned bots, full system prompt (scrollable), and Edit/Duplicate/Delete actions
- Card buttons (Edit, Duplicate, Delete) use `stopPropagation` so they still work independently of the drawer click

## Test plan
- [ ] Click a guard profile card -- verify drawer slides in from the right with full details
- [ ] Click outside the drawer or press Escape -- verify it closes
- [ ] Click Edit/Duplicate/Delete buttons on the card directly -- verify they still trigger their respective flows without opening the drawer
- [ ] Click Edit/Duplicate/Delete buttons inside the drawer -- verify they close the drawer and open the correct modal
- [ ] Click a persona card -- verify drawer opens with name, description, category, system prompt, and assigned bots
- [ ] Verify built-in personas show the "Built-in" badge and hide Edit/Delete actions in the drawer
- [ ] Verify drawer is full-width on mobile and ~28rem on desktop
- [ ] Run `cd src/client && npx tsc --noEmit` -- only pre-existing jest/node type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)