### PR TITLE
feat(ui): add detail drawers to LLM Providers and MCP Servers pages

### DIFF
--- a/src/client/src/pages/LLMProvidersPage.tsx
+++ b/src/client/src/pages/LLMProvidersPage.tsx
@@ -35,6 +35,7 @@ import type { LLMProviderType } from '../types/bot';
 import { LLM_PROVIDER_CONFIGS } from '../types/bot';
 import ProviderConfigModal from '../components/ProviderConfiguration/ProviderConfigModal';
 import Divider from '../components/DaisyUI/Divider';
+import DetailDrawer from '../components/DaisyUI/DetailDrawer';
 import { apiService } from '../services/api';
 import useUrlParams from '../hooks/useUrlParams';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
@@ -88,6 +89,7 @@ const LLMProvidersPage: React.FC = () => {
   const setSearchQuery = (v: string) => setUrlParam('search', v);
   const filterType = urlParams.type;
   const setFilterType = (v: string) => setUrlParam('type', v);
+  const [drawerProfile, setDrawerProfile] = useState<any | null>(null);
   const [confirmModal, setConfirmModal] = useState<{
     isOpen: boolean; title: string; message: string; onConfirm: () => void;
   }>({ isOpen: false, title: '', message: '', onConfirm: () => {} });
@@ -569,7 +571,7 @@ const LLMProvidersPage: React.FC = () => {
           />
         <div className="grid grid-cols-1 gap-4">
           {filteredProfiles.map((profile) => (
-            <Card key={profile.key} className="bg-base-100 shadow-sm border border-base-200 transition-all hover:shadow-md">
+            <Card key={profile.key} className={`bg-base-100 shadow-sm border transition-all hover:shadow-md cursor-pointer ${drawerProfile?.key === profile.key ? 'border-primary ring-2 ring-primary/20' : 'border-base-200'}`} onClick={() => setDrawerProfile(profile)}>
               <div>
                 <div className="p-4 flex items-center justify-between cursor-pointer" onClick={() => toggleExpand(profile.key)}>
                   <div className="flex items-center gap-4">
@@ -649,6 +651,147 @@ const LLMProvidersPage: React.FC = () => {
         </div>
         </>
       )}
+
+      {/* Detail Drawer */}
+      <DetailDrawer
+        isOpen={!!drawerProfile}
+        onClose={() => setDrawerProfile(null)}
+        title={drawerProfile?.name || 'Profile Details'}
+        subtitle={drawerProfile?.provider ? `${drawerProfile.provider} provider` : undefined}
+      >
+        {drawerProfile && (
+          <div className="space-y-4">
+            {/* Provider info */}
+            <div className="flex items-center gap-3">
+              <div className="p-3 bg-primary/10 text-primary rounded-xl">
+                {getProviderIcon(drawerProfile.provider)}
+              </div>
+              <div>
+                <div className="font-bold text-lg">{drawerProfile.name}</div>
+                <span className="text-xs font-mono opacity-50 bg-base-200 px-2 py-0.5 rounded-full">{drawerProfile.key}</span>
+              </div>
+            </div>
+
+            <Divider />
+
+            {/* Type badges */}
+            <div className="flex flex-wrap gap-2">
+              <Badge variant="secondary" size="small" style="outline">{drawerProfile.provider}</Badge>
+              <Badge
+                variant={
+                  normalizeModelType(drawerProfile.modelType) === 'embedding'
+                    ? 'warning'
+                    : normalizeModelType(drawerProfile.modelType) === 'both'
+                      ? 'info'
+                      : 'neutral'
+                }
+                size="small"
+              >
+                {normalizeModelType(drawerProfile.modelType)}
+              </Badge>
+              {renderLibraryCheck(drawerProfile.provider)}
+              {drawerProfile.key === defaultChatbotProfile && (
+                <Badge variant="primary" size="small">Default Chatbot</Badge>
+              )}
+              {drawerProfile.key === webuiIntelligenceProvider && (
+                <Badge variant="warning" size="small">WebUI AI</Badge>
+              )}
+              {drawerProfile.key === defaultEmbeddingProvider && (
+                <Badge variant="secondary" size="small">Default Embedding</Badge>
+              )}
+            </div>
+
+            <Divider />
+
+            {/* Configuration details */}
+            <div>
+              <h4 className="text-xs font-bold uppercase opacity-50 mb-3 flex items-center gap-2">
+                <ConfigIcon className="w-3 h-3" /> Model Configuration
+              </h4>
+              <div className="space-y-2">
+                {Object.entries(drawerProfile.config || {}).map(([k, v]) => {
+                  const isSecret = /key|secret|token|password/i.test(k);
+                  return (
+                    <div key={k} className="flex justify-between items-center p-2 bg-base-200/50 rounded text-sm">
+                      <span className="font-medium text-base-content/70">{k}</span>
+                      <span className="font-mono text-xs truncate max-w-[200px]">
+                        {isSecret && v
+                          ? <span className="text-success">Configured <CheckIcon className="w-3 h-3 inline" /></span>
+                          : v === '' || v === null || v === undefined
+                            ? <span className="text-error">Not set <XIcon className="w-3 h-3 inline" /></span>
+                            : String(v)}
+                      </span>
+                    </div>
+                  );
+                })}
+                {Object.keys(drawerProfile.config || {}).length === 0 && (
+                  <p className="text-sm opacity-50 italic">No configuration values set.</p>
+                )}
+              </div>
+            </div>
+
+            <Divider />
+
+            {/* Actions */}
+            <div className="space-y-2">
+              <h4 className="text-xs font-bold uppercase opacity-50 mb-2">Actions</h4>
+
+              {/* Set as default buttons */}
+              {isChatCapable(drawerProfile) && drawerProfile.key !== defaultChatbotProfile && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full justify-start gap-2"
+                  onClick={async () => {
+                    setDefaultChatbotProfile(drawerProfile.key);
+                    await saveGlobal({ defaultChatbotProfile: drawerProfile.key }).catch(() => {});
+                  }}
+                >
+                  <ChatIcon className="w-4 h-4" /> Set as Default Chatbot
+                </Button>
+              )}
+
+              {isEmbeddingCapable(drawerProfile) && drawerProfile.key !== defaultEmbeddingProvider && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full justify-start gap-2"
+                  onClick={async () => {
+                    setDefaultEmbeddingProvider(drawerProfile.key);
+                    await saveLlmConfig({ DEFAULT_EMBEDDING_PROVIDER: drawerProfile.key }).catch(() => {});
+                  }}
+                >
+                  <CpuIcon className="w-4 h-4" /> Set as Default Embedding
+                </Button>
+              )}
+
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full justify-start gap-2"
+                onClick={() => {
+                  handleEditProfile(drawerProfile);
+                  setDrawerProfile(null);
+                }}
+              >
+                <EditIcon className="w-4 h-4" /> Edit Profile
+              </Button>
+
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full justify-start gap-2 text-error border-error/30 hover:bg-error/10"
+                onClick={() => {
+                  handleDeleteProfile(drawerProfile.key);
+                  setDrawerProfile(null);
+                }}
+              >
+                <DeleteIcon className="w-4 h-4" /> Delete Profile
+              </Button>
+            </div>
+          </div>
+        )}
+      </DetailDrawer>
 
       <ProviderConfigModal
         modalState={{ ...modalState, providerType: 'llm' }}

--- a/src/client/src/pages/MCPServersPage/MCPServerCard.tsx
+++ b/src/client/src/pages/MCPServersPage/MCPServerCard.tsx
@@ -35,6 +35,8 @@ interface MCPServerCardProps {
   handleServerAction: (serverId: string, action: 'start' | 'stop' | 'restart') => void;
   handleEditServer: (server: MCPServer) => void;
   handleDeleteServer: (serverId: string) => void;
+  onCardClick?: (server: MCPServer) => void;
+  isSelected?: boolean;
 }
 
 export const MCPServerCard: React.FC<MCPServerCardProps> = ({
@@ -45,9 +47,11 @@ export const MCPServerCard: React.FC<MCPServerCardProps> = ({
   handleServerAction,
   handleEditServer,
   handleDeleteServer,
+  onCardClick,
+  isSelected,
 }) => {
   return (
-    <Card key={server.id} className="shadow-xl h-full border border-base-200">
+    <Card key={server.id} className={`shadow-xl h-full border transition-all cursor-pointer ${isSelected ? 'border-primary ring-2 ring-primary/20' : 'border-base-200 hover:shadow-2xl'}`} onClick={() => onCardClick?.(server)}>
         <div className="flex justify-between items-start mb-2">
           <div className="flex items-center gap-2">
             <Checkbox
@@ -98,7 +102,7 @@ export const MCPServerCard: React.FC<MCPServerCardProps> = ({
           )}
         </div>
 
-        <Card.Actions className="justify-between mt-auto pt-4 border-t border-base-200">
+        <Card.Actions className="justify-between mt-auto pt-4 border-t border-base-200" onClick={(e: React.MouseEvent) => e.stopPropagation()}>
           <div className="flex gap-1">
             {server.status === 'running' ? (
               <Tooltip content="Disconnect">

--- a/src/client/src/pages/MCPServersPage/MCPServerList.tsx
+++ b/src/client/src/pages/MCPServersPage/MCPServerList.tsx
@@ -28,6 +28,8 @@ interface MCPServerListProps {
   handleServerAction: (serverId: string, action: 'start' | 'stop' | 'restart') => void;
   handleEditServer: (server: MCPServer) => void;
   handleDeleteServer: (serverId: string) => void;
+  onCardClick?: (server: MCPServer) => void;
+  selectedServerId?: string | null;
 }
 
 export const MCPServerList: React.FC<MCPServerListProps> = ({
@@ -41,6 +43,8 @@ export const MCPServerList: React.FC<MCPServerListProps> = ({
   handleServerAction,
   handleEditServer,
   handleDeleteServer,
+  onCardClick,
+  selectedServerId,
 }) => {
   return (
     <>
@@ -80,6 +84,8 @@ export const MCPServerList: React.FC<MCPServerListProps> = ({
             handleServerAction={handleServerAction}
             handleEditServer={handleEditServer as any}
             handleDeleteServer={handleDeleteServer}
+            onCardClick={onCardClick}
+            isSelected={selectedServerId === server.id}
           />
         ))}
       </div>

--- a/src/client/src/pages/MCPServersPage/index.tsx
+++ b/src/client/src/pages/MCPServersPage/index.tsx
@@ -1,13 +1,26 @@
 import React, { useMemo, useState } from 'react';
 import {
+  AlertCircle,
+  CheckCircle,
+  Edit as EditIcon,
+  Globe,
+  Play,
   Plus,
+  RefreshCw,
   Search,
   Server,
   ShieldAlert,
+  Square,
+  Trash2,
+  Wrench,
+  XCircle,
 } from 'lucide-react';
 import PageHeader from '../../components/DaisyUI/PageHeader';
 import { Alert } from '../../components/DaisyUI/Alert';
-import { Badge } from '../../components/DaisyUI/Badge';
+import Badge from '../../components/DaisyUI/Badge';
+import Button from '../../components/DaisyUI/Button';
+import Divider from '../../components/DaisyUI/Divider';
+import DetailDrawer from '../../components/DaisyUI/DetailDrawer';
 import EmptyState from '../../components/DaisyUI/EmptyState';
 import { SkeletonGrid } from '../../components/DaisyUI/Skeleton';
 import SearchFilterBar from '../../components/SearchFilterBar';
@@ -46,6 +59,7 @@ const MCPServersPage: React.FC = () => {
   } = useMCPServerData();
 
   const [selectedServer, setSelectedServer] = useState<MCPServer | null>(null);
+  const [drawerServer, setDrawerServer] = useState<MCPServer | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [toolsModalOpen, setToolsModalOpen] = useState(false);
   const [viewingTools, setViewingTools] = useState<Tool[]>([]);
@@ -231,8 +245,170 @@ const MCPServersPage: React.FC = () => {
             setDialogOpen(true);
           }}
           handleDeleteServer={handleDeleteServer}
+          onCardClick={(server) => setDrawerServer(server)}
+          selectedServerId={drawerServer?.id}
         />
       )}
+      {/* Detail Drawer */}
+      <DetailDrawer
+        isOpen={!!drawerServer}
+        onClose={() => setDrawerServer(null)}
+        title={drawerServer?.name || 'Server Details'}
+        subtitle={drawerServer?.url || undefined}
+      >
+        {drawerServer && (() => {
+          // Find the latest server data (status may have changed)
+          const liveServer = servers.find(s => s.id === drawerServer.id) || drawerServer;
+          return (
+            <div className="space-y-4">
+              {/* Status */}
+              <div className="flex items-center gap-3">
+                <Server className="w-6 h-6 text-primary" />
+                <div className="flex-1">
+                  <div className="font-bold text-lg">{liveServer.name}</div>
+                  <p className="text-sm text-base-content/60">{liveServer.description || 'No description'}</p>
+                </div>
+                <Badge
+                  variant={liveServer.status === 'running' ? 'success' : liveServer.status === 'error' ? 'error' : 'ghost'}
+                  size="small"
+                >
+                  {liveServer.status}
+                </Badge>
+              </div>
+
+              <Divider />
+
+              {/* Connection details */}
+              <div>
+                <h4 className="text-xs font-bold uppercase opacity-50 mb-3 flex items-center gap-2">
+                  <Globe className="w-3 h-3" /> Connection Details
+                </h4>
+                <div className="space-y-2">
+                  <div className="flex justify-between items-center p-2 bg-base-200/50 rounded text-sm">
+                    <span className="font-medium text-base-content/70">URL</span>
+                    <span className="font-mono text-xs truncate max-w-[220px]">{liveServer.url || 'Not set'}</span>
+                  </div>
+                  <div className="flex justify-between items-center p-2 bg-base-200/50 rounded text-sm">
+                    <span className="font-medium text-base-content/70">Status</span>
+                    <span className={`text-xs font-medium ${liveServer.status === 'running' ? 'text-success' : liveServer.status === 'error' ? 'text-error' : 'text-base-content/50'}`}>
+                      {liveServer.status === 'running' && <><CheckCircle className="w-3 h-3 inline mr-1" />Connected</>}
+                      {liveServer.status === 'stopped' && <><XCircle className="w-3 h-3 inline mr-1" />Disconnected</>}
+                      {liveServer.status === 'error' && <><AlertCircle className="w-3 h-3 inline mr-1" />Error</>}
+                    </span>
+                  </div>
+                  <div className="flex justify-between items-center p-2 bg-base-200/50 rounded text-sm">
+                    <span className="font-medium text-base-content/70">API Key</span>
+                    <span className="text-xs">
+                      {liveServer.apiKey
+                        ? <span className="text-success">Configured <CheckCircle className="w-3 h-3 inline" /></span>
+                        : <span className="text-base-content/50">Not set</span>}
+                    </span>
+                  </div>
+                  {liveServer.lastConnected && (
+                    <div className="flex justify-between items-center p-2 bg-base-200/50 rounded text-sm">
+                      <span className="font-medium text-base-content/70">Last Connected</span>
+                      <span className="text-xs">{new Date(liveServer.lastConnected).toLocaleString()}</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* Error display */}
+              {liveServer.status === 'error' && liveServer.error && (
+                <Alert status="error" className="text-xs">
+                  <AlertCircle className="w-4 h-4" />
+                  <span>{liveServer.error}</span>
+                </Alert>
+              )}
+
+              <Divider />
+
+              {/* Tools list */}
+              <div>
+                <h4 className="text-xs font-bold uppercase opacity-50 mb-3 flex items-center gap-2">
+                  <Wrench className="w-3 h-3" /> Available Tools ({liveServer.toolCount})
+                </h4>
+                {liveServer.tools && liveServer.tools.length > 0 ? (
+                  <div className="space-y-2 max-h-48 overflow-y-auto">
+                    {liveServer.tools.map((tool) => (
+                      <div key={tool.name} className="p-2 bg-base-200/50 rounded text-sm">
+                        <div className="font-medium text-xs">{tool.name}</div>
+                        {tool.description && (
+                          <p className="text-xs text-base-content/50 mt-0.5 line-clamp-2">{tool.description}</p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-sm opacity-50 italic">
+                    {liveServer.status === 'running' ? 'No tools reported.' : 'Connect to discover tools.'}
+                  </p>
+                )}
+              </div>
+
+              <Divider />
+
+              {/* Actions */}
+              <div className="space-y-2">
+                <h4 className="text-xs font-bold uppercase opacity-50 mb-2">Actions</h4>
+
+                {/* Connect / Disconnect */}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className={`w-full justify-start gap-2 ${liveServer.status === 'running' ? 'text-error border-error/30 hover:bg-error/10' : 'text-success border-success/30 hover:bg-success/10'}`}
+                  onClick={() => {
+                    handleServerAction(liveServer.id, liveServer.status === 'running' ? 'stop' : 'start');
+                  }}
+                >
+                  {liveServer.status === 'running'
+                    ? <><Square className="w-4 h-4" /> Disconnect</>
+                    : <><Play className="w-4 h-4" /> Connect</>}
+                </Button>
+
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full justify-start gap-2"
+                  onClick={() => {
+                    handleTestConnection(liveServer);
+                    setDrawerServer(null);
+                  }}
+                >
+                  <RefreshCw className={`w-4 h-4 ${isTesting ? 'animate-spin' : ''}`} /> Test Connection
+                </Button>
+
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full justify-start gap-2"
+                  onClick={() => {
+                    setSelectedServer(liveServer);
+                    setIsEditing(true);
+                    setDialogOpen(true);
+                    setDrawerServer(null);
+                  }}
+                >
+                  <EditIcon className="w-4 h-4" /> Edit Server
+                </Button>
+
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full justify-start gap-2 text-error border-error/30 hover:bg-error/10"
+                  onClick={() => {
+                    handleDeleteServer(liveServer.id);
+                    setDrawerServer(null);
+                  }}
+                >
+                  <Trash2 className="w-4 h-4" /> Remove Server
+                </Button>
+              </div>
+            </div>
+          );
+        })()}
+      </DetailDrawer>
+
       <MCPServerModals
         toolsModalOpen={toolsModalOpen}
         setToolsModalOpen={setToolsModalOpen}


### PR DESCRIPTION
## Summary
- **New `DetailDrawer` component** -- a reusable right-side slide-out panel with backdrop overlay, escape-key dismiss, and smooth CSS transitions (full-width on mobile, 420px on desktop)
- **LLMProvidersPage**: clicking a provider profile card opens a drawer showing provider type, model configuration with masked API keys (secret fields show "Configured" or "Not set"), role badges, and action buttons (Set as Default Chatbot/Embedding, Edit, Delete)
- **MCPServersPage**: clicking a server card opens a drawer showing connection details, available tools list, error state, and action buttons (Connect/Disconnect, Test Connection, Edit, Remove)
- Selected items in both lists are visually highlighted with a primary-colored ring

## Test plan
- [ ] Navigate to LLM Providers page, click a profile card -- drawer slides from right with full details
- [ ] Verify API key fields show "Configured" (not the actual value) in the drawer
- [ ] Click "Set as Default Chatbot" in the drawer and verify the assignment updates
- [ ] Click "Edit Profile" in the drawer and verify the edit modal opens
- [ ] Click "Delete Profile" in the drawer and verify the confirm dialog appears
- [ ] Close the drawer via X button, backdrop click, and Escape key
- [ ] Navigate to MCP Servers page, click a server card -- drawer slides from right
- [ ] Verify tools list is shown for connected servers
- [ ] Click Connect/Disconnect button in the drawer
- [ ] Click "Test Connection" and verify it triggers the test
- [ ] Verify selected card has a visual highlight ring
- [ ] Test on mobile viewport (drawer should be full-width)
- [ ] Run `cd src/client && npx tsc --noEmit` -- passes with no errors

Generated with [Claude Code](https://claude.com/claude-code)