### PR TITLE
feat(personas): add per-persona response behavior overrides

### DIFF
--- a/src/client/src/types/bot.ts
+++ b/src/client/src/types/bot.ts
@@ -55,6 +55,23 @@ export interface LLMProvider {
   enabled: boolean;
 }
 
+/** Per-persona response behavior overrides. All fields optional -- falls back to global config. */
+export interface PersonaResponseBehavior {
+  baseChance?: number;
+  mentionBonus?: number;
+  leadingMentionBonus?: number;
+  offTopicPenalty?: number;
+  botResponsePenalty?: number;
+  burstTrafficPenalty?: number;
+  userDensityPenalty?: number;
+  botRatioPenalty?: number;
+  onlyWhenSpokenTo?: boolean;
+  graceWindowMs?: number;
+  interactiveFollowups?: boolean;
+  unsolicitedAddressed?: boolean;
+  unsolicitedUnaddressed?: boolean;
+}
+
 export interface Persona {
   id: string;
   name: string;
@@ -62,6 +79,7 @@ export interface Persona {
   category: PersonaCategory | string;
   traits: PersonaTrait[];
   systemPrompt: string;
+  responseBehavior?: PersonaResponseBehavior;
   isBuiltIn?: boolean;
   usageCount?: number;
   avatarId?: string;
@@ -82,6 +100,7 @@ export interface CreatePersonaRequest {
   category: PersonaCategory;
   traits: PersonaTrait[];
   systemPrompt: string;
+  responseBehavior?: PersonaResponseBehavior;
 }
 
 export interface UpdatePersonaRequest {
@@ -91,6 +110,7 @@ export interface UpdatePersonaRequest {
   category?: PersonaCategory;
   traits?: PersonaTrait[];
   systemPrompt?: string;
+  responseBehavior?: PersonaResponseBehavior;
 }
 
 export interface ProviderModalState {

--- a/src/config/responseBehaviorResolver.ts
+++ b/src/config/responseBehaviorResolver.ts
@@ -1,0 +1,64 @@
+import type { PersonaResponseBehavior } from '../managers/PersonaManager';
+import messageConfig from './messageConfig';
+
+/**
+ * Fully resolved response behavior — every field has a concrete value
+ * (either from persona override or global default).
+ */
+export interface ResolvedResponseBehavior {
+  baseChance: number;
+  mentionBonus: number;
+  leadingMentionBonus: number;
+  offTopicPenalty: number;
+  botResponsePenalty: number;
+  burstTrafficPenalty: number;
+  userDensityPenalty: number;
+  botRatioPenalty: number;
+  onlyWhenSpokenTo: boolean;
+  graceWindowMs: number;
+  interactiveFollowups: boolean;
+  unsolicitedAddressed: boolean;
+  unsolicitedUnaddressed: boolean;
+}
+
+/**
+ * Merge per-persona response behavior overrides with global defaults.
+ *
+ * For each field the persona value is used when explicitly set (not undefined);
+ * otherwise the corresponding global messageConfig value (or a sensible
+ * hard-coded default for fields that have no global env-var equivalent) is used.
+ */
+export function resolveResponseBehavior(
+  persona?: PersonaResponseBehavior | null,
+): ResolvedResponseBehavior {
+  const p = persona ?? {};
+
+  return {
+    baseChance:
+      p.baseChance ?? (messageConfig.get('MESSAGE_UNSOLICITED_BASE_CHANCE') as number),
+    mentionBonus:
+      p.mentionBonus ?? (messageConfig.get('MESSAGE_MENTION_BONUS') as number),
+    leadingMentionBonus:
+      p.leadingMentionBonus ?? 1.0,
+    offTopicPenalty:
+      p.offTopicPenalty ?? -0.1,
+    botResponsePenalty:
+      p.botResponsePenalty ?? (messageConfig.get('MESSAGE_BOT_RESPONSE_MODIFIER') as number),
+    burstTrafficPenalty:
+      p.burstTrafficPenalty ?? -0.1,
+    userDensityPenalty:
+      p.userDensityPenalty ?? -0.02,
+    botRatioPenalty:
+      p.botRatioPenalty ?? -0.30,
+    onlyWhenSpokenTo:
+      p.onlyWhenSpokenTo ?? (messageConfig.get('MESSAGE_ONLY_WHEN_SPOKEN_TO') as boolean),
+    graceWindowMs:
+      p.graceWindowMs ?? (messageConfig.get('MESSAGE_ONLY_WHEN_SPOKEN_TO_GRACE_WINDOW_MS') as number),
+    interactiveFollowups:
+      p.interactiveFollowups ?? (messageConfig.get('MESSAGE_INTERACTIVE_FOLLOWUPS') as boolean),
+    unsolicitedAddressed:
+      p.unsolicitedAddressed ?? (messageConfig.get('MESSAGE_UNSOLICITED_ADDRESSED') as boolean),
+    unsolicitedUnaddressed:
+      p.unsolicitedUnaddressed ?? (messageConfig.get('MESSAGE_UNSOLICITED_UNADDRESSED') as boolean),
+  };
+}

--- a/src/managers/PersonaManager.ts
+++ b/src/managers/PersonaManager.ts
@@ -7,6 +7,39 @@ import { ErrorUtils } from '../types/errors';
 
 const debug = Debug('app:PersonaManager');
 
+/**
+ * Per-persona response behavior overrides.
+ * Each field is optional — when not set, falls back to the global config value.
+ */
+export interface PersonaResponseBehavior {
+  /** Base probability for unsolicited replies (0-1). Default from MESSAGE_UNSOLICITED_BASE_CHANCE. */
+  baseChance?: number;
+  /** Bonus when persona is mentioned (default 0.5). */
+  mentionBonus?: number;
+  /** Bonus when persona is mentioned at the start (default 1.0). */
+  leadingMentionBonus?: number;
+  /** Penalty for off-topic messages (default -0.1). */
+  offTopicPenalty?: number;
+  /** Penalty when responding to other bots (default -0.1). */
+  botResponsePenalty?: number;
+  /** Per-message penalty during traffic bursts (default -0.1). */
+  burstTrafficPenalty?: number;
+  /** Per-extra-user penalty in dense conversations (default -0.02). */
+  userDensityPenalty?: number;
+  /** Penalty when bot-to-human ratio is high (default -0.30). */
+  botRatioPenalty?: number;
+  /** Only respond when explicitly addressed. Default from MESSAGE_ONLY_WHEN_SPOKEN_TO. */
+  onlyWhenSpokenTo?: boolean;
+  /** Grace window (ms) after last bot message in channel. Default 300000. */
+  graceWindowMs?: number;
+  /** Allow interactive follow-up questions. Default false. */
+  interactiveFollowups?: boolean;
+  /** Allow unsolicited addressed messages. Default false. */
+  unsolicitedAddressed?: boolean;
+  /** Allow unsolicited unaddressed messages. Default false. */
+  unsolicitedUnaddressed?: boolean;
+}
+
 export interface Persona {
   id: string;
   name: string;
@@ -21,6 +54,7 @@ export interface Persona {
     | 'professional';
   traits: { name: string; value: string; weight?: number; type?: string }[];
   systemPrompt: string;
+  responseBehavior?: PersonaResponseBehavior;
   isBuiltIn?: boolean;
   usageCount?: number;
   createdAt: string;
@@ -33,6 +67,7 @@ export interface CreatePersonaRequest {
   category: Persona['category'];
   traits: Persona['traits'];
   systemPrompt: string;
+  responseBehavior?: PersonaResponseBehavior;
 }
 
 export interface UpdatePersonaRequest extends Partial<CreatePersonaRequest> {}

--- a/src/server/routes/personas.ts
+++ b/src/server/routes/personas.ts
@@ -10,6 +10,7 @@ import {
   BulkDeletePersonasSchema,
   ClonePersonaSchema,
   PersonaIdParamSchema,
+  PersonaResponseBehaviorSchema,
   UpdatePersonaRouteSchema,
 } from '../../validation/schemas/personasSchema';
 import { validateRequest } from '../../validation/validateRequest';
@@ -56,6 +57,7 @@ const CreatePersonaSchema = z.object({
       .max(MAX_SYSTEM_PROMPT_LENGTH, {
         message: `System prompt must not exceed ${MAX_SYSTEM_PROMPT_LENGTH} characters`,
       }),
+    responseBehavior: PersonaResponseBehaviorSchema,
   }),
 });
 

--- a/src/validation/schemas/personasSchema.ts
+++ b/src/validation/schemas/personasSchema.ts
@@ -2,6 +2,25 @@ import { z } from 'zod';
 
 const MAX_SYSTEM_PROMPT_LENGTH = 8000;
 
+/** Zod schema for per-persona response behavior overrides. All fields optional. */
+export const PersonaResponseBehaviorSchema = z
+  .object({
+    baseChance: z.number().min(0).max(1).optional(),
+    mentionBonus: z.number().optional(),
+    leadingMentionBonus: z.number().optional(),
+    offTopicPenalty: z.number().optional(),
+    botResponsePenalty: z.number().optional(),
+    burstTrafficPenalty: z.number().optional(),
+    userDensityPenalty: z.number().optional(),
+    botRatioPenalty: z.number().optional(),
+    onlyWhenSpokenTo: z.boolean().optional(),
+    graceWindowMs: z.number().int().min(0).optional(),
+    interactiveFollowups: z.boolean().optional(),
+    unsolicitedAddressed: z.boolean().optional(),
+    unsolicitedUnaddressed: z.boolean().optional(),
+  })
+  .optional();
+
 /** Schema for PUT /api/personas/:id — update persona */
 export const UpdatePersonaRouteSchema = z.object({
   params: z.object({
@@ -48,6 +67,7 @@ export const UpdatePersonaRouteSchema = z.object({
         message: `System prompt must not exceed ${MAX_SYSTEM_PROMPT_LENGTH} characters`,
       })
       .optional(),
+    responseBehavior: PersonaResponseBehaviorSchema,
   }),
 });
 
@@ -97,6 +117,7 @@ export const ClonePersonaSchema = z.object({
         message: `System prompt must not exceed ${MAX_SYSTEM_PROMPT_LENGTH} characters`,
       })
       .optional(),
+    responseBehavior: PersonaResponseBehaviorSchema,
   }),
 });
 


### PR DESCRIPTION
## Summary
- Adds an optional `responseBehavior` object to the Persona data model with 13 configurable fields (base chance, mention bonuses, penalties, only-when-spoken-to, grace window, interactive followups, unsolicited behavior)
- Each field falls back to the global `messageConfig` value when not set, ensuring backward compatibility
- Adds `resolveResponseBehavior()` utility function that merges persona overrides with global defaults
- Updates Zod validation schemas and all persona CRUD routes (create, update, clone) to accept the new field
- Updates client-side TypeScript types to match

## Test plan
- [ ] Verify `npx tsc --noEmit` passes in `src/client/` (no new errors)
- [ ] Verify existing persona CRUD still works: `curl http://localhost:3027/api/personas`
- [ ] Create a persona with `responseBehavior` overrides and verify they persist
- [ ] Update a persona to add/remove `responseBehavior` fields
- [ ] Verify personas without `responseBehavior` still load correctly (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)