### PR TITLE
feat(ui): replace chat bubbles with rich response timeline

### DIFF
--- a/src/client/src/components/BotResponseTimeline.tsx
+++ b/src/client/src/components/BotResponseTimeline.tsx
@@ -1,0 +1,255 @@
+import React, { useRef, useEffect, useState } from 'react';
+import { Bot, User, MessageSquare, RefreshCw, AlertCircle, ChevronDown, ChevronUp, Zap, AtSign, MessageCircle } from 'lucide-react';
+import { Badge } from './DaisyUI/Badge';
+import Tooltip from './DaisyUI/Tooltip';
+
+export interface ChatMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  timestamp: string | number | Date;
+  metadata?: {
+    probability?: number;
+    responseReason?: 'mentioned' | 'followup' | 'unsolicited' | 'triggered';
+    processingTime?: number;
+    [key: string]: unknown;
+  };
+  sender?: string;
+}
+
+interface BotResponseTimelineProps {
+  chatHistory: ChatMessage[];
+  chatError?: string | null;
+  onRetry?: () => void;
+  onRefresh?: () => void;
+  className?: string;
+}
+
+/** Format a timestamp as a relative string when recent, otherwise as a compact time. */
+function formatRelativeTime(ts: string | number | Date): string {
+  const date = new Date(ts);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHr = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHr / 24);
+
+  if (diffSec < 60) return 'Just now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHr < 24) return `${diffHr}h ago`;
+  if (diffDay < 7) return `${diffDay}d ago`;
+
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) +
+    ' ' + date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+}
+
+/** Map a response reason to a human-readable label and icon. */
+function getReasonInfo(reason?: string): { label: string; icon: React.ReactNode } | null {
+  switch (reason) {
+    case 'mentioned':
+      return { label: 'Mentioned', icon: <AtSign className="w-3 h-3" /> };
+    case 'followup':
+      return { label: 'Follow-up', icon: <MessageCircle className="w-3 h-3" /> };
+    case 'unsolicited':
+      return { label: 'Unsolicited', icon: <Zap className="w-3 h-3" /> };
+    case 'triggered':
+      return { label: 'Triggered', icon: <Zap className="w-3 h-3" /> };
+    default:
+      return null;
+  }
+}
+
+/** Color for the timeline dot based on message role. */
+function getDotColor(role: string): string {
+  switch (role) {
+    case 'user':
+      return 'bg-info';
+    case 'assistant':
+      return 'bg-success';
+    case 'system':
+      return 'bg-base-300';
+    default:
+      return 'bg-base-300';
+  }
+}
+
+/** Border accent color for the message card. */
+function getCardBorder(role: string): string {
+  switch (role) {
+    case 'user':
+      return 'border-l-info';
+    case 'assistant':
+      return 'border-l-success';
+    case 'system':
+      return 'border-l-base-300';
+    default:
+      return 'border-l-base-300';
+  }
+}
+
+const MESSAGE_TRUNCATE_LENGTH = 180;
+
+const TimelineEntry: React.FC<{ msg: ChatMessage; isLast: boolean }> = ({ msg, isLast }) => {
+  const [expanded, setExpanded] = useState(false);
+  const isLong = msg.content.length > MESSAGE_TRUNCATE_LENGTH;
+  const displayContent = !expanded && isLong
+    ? msg.content.slice(0, MESSAGE_TRUNCATE_LENGTH) + '...'
+    : msg.content;
+
+  const reasonInfo = msg.role === 'assistant' ? getReasonInfo(msg.metadata?.responseReason) : null;
+  const probability = msg.metadata?.probability;
+  const processingTime = msg.metadata?.processingTime;
+
+  return (
+    <div className="flex gap-2 relative">
+      {/* Timeline line + dot */}
+      <div className="flex flex-col items-center flex-shrink-0 w-5">
+        <div className={`w-2.5 h-2.5 rounded-full mt-1.5 flex-shrink-0 ring-2 ring-base-100 ${getDotColor(msg.role)}`} />
+        {!isLast && <div className="w-px flex-1 bg-base-300 mt-1" />}
+      </div>
+
+      {/* Content card */}
+      <div className="flex-1 min-w-0 pb-3">
+        {/* Timestamp */}
+        <div className="text-[10px] text-base-content/50 font-mono mb-0.5">
+          {formatRelativeTime(msg.timestamp)}
+        </div>
+
+        {/* Card */}
+        <div className={`bg-base-200/40 rounded-lg p-2 border-l-2 ${getCardBorder(msg.role)}`}>
+          {/* Sender row */}
+          <div className="flex items-center gap-1.5 mb-1">
+            {msg.role === 'user' ? (
+              <User className="w-3 h-3 text-info flex-shrink-0" />
+            ) : msg.role === 'assistant' ? (
+              <Bot className="w-3 h-3 text-success flex-shrink-0" />
+            ) : (
+              <AlertCircle className="w-3 h-3 text-base-content/40 flex-shrink-0" />
+            )}
+            <span className="text-xs font-semibold truncate">
+              {msg.sender || (msg.role === 'user' ? 'User' : msg.role === 'assistant' ? 'Bot' : 'System')}
+            </span>
+
+            {/* Role badge */}
+            {msg.role === 'assistant' && reasonInfo && (
+              <Badge variant="ghost" size="xs" icon={reasonInfo.icon}>
+                {reasonInfo.label}
+              </Badge>
+            )}
+          </div>
+
+          {/* Message content */}
+          <p className="text-xs text-base-content/80 whitespace-pre-wrap break-words leading-relaxed">
+            {displayContent}
+          </p>
+
+          {isLong && (
+            <button
+              className="text-[10px] text-primary hover:underline mt-0.5 inline-flex items-center gap-0.5"
+              onClick={() => setExpanded(!expanded)}
+            >
+              {expanded ? (
+                <><ChevronUp className="w-3 h-3" /> Show less</>
+              ) : (
+                <><ChevronDown className="w-3 h-3" /> Show more</>
+              )}
+            </button>
+          )}
+
+          {/* Response metadata for bot messages */}
+          {msg.role === 'assistant' && (probability != null || processingTime != null) && (
+            <div className="flex items-center gap-2 mt-1.5 pt-1 border-t border-base-300/50">
+              {probability != null && (
+                <Tooltip content={`Response probability: ${(probability * 100).toFixed(1)}%`}>
+                  <span className="text-[10px] font-mono text-base-content/50">
+                    P={(probability * 100).toFixed(0)}%
+                  </span>
+                </Tooltip>
+              )}
+              {processingTime != null && (
+                <Tooltip content={`Processing time: ${processingTime}ms`}>
+                  <span className="text-[10px] font-mono text-base-content/50">
+                    {processingTime}ms
+                  </span>
+                </Tooltip>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const BotResponseTimeline: React.FC<BotResponseTimelineProps> = ({
+  chatHistory,
+  chatError,
+  onRetry,
+  onRefresh,
+  className = '',
+}) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll to bottom (latest) on new messages
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [chatHistory]);
+
+  // Error state
+  if (chatError) {
+    return (
+      <div className="text-center py-6">
+        <AlertCircle className="w-8 h-8 mx-auto mb-2 text-error" />
+        <p className="text-xs text-error mb-2">{chatError}</p>
+        {onRetry && (
+          <button className="btn btn-ghost btn-xs" onClick={onRetry}>
+            <RefreshCw className="w-3 h-3 mr-1" /> Retry
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  // Empty state
+  if (chatHistory.length === 0) {
+    return (
+      <div className="text-center py-8 opacity-40">
+        <MessageSquare className="w-8 h-8 mx-auto mb-2" />
+        <p className="text-xs">No activity yet</p>
+        <p className="text-[10px] mt-1">Messages will appear here as the bot interacts.</p>
+      </div>
+    );
+  }
+
+  // Sort chronologically (oldest first so timeline reads top-to-bottom)
+  const sorted = [...chatHistory].sort(
+    (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+  );
+
+  return (
+    <div className={className}>
+      {/* Header with refresh */}
+      {onRefresh && (
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-[10px] uppercase tracking-wider font-bold text-base-content/40">
+            Response History
+          </span>
+          <button className="btn btn-ghost btn-xs btn-square" onClick={onRefresh} aria-label="Refresh">
+            <RefreshCw className="w-3 h-3" />
+          </button>
+        </div>
+      )}
+
+      {/* Scrollable timeline */}
+      <div ref={scrollRef} className="max-h-[300px] overflow-y-auto pr-1 custom-scrollbar">
+        {sorted.map((msg, idx) => (
+          <TimelineEntry key={idx} msg={msg} isLast={idx === sorted.length - 1} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default BotResponseTimeline;

--- a/src/client/src/pages/BotsPage/BotDetailContent.tsx
+++ b/src/client/src/pages/BotsPage/BotDetailContent.tsx
@@ -12,6 +12,7 @@ import Tooltip from '../../components/DaisyUI/Tooltip';
 import Figure from '../../components/DaisyUI/Figure';
 import Input from '../../components/DaisyUI/Input';
 import Join from '../../components/DaisyUI/Join';
+import BotResponseTimeline from '../../components/BotResponseTimeline';
 
 interface BotDetailContentProps {
   previewBot: BotConfig | null;
@@ -222,47 +223,14 @@ export const BotDetailContent: React.FC<BotDetailContentProps> = ({
         </div>
       )}
 
-      {/* Chat History Panel */}
+      {/* Chat History Panel — Response Timeline */}
       {previewTab === 'chat' && (
-        <div className="space-y-3 max-h-[300px] overflow-y-auto pr-1 custom-scrollbar">
-          {chatError ? (
-            <div className="text-center py-6">
-              <AlertCircle className="w-8 h-8 mx-auto mb-2 text-error" />
-              <p className="text-xs text-error mb-2">{chatError}</p>
-              <button
-                className="btn btn-ghost btn-xs"
-                onClick={() => previewBot && fetchPreviewChat(previewBot.id)}
-              >
-                <RefreshCw className="w-3 h-3 mr-1" /> Retry
-              </button>
-            </div>
-          ) : chatHistory.length === 0 ? (
-            <div className="text-center py-8 opacity-40">
-              <MessageSquare className="w-8 h-8 mx-auto mb-2" />
-              <p className="text-xs">No recent chat history</p>
-            </div>
-          ) : (
-            <div className="space-y-3">
-              {chatHistory.map((msg, idx) => (
-                <div
-                  key={idx}
-                  className={`chat ${msg.role === 'user' ? 'chat-end' : 'chat-start'}`}
-                >
-                  <div
-                    className={`chat-bubble text-xs min-h-0 py-1.5 px-3 ${
-                      msg.role === 'user' ? 'chat-bubble-primary' : 'chat-bubble-secondary'
-                    }`}
-                  >
-                    {msg.content}
-                  </div>
-                  <div className="chat-footer opacity-50 text-[10px] mt-0.5">
-                    {new Date(msg.timestamp).toLocaleTimeString()}
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
+        <BotResponseTimeline
+          chatHistory={chatHistory}
+          chatError={chatError}
+          onRetry={() => previewBot && fetchPreviewChat(previewBot.id)}
+          onRefresh={() => previewBot && fetchPreviewChat(previewBot.id)}
+        />
       )}
 
       {/* Action buttons */}

--- a/src/client/src/pages/BotsPage/BotPreviewSidebar.tsx
+++ b/src/client/src/pages/BotsPage/BotPreviewSidebar.tsx
@@ -12,6 +12,7 @@ import Tooltip from '../../components/DaisyUI/Tooltip';
 import Card from '../../components/DaisyUI/Card';
 import Join from '../../components/DaisyUI/Join';
 import Figure from '../../components/DaisyUI/Figure';
+import BotResponseTimeline from '../../components/BotResponseTimeline';
 
 interface BotPreviewSidebarProps {
   previewBot: BotConfig | null;
@@ -231,47 +232,14 @@ export const BotPreviewSidebar: React.FC<BotPreviewSidebarProps> = ({
             </div>
           )}
 
-          {/* Chat History Panel */}
+          {/* Chat History Panel — Response Timeline */}
           {previewTab === 'chat' && (
-            <div className="space-y-3 max-h-[300px] overflow-y-auto pr-1 custom-scrollbar">
-              {chatError ? (
-                <div className="text-center py-6">
-                  <AlertCircle className="w-8 h-8 mx-auto mb-2 text-error" />
-                  <p className="text-xs text-error mb-2">{chatError}</p>
-                  <button
-                    className="btn btn-ghost btn-xs"
-                    onClick={() => previewBot && fetchPreviewChat(previewBot.id)}
-                  >
-                    <RefreshCw className="w-3 h-3 mr-1" /> Retry
-                  </button>
-                </div>
-              ) : chatHistory.length === 0 ? (
-                <div className="text-center py-8 opacity-40">
-                  <MessageSquare className="w-8 h-8 mx-auto mb-2" />
-                  <p className="text-xs">No recent chat history</p>
-                </div>
-              ) : (
-                <div className="space-y-3">
-                  {chatHistory.map((msg, idx) => (
-                    <div
-                      key={idx}
-                      className={`chat ${msg.role === 'user' ? 'chat-end' : 'chat-start'}`}
-                    >
-                      <div
-                        className={`chat-bubble text-xs min-h-0 py-1.5 px-3 ${
-                          msg.role === 'user' ? 'chat-bubble-primary' : 'chat-bubble-secondary'
-                        }`}
-                      >
-                        {msg.content}
-                      </div>
-                      <div className="chat-footer opacity-50 text-[10px] mt-0.5">
-                        {new Date(msg.timestamp).toLocaleTimeString()}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
+            <BotResponseTimeline
+              chatHistory={chatHistory}
+              chatError={chatError}
+              onRetry={() => previewBot && fetchPreviewChat(previewBot.id)}
+              onRefresh={() => previewBot && fetchPreviewChat(previewBot.id)}
+            />
           )}
 
           <Card.Actions className="mt-2 pt-4 border-t border-base-200">


### PR DESCRIPTION
## Summary
- Created new `BotResponseTimeline` component that renders chat history as a vertical timeline with color-coded dots (blue=user, green=bot, grey=system), relative timestamps, sender badges, and expandable long messages
- Shows bot response decision context (mentioned, follow-up, unsolicited) via ghost badges and displays probability/processing time metadata when available
- Replaced the plain chat bubble view in both `BotPreviewSidebar` and `BotDetailContent` (detail drawer) with the new timeline component

## Test plan
- [ ] Open the Bots page and click a bot to open the preview sidebar
- [ ] Switch to the "Chat" tab and verify the timeline renders with color-coded dots and relative timestamps
- [ ] Verify long messages are truncated with a "Show more" toggle
- [ ] Verify the empty state shows "No activity yet" message
- [ ] Verify error state shows retry button
- [ ] Click a bot card to open the detail drawer and verify the Chat tab also uses the timeline
- [ ] Verify the refresh button at the top of the timeline works

🤖 Generated with [Claude Code](https://claude.com/claude-code)