### PR TITLE
refactor(ui): replace all heroicons with lucide-react

### DIFF
--- a/src/client/src/animations/AnimationComponents.tsx
+++ b/src/client/src/animations/AnimationComponents.tsx
@@ -5,11 +5,11 @@ import Badge from '../components/DaisyUI/Badge';
 import { Progress } from '../components/DaisyUI/Loading';
 import { Alert } from '../components/DaisyUI/Alert';
 import {
-  SparklesIcon,
-  PlayIcon,
-  PauseIcon,
-} from '@heroicons/react/24/outline';
-import { RefreshCw } from 'lucide-react';
+  RefreshCw,
+  Sparkles as SparklesIcon,
+  Play as PlayIcon,
+  Pause as PauseIcon,
+} from 'lucide-react';
 
 export interface SimpleAnimation {
   id: string;

--- a/src/client/src/components/ActivityTimeline.tsx
+++ b/src/client/src/components/ActivityTimeline.tsx
@@ -5,12 +5,12 @@ import Button from './DaisyUI/Button';
 import { Alert } from './DaisyUI/Alert';
 import Timeline from './DaisyUI/Timeline';
 import {
-  ClockIcon,
-  UserIcon,
-  CogIcon,
-  ExclamationTriangleIcon,
-  CheckCircleIcon,
-} from '@heroicons/react/24/outline';
+  Clock as ClockIcon,
+  User as UserIcon,
+  Settings as CogIcon,
+  AlertTriangle as ExclamationTriangleIcon,
+  CheckCircle as CheckCircleIcon,
+} from 'lucide-react';
 
 export interface TimelineEvent {
   id: string;

--- a/src/client/src/components/ConfigManager.tsx
+++ b/src/client/src/components/ConfigManager.tsx
@@ -10,10 +10,10 @@ import Toggle from './DaisyUI/Toggle';
 import Tooltip from './DaisyUI/Tooltip';
 import { Loading } from './DaisyUI/Loading';
 import {
-  TrashIcon,
-  MagnifyingGlassIcon,
-} from '@heroicons/react/24/outline';
-import { RefreshCw } from 'lucide-react';
+  RefreshCw,
+  Trash2 as TrashIcon,
+  Search as MagnifyingGlassIcon,
+} from 'lucide-react';
 import { useConfigStore } from '../store/configStore';
 import { SkeletonPage } from './DaisyUI/Skeleton';
 import Debug from 'debug';

--- a/src/client/src/components/ConfigSources.tsx
+++ b/src/client/src/components/ConfigSources.tsx
@@ -14,12 +14,12 @@ import Textarea from './DaisyUI/Textarea';
 import DataTable from './DaisyUI/DataTable';
 import { Loading } from './DaisyUI/Loading';
 import {
-  Cog6ToothIcon,
-  CodeBracketIcon,
-  LockClosedIcon,
-  ChevronDownIcon,
-} from '@heroicons/react/24/outline';
-import { RefreshCw } from 'lucide-react';
+  RefreshCw,
+  Settings as Cog6ToothIcon,
+  Code as CodeBracketIcon,
+  Lock as LockClosedIcon,
+  ChevronDown as ChevronDownIcon,
+} from 'lucide-react';
 import { apiService } from '../services/api';
 import type { ConfigSourcesResponse } from '../services/api';
 

--- a/src/client/src/components/DaisyUI/Breadcrumbs.tsx
+++ b/src/client/src/components/DaisyUI/Breadcrumbs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { HomeIcon } from '@heroicons/react/24/solid';
+import { Home as HomeIcon } from 'lucide-react';
 
 /**
  * Route segment to human-readable label mapping.

--- a/src/client/src/components/DaisyUI/Dropdown.tsx
+++ b/src/client/src/components/DaisyUI/Dropdown.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { ChevronDownIcon } from '@heroicons/react/24/solid';
+import { ChevronDown as ChevronDownIcon } from 'lucide-react';
 
 type DropdownProps = {
   trigger: React.ReactNode;

--- a/src/client/src/components/IntegrationsPanel.tsx
+++ b/src/client/src/components/IntegrationsPanel.tsx
@@ -16,21 +16,19 @@ import Badge from './DaisyUI/Badge';
 import Join from './DaisyUI/Join';
 import { useErrorToast } from './DaisyUI/ToastNotification';
 import {
-  PuzzlePieceIcon,
-  ChatBubbleLeftRightIcon,
-  CpuChipIcon,
-  PlusIcon,
-  PencilSquareIcon,
-  TrashIcon,
-  LockClosedIcon,
-} from '@heroicons/react/24/outline';
-import {
   MessageSquare,
   Brain,
   Plug,
   CheckCircle,
   AlertCircle,
   Bot,
+  Puzzle as PuzzlePieceIcon,
+  MessageCircle as ChatBubbleLeftRightIcon,
+  Cpu as CpuChipIcon,
+  Plus as PlusIcon,
+  Pencil as PencilSquareIcon,
+  Trash2 as TrashIcon,
+  Lock as LockClosedIcon,
 } from 'lucide-react';
 
 import { apiService } from '../services/api';

--- a/src/client/src/components/Login.tsx
+++ b/src/client/src/components/Login.tsx
@@ -7,7 +7,7 @@ import { Alert } from './DaisyUI/Alert';
 import { Loading } from './DaisyUI/Loading';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
-import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import { AlertTriangle as ExclamationTriangleIcon } from 'lucide-react';
 
 const Login: React.FC = () => {
   const navigate = useNavigate();

--- a/src/client/src/components/MCPServerManager.tsx
+++ b/src/client/src/components/MCPServerManager.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import {
-  LinkIcon,
-  PlusIcon,
-  WrenchScrewdriverIcon,
-} from '@heroicons/react/24/outline';
-import { RefreshCw } from 'lucide-react';
+  RefreshCw,
+  Link2 as LinkIcon,
+  Plus as PlusIcon,
+  Wrench as WrenchScrewdriverIcon,
+} from 'lucide-react';
 import { Alert } from './DaisyUI/Alert';
 import Badge from './DaisyUI/Badge';
 import Button from './DaisyUI/Button';

--- a/src/client/src/components/Monitoring/MetricChart.tsx
+++ b/src/client/src/components/Monitoring/MetricChart.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Line, Bar, Area, Pie, LineChart, BarChart, AreaChart, PieChart, XAxis, YAxis, Tooltip, CartesianGrid, Legend } from 'recharts';
-import { ChartBarIcon } from '@heroicons/react/24/outline';
+import { BarChart3 as ChartBarIcon } from 'lucide-react';
 import { Alert } from '../DaisyUI/Alert';
 import Card from '../DaisyUI/Card';
 import EmptyState from '../DaisyUI/EmptyState';

--- a/src/client/src/components/ProviderManagement/BaseProvidersConfig.tsx
+++ b/src/client/src/components/ProviderManagement/BaseProvidersConfig.tsx
@@ -18,12 +18,12 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import {
-  ArrowTopRightOnSquareIcon,
-  Bars3Icon,
-  PencilIcon,
-  PlusIcon,
-  TrashIcon,
-} from '@heroicons/react/24/outline';
+  ExternalLink as ArrowTopRightOnSquareIcon,
+  GripVertical as Bars3Icon,
+  Pencil as PencilIcon,
+  Plus as PlusIcon,
+  Trash2 as TrashIcon,
+} from 'lucide-react';
 import { Alert } from '../DaisyUI/Alert';
 import Badge from '../DaisyUI/Badge';
 import Button from '../DaisyUI/Button';

--- a/src/client/src/components/QuickActions.tsx
+++ b/src/client/src/components/QuickActions.tsx
@@ -7,14 +7,15 @@ import Toggle from './DaisyUI/Toggle';
 import Kbd from './DaisyUI/Kbd';
 import { Loading, LoadingSpinner } from './DaisyUI/Loading';
 import {
-  XMarkIcon,
-  ArrowDownTrayIcon,
-  BeakerIcon,
-  CheckCircleIcon,
-  ExclamationCircleIcon,
-  InformationCircleIcon,
-} from '@heroicons/react/24/outline';
-import { Keyboard, RefreshCw } from 'lucide-react';
+  Keyboard,
+  RefreshCw,
+  X as XMarkIcon,
+  Download as ArrowDownTrayIcon,
+  FlaskConical as BeakerIcon,
+  CheckCircle as CheckCircleIcon,
+  AlertCircle as ExclamationCircleIcon,
+  Info as InformationCircleIcon,
+} from 'lucide-react';
 import { apiService } from '../services/api';
 
 interface QuickActionsProps {

--- a/src/client/src/components/SecureConfigManager.tsx
+++ b/src/client/src/components/SecureConfigManager.tsx
@@ -12,15 +12,15 @@ import Toggle from './DaisyUI/Toggle';
 import Tooltip from './DaisyUI/Tooltip';
 import Textarea from './DaisyUI/Textarea';
 import {
-  PlusIcon,
-  PencilIcon,
-  TrashIcon,
-  ShieldCheckIcon,
-  LockClosedIcon,
-  LockOpenIcon,
-  ArrowDownTrayIcon,
-  ArrowUpTrayIcon,
-} from '@heroicons/react/24/outline';
+  Plus as PlusIcon,
+  Pencil as PencilIcon,
+  Trash2 as TrashIcon,
+  ShieldCheck as ShieldCheckIcon,
+  Lock as LockClosedIcon,
+  Unlock as LockOpenIcon,
+  Download as ArrowDownTrayIcon,
+  Upload as ArrowUpTrayIcon,
+} from 'lucide-react';
 import { apiService } from '../services/api';
 import type { SecureConfig } from '../services/api';
 

--- a/src/client/src/components/SystemInfo.tsx
+++ b/src/client/src/components/SystemInfo.tsx
@@ -17,12 +17,12 @@ import Tooltip from './DaisyUI/Tooltip';
 import { LoadingSpinner } from './DaisyUI/Loading';
 import { ConfirmModal } from './DaisyUI/Modal';
 import {
-  ArrowDownTrayIcon,
-  PowerIcon,
-  PlayIcon,
-  XMarkIcon,
-} from '@heroicons/react/24/outline';
-import { RefreshCw } from 'lucide-react';
+  RefreshCw,
+  Download as ArrowDownTrayIcon,
+  Power as PowerIcon,
+  Play as PlayIcon,
+  X as XMarkIcon,
+} from 'lucide-react';
 import { useDashboardStore } from '../store/dashboardStore';
 import { apiService } from '../services/api';
 import Debug from 'debug';

--- a/src/client/src/components/ToolResultHistory.tsx
+++ b/src/client/src/components/ToolResultHistory.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import {
-  ClockIcon,
-  CheckCircleIcon,
-  XCircleIcon,
-  EyeIcon,
-} from '@heroicons/react/24/outline';
+  Clock as ClockIcon,
+  CheckCircle as CheckCircleIcon,
+  XCircle as XCircleIcon,
+  Eye as EyeIcon,
+} from 'lucide-react';
 import Button from './DaisyUI/Button';
 import Card from './DaisyUI/Card';
 import { Badge } from './DaisyUI/Badge';

--- a/src/client/src/components/ToolResultModal.tsx
+++ b/src/client/src/components/ToolResultModal.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import {
-  ClipboardDocumentIcon,
-  ArrowDownTrayIcon,
-  CheckIcon,
-  ExclamationTriangleIcon,
-} from '@heroicons/react/24/outline';
+  ClipboardCopy as ClipboardDocumentIcon,
+  Download as ArrowDownTrayIcon,
+  Check as CheckIcon,
+  AlertTriangle as ExclamationTriangleIcon,
+} from 'lucide-react';
 import Modal from './DaisyUI/Modal';
 import Mockup from './DaisyUI/Mockup';
 import { Alert } from './DaisyUI/Alert';

--- a/src/client/src/components/ToolUsageGuardsConfig.tsx
+++ b/src/client/src/components/ToolUsageGuardsConfig.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useMemo } from 'react';
-import { PencilIcon, PlusIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { Pencil as PencilIcon, Plus as PlusIcon, Trash2 as TrashIcon } from 'lucide-react';
 import { Alert } from './DaisyUI/Alert';
 import Badge from './DaisyUI/Badge';
 import Button from './DaisyUI/Button';

--- a/src/client/src/components/mcp-tools/ToolConfigPanel.tsx
+++ b/src/client/src/components/mcp-tools/ToolConfigPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { MCPTool } from './types';
-import { CodeBracketIcon, ListBulletIcon } from '@heroicons/react/24/outline';
+import { Code as CodeBracketIcon, List as ListBulletIcon } from 'lucide-react';
 import { Alert } from '../DaisyUI/Alert';
 import Mockup from '../DaisyUI/Mockup';
 import Toggle from '../DaisyUI/Toggle';

--- a/src/client/src/components/mcp-tools/ToolRegistryPanel.tsx
+++ b/src/client/src/components/mcp-tools/ToolRegistryPanel.tsx
@@ -2,14 +2,16 @@ import React, { useRef, useMemo } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { MCPTool, RecentToolUsage } from './types';
 import {
-  WrenchScrewdriverIcon as ToolIcon,
-  PlayIcon as RunIcon,
-  ClockIcon,
-} from '@heroicons/react/24/outline';
-import { Search } from 'lucide-react';
+  Wrench as ToolIcon,
+  Play as RunIcon,
+  Clock as ClockIcon,
+  Search,
+  Star as StarOutlineIcon,
+} from 'lucide-react';
 import { ToolFilters } from '../tools/ToolFilters';
-import { StarIcon as StarSolidIcon } from '@heroicons/react/24/solid';
-import { StarIcon as StarOutlineIcon } from '@heroicons/react/24/outline';
+
+// For the filled star, use the same Star icon with fill prop
+const StarSolidIcon = (props: any) => <StarOutlineIcon {...props} fill="currentColor" />;
 import Card from '../DaisyUI/Card';
 import EmptyState from '../DaisyUI/EmptyState';
 import { SkeletonGrid } from '../DaisyUI/Skeleton';

--- a/src/client/src/components/tools/ToolCard.tsx
+++ b/src/client/src/components/tools/ToolCard.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import {
-  WrenchScrewdriverIcon as ToolIcon,
-  PlayIcon as RunIcon,
-} from '@heroicons/react/24/outline';
-import { StarIcon as StarSolidIcon } from '@heroicons/react/24/solid';
-import { StarIcon as StarOutlineIcon } from '@heroicons/react/24/outline';
+  Wrench as ToolIcon,
+  Play as RunIcon,
+  Star as StarOutlineIcon,
+} from 'lucide-react';
+
+// For the filled star, use the same Star icon with fill prop
+const StarSolidIcon = (props: any) => <StarOutlineIcon {...props} fill="currentColor" />;
 import type { MCPTool } from '../../hooks/useToolsLogic';
 import Card from '../DaisyUI/Card';
 import { Badge } from '../DaisyUI/Badge';

--- a/src/client/src/components/tools/ToolFilters.tsx
+++ b/src/client/src/components/tools/ToolFilters.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MagnifyingGlassIcon as SearchIcon } from '@heroicons/react/24/outline';
+import { Search as SearchIcon } from 'lucide-react';
 import Input from '../DaisyUI/Input';
 import Select from '../DaisyUI/Select';
 

--- a/src/client/src/i18n/I18nProvider.tsx
+++ b/src/client/src/i18n/I18nProvider.tsx
@@ -4,7 +4,7 @@ import Card from '../components/DaisyUI/Card';
 import Badge from '../components/DaisyUI/Badge';
 import Button from '../components/DaisyUI/Button';
 import { LoadingSpinner } from '../components/DaisyUI/Loading';
-import { LanguageIcon, GlobeAltIcon } from '@heroicons/react/24/outline';
+import { Languages as LanguageIcon, Globe as GlobeAltIcon } from 'lucide-react';
 
 type Language = 'en' | 'es' | 'fr' | 'de' | 'zh';
 

--- a/src/client/src/pages/MCPToolsPage/components/ExecutionHistoryModal.tsx
+++ b/src/client/src/pages/MCPToolsPage/components/ExecutionHistoryModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/outline';
+import { CheckCircle as CheckCircleIcon, XCircle as XCircleIcon } from 'lucide-react';
 import Modal from '../../../components/DaisyUI/Modal';
 import Accordion from '../../../components/DaisyUI/Accordion';
 import { LoadingSpinner } from '../../../components/DaisyUI/Loading';

--- a/src/client/src/pages/MCPToolsTestingPage.tsx
+++ b/src/client/src/pages/MCPToolsTestingPage.tsx
@@ -2,14 +2,14 @@
 import React, { useState, useEffect } from 'react';
 import { authFetch } from '../utils/authFetch';
 import {
-  WrenchScrewdriverIcon,
-  PlayIcon,
-  ClockIcon,
-  CheckCircleIcon,
-  XCircleIcon,
-  CodeBracketIcon,
-  InformationCircleIcon,
-} from '@heroicons/react/24/outline';
+  Wrench as WrenchScrewdriverIcon,
+  Play as PlayIcon,
+  Clock as ClockIcon,
+  CheckCircle as CheckCircleIcon,
+  XCircle as XCircleIcon,
+  Code as CodeBracketIcon,
+  Info as InformationCircleIcon,
+} from 'lucide-react';
 import { SkeletonGrid } from '../components/DaisyUI/Skeleton';
 import { Alert } from '../components/DaisyUI/Alert';
 import { Badge } from '../components/DaisyUI/Badge';

--- a/src/client/src/pages/StaticPagesPage.tsx
+++ b/src/client/src/pages/StaticPagesPage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Card from '../components/DaisyUI/Card';
 import Button from '../components/DaisyUI/Button';
 
-import { ArrowTopRightOnSquareIcon, HomeIcon, ClockIcon, ComputerDesktopIcon } from '@heroicons/react/24/outline';
+import { ExternalLink as ArrowTopRightOnSquareIcon, Home as HomeIcon, Clock as ClockIcon, Monitor as ComputerDesktopIcon } from 'lucide-react';
 
 const StaticPagesPage: React.FC = () => {
 


### PR DESCRIPTION
## Summary
- Replace all 25 remaining `@heroicons/react` imports with `lucide-react` equivalents across the WebUI codebase
- Standardize on a single icon library (lucide-react) to reduce bundle size and ensure visual consistency
- For solid star icons (favorites), use a wrapper component with `fill="currentColor"` on the lucide `Star` icon

## Test plan
- [ ] Verify `npx tsc --noEmit` passes in `src/client/` (only pre-existing jest/node type definition warnings)
- [ ] Verify `grep -r '@heroicons/react' src/client/src/` returns no results
- [ ] Spot-check key pages: Dashboard, MCP Tools, Config Sources, Integrations Panel, Provider Management
- [ ] Verify star/favorite toggle icons render correctly (outline vs filled)
- [ ] Verify breadcrumbs home icon, dropdown chevron, and other DaisyUI component icons display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)