### PR TITLE
fix(ui): modals, barrel exports, semantic colors

### DIFF
--- a/src/client/src/components/DaisyUI/AdvancedThemeSwitcher.tsx
+++ b/src/client/src/components/DaisyUI/AdvancedThemeSwitcher.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import Divider from './Divider';
 import Input from './Input';
+import Modal from './Modal';
 import Debug from 'debug';
 import Toggle from './Toggle';
 const debug = Debug('app:client:components:DaisyUI:AdvancedThemeSwitcher');
@@ -44,6 +45,7 @@ const AdvancedThemeSwitcher: React.FC<ThemeSwitcherProps> = ({
   const [favoriteThemes, setFavoriteThemes] = useState<string[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<string>('all');
+  const [themeModalOpen, setThemeModalOpen] = useState(false);
 
   const themeOptions: ThemeOption[] = [
     {
@@ -310,19 +312,18 @@ const AdvancedThemeSwitcher: React.FC<ThemeSwitcherProps> = ({
   if (position === 'modal') {
     return (
       <>
-        <button className="btn btn-ghost btn-circle" onClick={() => (document.getElementById('theme-modal') as HTMLDialogElement)?.showModal()} aria-label="Open theme switcher">
+        <button className="btn btn-ghost btn-circle" onClick={() => setThemeModalOpen(true)} aria-label="Open theme switcher">
           🎨
         </button>
 
-        <dialog id="theme-modal" className="modal">
-          <div className="modal-box max-w-4xl">
-            <h3 className="font-bold text-lg mb-4">🎨 Choose Your Theme</h3>
-            <ThemeGrid />
-          </div>
-          <form method="dialog" className="modal-backdrop">
-            <button>close</button>
-          </form>
-        </dialog>
+        <Modal
+          isOpen={themeModalOpen}
+          onClose={() => setThemeModalOpen(false)}
+          title="🎨 Choose Your Theme"
+          size="xl"
+        >
+          <ThemeGrid />
+        </Modal>
       </>
     );
   }
@@ -483,7 +484,7 @@ const AdvancedThemeSwitcher: React.FC<ThemeSwitcherProps> = ({
         {/* Favorite Button */}
         {!compact && (
           <button
-            className={`absolute -top-1 -right-1 btn btn-xs btn-circle transition-opacity ${isFav ? 'text-yellow-500' : 'text-base-content/30'
+            className={`absolute -top-1 -right-1 btn btn-xs btn-circle transition-opacity ${isFav ? 'text-warning' : 'text-base-content/30'
               } ${isFavorite || 'opacity-0 group-hover:opacity-100'}`}
             onClick={(e) => {
               e.stopPropagation();

--- a/src/client/src/components/DaisyUI/ModalForm.tsx
+++ b/src/client/src/components/DaisyUI/ModalForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import Input from './Input';
+import Modal from './Modal';
 import type { FormField } from './formTypes';
 import Checkbox from './Checkbox';
 
@@ -46,16 +47,6 @@ const ModalForm: React.FC<ModalFormProps> = ({
       setCurrentStep(0);
     }
   }, [isOpen, initialData]);
-
-  const getSizeClass = () => {
-    switch (size) {
-    case 'sm': return 'w-11/12 max-w-md';
-    case 'md': return 'w-11/12 max-w-2xl';
-    case 'lg': return 'w-11/12 max-w-4xl';
-    case 'xl': return 'w-11/12 max-w-6xl';
-    default: return 'w-11/12 max-w-2xl';
-    }
-  };
 
   const validateField = (field: FormField, value: any): string | null => {
     if (field.required && (!value || (typeof value === 'string' && !value.trim()))) {
@@ -247,23 +238,14 @@ const ModalForm: React.FC<ModalFormProps> = ({
     return fields.filter(field => steps[currentStep].fields.includes(field.name));
   };
 
-  if (!isOpen) {return null;}
-
   return (
-    <div className="modal modal-open" role="dialog" aria-modal="true" aria-labelledby="modal-form-title">
-      <div className={`modal-box ${getSizeClass()}`}>
-        {/* Header */}
-        <div className="flex items-center justify-between mb-4">
-          <h3 id="modal-form-title" className="font-bold text-lg">{title}</h3>
-          <button
-            className="btn btn-sm btn-circle btn-ghost"
-            onClick={onClose}
-            disabled={isSubmitting}
-            aria-label="Close modal"
-          >
-            ✕
-          </button>
-        </div>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={title}
+      size={size}
+      closable={!isSubmitting}
+    >
 
         {/* Steps indicator */}
         {steps && steps.length > 1 && (
@@ -373,8 +355,7 @@ const ModalForm: React.FC<ModalFormProps> = ({
             )}
           </div>
         </form>
-      </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/src/client/src/components/DaisyUI/Rating.tsx
+++ b/src/client/src/components/DaisyUI/Rating.tsx
@@ -133,7 +133,7 @@ export const Rating: React.FC<RatingProps> = ({
             key={`rating-${i}-half`}
             type="radio"
             name={groupName}
-            className={`mask ${maskClass} bg-orange-400`}
+            className={`mask ${maskClass} bg-warning`}
             style={{ maskPosition: 'left' }}
             checked={displayValue === i - 0.5}
             onChange={() => handleInputChange(i - 0.5)}
@@ -150,7 +150,7 @@ export const Rating: React.FC<RatingProps> = ({
           key={`rating-${i}`}
           type="radio"
           name={groupName}
-          className={`mask ${maskClass} bg-orange-400`}
+          className={`mask ${maskClass} bg-warning`}
           checked={displayValue === i}
           onChange={() => handleInputChange(i)}
           onMouseEnter={() => handleMouseEnter(i)}

--- a/src/client/src/components/DaisyUI/index.ts
+++ b/src/client/src/components/DaisyUI/index.ts
@@ -94,6 +94,15 @@ export type { ValidatorProps, ValidatorHintProps } from './Validator';
 
 // Advanced Components
 export { default as AdvancedThemeSwitcher } from './AdvancedThemeSwitcher';
+export { default as Chat } from './Chat';
+export { default as CodeBlock } from './CodeBlock';
+export { default as ConfigKeyValueCard } from './ConfigKeyValueCard';
+export { EnhancedErrorAlert } from './EnhancedErrorAlert';
+export { default as FormField } from './FormField';
+export { default as ModelAutocomplete } from './ModelAutocomplete';
+export { default as RateLimitIndicator } from './RateLimitIndicator';
+export { default as ResponsiveNavigation } from './ResponsiveNavigation';
+export { default as ThemeDropdown } from './ThemeDropdown';
 export { default as DashboardWidgetSystem } from './DashboardWidgetSystem';
 
 // Navigation Components

--- a/src/client/src/components/DemoModeBanner.tsx
+++ b/src/client/src/components/DemoModeBanner.tsx
@@ -61,9 +61,9 @@ const DemoModeBanner: React.FC = () => {
                         <span className="mr-3">🤖 {demoStatus.botCount} Demo Bots</span>
                         <span className="mr-3">💬 {demoStatus.conversationCount} Conversations</span>
                         {demoStatus.isSimulationRunning && (
-                            <span className="mr-3 text-green-200">
+                            <span className="mr-3 text-success">
                                 📊 Live Simulation
-                                <span className="inline-block w-2 h-2 bg-green-400 rounded-full ml-1 animate-pulse"></span>
+                                <span className="inline-block w-2 h-2 bg-success rounded-full ml-1 animate-pulse"></span>
                             </span>
                         )}
                     </div>

--- a/src/client/src/components/ProviderConfigForm.tsx
+++ b/src/client/src/components/ProviderConfigForm.tsx
@@ -387,7 +387,7 @@ export const ProviderConfigForm: React.FC<ProviderConfigFormProps> = ({
       <div className="space-y-1">
         {renderInput()}
         {error && (
-          <p className="text-xs text-red-500 mt-1">{error}</p>
+          <p className="text-xs text-error mt-1">{error}</p>
         )}
         {!error && formatHint && (field.type === 'password' || field.name === 'apiKey' || field.name === 'botToken') && (
           <p className="text-xs text-base-content/50 mt-1 italic">{formatHint}</p>

--- a/src/client/src/pages/BotCreatePage.tsx
+++ b/src/client/src/pages/BotCreatePage.tsx
@@ -119,10 +119,10 @@ const BotCreatePage: React.FC = () => {
   };
 
   const platforms = [
-    { id: 'discord', name: 'Discord', icon: Gamepad2, color: 'text-indigo-500' },
-    { id: 'slack', name: 'Slack', icon: Hash, color: 'text-purple-500' },
-    { id: 'mattermost', name: 'Mattermost', icon: MessageSquare, color: 'text-blue-500' },
-    { id: 'telegram', name: 'Telegram', icon: Send, color: 'text-sky-500' },
+    { id: 'discord', name: 'Discord', icon: Gamepad2, color: 'text-primary' },
+    { id: 'slack', name: 'Slack', icon: Hash, color: 'text-secondary' },
+    { id: 'mattermost', name: 'Mattermost', icon: MessageSquare, color: 'text-accent' },
+    { id: 'telegram', name: 'Telegram', icon: Send, color: 'text-info' },
   ];
 
   const selectedPersona = personas.find(p => p.id === formData.persona);

--- a/src/client/src/pages/PersonasPage/index.tsx
+++ b/src/client/src/pages/PersonasPage/index.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useState } from 'react';
 import { Alert } from '../../components/DaisyUI/Alert';
 import { Badge } from '../../components/DaisyUI/Badge';
 import Button from '../../components/DaisyUI/Button';
+import { ConfirmModal } from '../../components/DaisyUI/Modal';
 import Card from '../../components/DaisyUI/Card';
 import DetailDrawer from '../../components/DaisyUI/DetailDrawer';
 import Divider from '../../components/DaisyUI/Divider';
@@ -297,28 +298,17 @@ const PersonasPage: React.FC = () => {
       />
 
       {/* Delete Confirmation Modal */}
-      {showDeleteModal && deletingPersona && (
-        <div className="modal modal-open" role="dialog" aria-modal="true">
-          <div className="modal-box">
-            <h3 className="font-bold text-lg flex items-center gap-2">
-              <Trash2 className="w-5 h-5 text-error" />
-              Delete Persona
-            </h3>
-            <p className="py-4">
-              Are you sure you want to delete <strong>{deletingPersona.name}</strong>?
-              Any bots assigned to this persona will be reset to the default persona.
-            </p>
-            <div className="modal-action">
-              <Button variant="ghost" onClick={() => { setShowDeleteModal(false); setDeletingPersona(null); }} disabled={deleting}>
-                Cancel
-              </Button>
-              <Button variant="primary" color="error" onClick={handleConfirmDelete} loading={deleting}>
-                Delete
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
+      <ConfirmModal
+        isOpen={showDeleteModal && !!deletingPersona}
+        onClose={() => { setShowDeleteModal(false); setDeletingPersona(null); }}
+        onConfirm={handleConfirmDelete}
+        title="Delete Persona"
+        message={deletingPersona ? `Are you sure you want to delete "${deletingPersona.name}"? Any bots assigned to this persona will be reset to the default persona.` : ''}
+        confirmText="Delete"
+        cancelText="Cancel"
+        confirmVariant="error"
+        loading={deleting}
+      />
     </div>
   );
 };

--- a/src/client/src/pages/WebhookEventsPage.tsx
+++ b/src/client/src/pages/WebhookEventsPage.tsx
@@ -53,10 +53,10 @@ interface EventsResponse {
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 const SOURCE_ICONS: Record<string, React.ReactNode> = {
-  discord: <MessageSquare className="w-4 h-4 text-indigo-400" />,
-  slack: <Hash className="w-4 h-4 text-green-400" />,
-  mattermost: <MessageSquare className="w-4 h-4 text-blue-400" />,
-  telegram: <MessageSquare className="w-4 h-4 text-sky-400" />,
+  discord: <MessageSquare className="w-4 h-4 text-primary" />,
+  slack: <Hash className="w-4 h-4 text-secondary" />,
+  mattermost: <MessageSquare className="w-4 h-4 text-accent" />,
+  telegram: <MessageSquare className="w-4 h-4 text-info" />,
 };
 
 function sourceIcon(source: string) {


### PR DESCRIPTION
## Summary
- **Raw modals replaced**: Converted raw `<div className="modal modal-open">` in PersonasPage and ModalForm, and `<dialog id="theme-modal">` in AdvancedThemeSwitcher, to use the shared `Modal`/`ConfirmModal` components from `Modal.tsx`
- **Barrel exports added**: Added 9 missing component exports (Chat, CodeBlock, ConfigKeyValueCard, EnhancedErrorAlert, FormField, ModelAutocomplete, RateLimitIndicator, ResponsiveNavigation, ThemeDropdown) to `DaisyUI/index.ts`
- **Hardcoded colors replaced**: Swapped raw Tailwind colors (`text-red-500`, `bg-orange-400`, `text-indigo-500`, `text-yellow-500`, etc.) with DaisyUI semantic tokens (`text-error`, `bg-warning`, `text-primary`, `text-warning`, etc.) across 6 files

## Test plan
- [ ] Verify PersonasPage delete confirmation modal opens/closes correctly
- [ ] Verify ModalForm-based dialogs (e.g., bot creation wizard) still function
- [ ] Verify theme switcher modal opens/closes in modal position mode
- [ ] Verify platform icons in BotCreatePage and WebhookEventsPage render with themed colors
- [ ] Verify Rating component star colors adapt to current theme
- [ ] Run `cd src/client && npx tsc --noEmit` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)