### PR TITLE
refactor(ui): standardize PageHeader across 5 pages

### DIFF
--- a/src/client/src/pages/AdminHealthPage.tsx
+++ b/src/client/src/pages/AdminHealthPage.tsx
@@ -2,20 +2,18 @@
 import React from 'react';
 import HealthCheckWidget from '../components/Dashboard/HealthCheckWidget';
 import SystemHealth from '../components/SystemHealth';
+import PageHeader from '../components/DaisyUI/PageHeader';
 import { Activity } from 'lucide-react';
 
 const AdminHealthPage: React.FC = () => {
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <Activity className="w-7 h-7 text-primary" />
-        <div>
-          <h1 className="text-2xl font-bold">System Health</h1>
-          <p className="text-sm text-base-content/60">
-            Real-time service status and infrastructure health monitoring
-          </p>
-        </div>
-      </div>
+      <PageHeader
+        title="System Health"
+        description="Real-time service status and infrastructure health monitoring"
+        icon={Activity}
+        gradient="success"
+      />
 
       {/* Service-level health widget with 15s refresh for detailed view */}
       <HealthCheckWidget refreshInterval={15000} compact={false} />

--- a/src/client/src/pages/ApiDocsPage.tsx
+++ b/src/client/src/pages/ApiDocsPage.tsx
@@ -8,7 +8,9 @@ import { Badge } from '../components/DaisyUI/Badge';
 import { apiService } from '../services/api';
 import Input from '../components/DaisyUI/Input';
 import Textarea from '../components/DaisyUI/Textarea';
+import PageHeader from '../components/DaisyUI/PageHeader';
 import Accordion from '../components/DaisyUI/Accordion';
+import { Code as CodeBracketIcon } from 'lucide-react';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -405,24 +407,22 @@ const ApiDocsPage: React.FC = () => {
   return (
     <div className="p-4 space-y-4">
       {/* Header */}
-      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
-        <div>
-          <h1 className="text-2xl font-bold">API Documentation</h1>
-          <p className="text-sm text-base-content/60">
-            {totalRoutes} endpoints across {groups.length} groups — auto-generated from route
-            introspection
-          </p>
-        </div>
-        <div className="form-control w-full sm:w-64">
-          <Input
-            type="text"
-            placeholder="Search endpoints..."
-            size="sm"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-          />
-        </div>
-      </div>
+      <PageHeader
+        title="API Documentation"
+        description={`${totalRoutes} endpoints across ${groups.length} groups — auto-generated from route introspection`}
+        icon={CodeBracketIcon}
+        actions={
+          <div className="form-control w-full sm:w-64">
+            <Input
+              type="text"
+              placeholder="Search endpoints..."
+              size="sm"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+          </div>
+        }
+      />
 
       {/* Content */}
       <div className="flex flex-col lg:flex-row gap-4">

--- a/src/client/src/pages/BotTemplatesPage.tsx
+++ b/src/client/src/pages/BotTemplatesPage.tsx
@@ -3,8 +3,9 @@ import { useNavigate } from 'react-router-dom';
 
 import EmptyState from '../components/DaisyUI/EmptyState';
 import { SkeletonGrid } from '../components/DaisyUI/Skeleton';
-import { Copy, Check, Search, RefreshCw } from 'lucide-react';
+import { Copy, Check, Search, RefreshCw, LayoutTemplate } from 'lucide-react';
 import Carousel from '../components/DaisyUI/Carousel';
+import PageHeader from '../components/DaisyUI/PageHeader';
 import SearchFilterBar from '../components/SearchFilterBar';
 import useUrlParams from '../hooks/useUrlParams';
 import { apiService } from '../services/api';
@@ -177,22 +178,19 @@ const BotTemplatesPage: React.FC = () => {
 
 
       <div className="mt-4 mb-8">
-        <div className="flex justify-between items-center mb-4">
-          <div>
-            <h1 className="text-3xl font-bold mb-2">
-              Bot Templates
-            </h1>
-            <p className="text-base-content/70">
-              Quick-start templates to help you create bots faster. Choose a template and customize it for your needs.
-            </p>
-          </div>
-          <Button
-            buttonStyle="outline"
-            onClick={() => navigate('/admin/bots/create')}
-          >
-            Create Custom Bot
-          </Button>
-        </div>
+        <PageHeader
+          title="Bot Templates"
+          description="Quick-start templates to help you create bots faster. Choose a template and customize it for your needs."
+          icon={LayoutTemplate}
+          actions={
+            <Button
+              buttonStyle="outline"
+              onClick={() => navigate('/admin/bots/create')}
+            >
+              Create Custom Bot
+            </Button>
+          }
+        />
 
         {/* Recommended Templates Carousel */}
         {templates.length > 0 && (

--- a/src/client/src/pages/MCPToolsTestingPage.tsx
+++ b/src/client/src/pages/MCPToolsTestingPage.tsx
@@ -10,6 +10,7 @@ import {
   Code as CodeBracketIcon,
   Info as InformationCircleIcon,
 } from 'lucide-react';
+import PageHeader from '../components/DaisyUI/PageHeader';
 import { SkeletonGrid } from '../components/DaisyUI/Skeleton';
 import { Alert } from '../components/DaisyUI/Alert';
 import { Badge } from '../components/DaisyUI/Badge';
@@ -351,12 +352,11 @@ const MCPToolsTestingPage: React.FC = () => {
 
   return (
     <div className="p-6">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold mb-2">MCP Tools Testing</h1>
-        <p className="text-base-content/70">
-          Test MCP tools with custom parameters before using them in bots
-        </p>
-      </div>
+      <PageHeader
+        title="MCP Tools Testing"
+        description="Test MCP tools with custom parameters before using them in bots"
+        icon={WrenchScrewdriverIcon}
+      />
 
       {alert && (
         <div className="mb-6">

--- a/src/client/src/pages/StaticPagesPage.tsx
+++ b/src/client/src/pages/StaticPagesPage.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import Card from '../components/DaisyUI/Card';
 import Button from '../components/DaisyUI/Button';
+import PageHeader from '../components/DaisyUI/PageHeader';
 
-import { ExternalLink as ArrowTopRightOnSquareIcon, Home as HomeIcon, Clock as ClockIcon, Monitor as ComputerDesktopIcon } from 'lucide-react';
+import { ExternalLink as ArrowTopRightOnSquareIcon, Home as HomeIcon, Clock as ClockIcon, Monitor as ComputerDesktopIcon, FileText } from 'lucide-react';
 
 const StaticPagesPage: React.FC = () => {
 
@@ -36,10 +37,11 @@ const StaticPagesPage: React.FC = () => {
 
   return (
     <div className="p-6">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold mb-2">Static Pages</h1>
-        <p className="text-base-content/70">Browse and access static HTML pages and resources</p>
-      </div>
+      <PageHeader
+        title="Static Pages"
+        description="Browse and access static HTML pages and resources"
+        icon={FileText}
+      />
 
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
         {staticPages.map((page) => (


### PR DESCRIPTION
## Summary
- **Part A**: Replaced raw `<h1>` headers with the `PageHeader` component in 5 pages: MCPToolsTestingPage, AdminHealthPage, ApiDocsPage, BotTemplatesPage, and StaticPagesPage. Each now gets consistent gradient backgrounds, icons, breadcrumbs, and optional action buttons.
- **Part B**: Evaluated BotChatBubbles for Chat component migration. The `ChatInterface` component requires `onSendMessage` and renders an input area, making it unsuitable for read-only preview. BotChatBubbles already uses proper DaisyUI `chat-*` classes directly -- no change needed.
- **Part C**: Evaluated `list-disc` usage in HelpPage, ProvidersPage, and StaticPagesPage. All instances are prose/informational content where plain HTML bullet lists are more readable than the structured DaisyUI `List` component -- no change needed.

## Test plan
- [ ] Run `cd src/client && npx tsc --noEmit` -- only pre-existing jest/node type errors, no new errors
- [ ] Verify each converted page renders correctly with PageHeader (gradient, icon, description, breadcrumbs)
- [ ] Verify ApiDocsPage search input still works in the actions slot
- [ ] Verify BotTemplatesPage "Create Custom Bot" button still works in the actions slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)