### PR TITLE
🎨 Palette: Add aria-label to favorite button in ToolCard

### DIFF
--- a/src/client/src/components/tools/ToolCard.tsx
+++ b/src/client/src/components/tools/ToolCard.tsx
@@ -57,6 +57,7 @@ export const ToolCard: React.FC<ToolCardProps> = ({
                 onToggleFavorite(tool.id);
               }}
               title={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+              aria-label={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
             >
               {isFavorite ? (
                 <StarSolidIcon className="w-4 h-4 text-warning" />
@@ -94,6 +95,7 @@ export const ToolCard: React.FC<ToolCardProps> = ({
               className="btn btn-sm btn-ghost btn-circle"
               onClick={() => onToggleFavorite(tool.id)}
               title={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+              aria-label={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
             >
               {isFavorite ? (
                 <StarSolidIcon className="w-5 h-5 text-warning" />


### PR DESCRIPTION
💡 What: Added an `aria-label` attribute to the favorite button in both variations (compact and non-compact) of the `ToolCard` component.

🎯 Why: The favorite button is an icon-only button and screen readers rely on an `aria-label` to provide context when navigating these types of UI components.

♿ Accessibility: Added `aria-label` which dynamically sets "Add to favorites" or "Remove from favorites" based on the state.

---
*PR created automatically by Jules for task [5854010390112074344](https://jules.google.com/task/5854010390112074344) started by @matthewhand*