### PR TITLE
Remove redundant AnnouncementBanner from dashboard

### DIFF
--- a/src/client/src/components/Dashboard.tsx
+++ b/src/client/src/components/Dashboard.tsx
@@ -9,7 +9,6 @@ import RadialProgress from './DaisyUI/RadialProgress';
 import { SkeletonCard } from './DaisyUI/Skeleton';
 import { Stat, Stats } from './DaisyUI/Stat';
 import DashboardBotCard from './DashboardBotCard';
-import AnnouncementBanner from './AnnouncementBanner';
 import TipRotator from './TipRotator';
 import QuickActions from './QuickActions';
 import AgentGrid from './Dashboard/AgentGrid';
@@ -261,8 +260,6 @@ const Dashboard: React.FC = () => {
 
       {/* Main Content */}
       <div className="px-2 py-2">
-        {/* Announcement Banner */}
-        <AnnouncementBanner />
         <TipRotator className="mb-4 px-2" />
 
         {/* Bot Cards Grid */}


### PR DESCRIPTION
## Summary
- Removed `AnnouncementBanner` import and JSX from `Dashboard.tsx`
- The announcement content was triple-redundant: shown in the AnnouncementBanner (static block), the carousel's "Announcements" slide, and partially overlapping with TipRotator
- The `AnnouncementBanner` component file is preserved since other pages may use it

## Test plan
- [ ] Verify dashboard loads without errors
- [ ] Confirm TipRotator still displays and rotates tips
- [ ] Confirm carousel still shows the "Announcements" slide when announcement data exists
- [ ] `npx tsc --noEmit` passes cleanly