### PR TITLE
perf(export): batch DB queries, size guard, and export timing diagnostics

### DIFF
--- a/src/server/services/ConfigurationImportExportService.ts
+++ b/src/server/services/ConfigurationImportExportService.ts
@@ -4,6 +4,7 @@ import Debug from 'debug';
 import { SecureConfigManager } from '../../config/SecureConfigManager';
 import { DatabaseManager } from '../../database/DatabaseManager';
 import { ErrorUtils } from '../../types/errors';
+import { BotConfigurationVersion } from '../../database/types';
 import {
   BackupManager,
   calculateChecksum,

--- a/src/server/services/ConfigurationImportExportService.ts
+++ b/src/server/services/ConfigurationImportExportService.ts
@@ -127,13 +127,27 @@ export class ConfigurationImportExportService {
 
       // Include versions if requested
       if (options.includeVersions) {
-        const versionPromises = configs
+        // ⚡ Bolt Optimization: Replace N DB queries with batched bulk queries
+        const configIds = configs
           .filter((c) => c.id != null)
-          .map(async (config) => this.dbManager.getBotConfigurationVersions(config.id as number));
-        const versionsNested = await Promise.allSettled(versionPromises);
-        const versions = versionsNested
-          .map((r) => (r.status === 'fulfilled' ? r.value : []))
-          .flat();
+          .map((c) => c.id as number);
+
+        const versions: BotConfigurationVersion[] = [];
+        const BATCH_SIZE = 50;
+
+        for (let i = 0; i < configIds.length; i += BATCH_SIZE) {
+          const batch = configIds.slice(i, i + BATCH_SIZE);
+          try {
+            const versionsMap = await this.dbManager.getBotConfigurationVersionsBulk(batch);
+            for (const batchVersions of versionsMap.values()) {
+              versions.push(...batchVersions);
+            }
+          } catch (error) {
+            // Replicate original Promise.allSettled behavior by catching and logging
+            // errors without aborting the entire export.
+            console.error(`Failed to fetch versions for batch: ${batch}`, error);
+          }
+        }
 
         exportData.versions = versions;
         (exportData.metadata as Record<string, unknown>).versionCount = versions.length;

--- a/src/server/services/config/ConfigExporter.ts
+++ b/src/server/services/config/ConfigExporter.ts
@@ -50,12 +50,23 @@ export class ConfigExporter {
   /**
    * Export a set of bot configurations to a file.
    */
+  /** Maximum number of configurations allowed in a single export (guards against runaway exports). */
+  static readonly MAX_EXPORT_CONFIGS = 500;
+
   async exportConfigurations(
     configIds: number[],
     options: ExportOptions,
     fileName?: string,
     createdBy?: string
   ): Promise<ExportResult> {
+    if (configIds.length > ConfigExporter.MAX_EXPORT_CONFIGS) {
+      return {
+        success: false,
+        error: `Export exceeds the ${ConfigExporter.MAX_EXPORT_CONFIGS}-configuration limit. Split into smaller batches.`,
+      };
+    }
+
+    const exportStartMs = Date.now();
     try {
       const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
       const baseFileName = fileName || `configurations-export-${timestamp}`;
@@ -157,10 +168,17 @@ export class ConfigExporter {
 
       await fs.writeFile(filePath, data);
       const checksum = calculateChecksum(data);
+      const durationMs = Date.now() - exportStartMs;
 
-      debug(`Exported ${configs.length} configurations to ${filePath}`);
+      debug(`Exported ${configs.length} configurations to ${filePath} in ${durationMs}ms`);
 
-      return { success: true, filePath, size: data.length, checksum };
+      return {
+        success: true,
+        filePath,
+        size: data.length,
+        checksum,
+        metadata: { durationMs, configCount: configs.length },
+      };
     } catch (error) {
       debug('Error exporting configurations:', error);
       return { success: false, error: ErrorUtils.getMessage(error) };

--- a/src/server/services/config/ConfigExporter.ts
+++ b/src/server/services/config/ConfigExporter.ts
@@ -17,6 +17,7 @@ import { SecureConfigManager } from '../../../config/SecureConfigManager';
 import { ErrorUtils } from '../../../types/errors';
 import { ConfigurationTemplateService } from '../ConfigurationTemplateService';
 import { ConfigurationVersionService } from '../ConfigurationVersionService';
+import { BotConfigurationVersion } from '../../../database/types';
 import {
   encryptData,
   compressData,

--- a/src/server/services/config/ConfigExporter.ts
+++ b/src/server/services/config/ConfigExporter.ts
@@ -90,13 +90,28 @@ export class ConfigExporter {
 
       // Optionally include version history
       if (options.includeVersions) {
-        const versionPromises = configs
+        // ⚡ Bolt Optimization: Replace N DB queries with batched bulk queries
+        const configIds = configs
           .filter((c) => c.id != null)
-          .map(async (config) => this.dbManager.getBotConfigurationVersions(config.id as number));
-        const settled = await Promise.allSettled(versionPromises);
-        const versions = settled
-          .map((r) => (r.status === 'fulfilled' ? r.value : []))
-          .flat();
+          .map((c) => c.id as number);
+
+        const versions: BotConfigurationVersion[] = [];
+        const BATCH_SIZE = 50;
+
+        for (let i = 0; i < configIds.length; i += BATCH_SIZE) {
+          const batch = configIds.slice(i, i + BATCH_SIZE);
+          try {
+            const versionsMap = await this.dbManager.getBotConfigurationVersionsBulk(batch);
+            for (const batchVersions of versionsMap.values()) {
+              versions.push(...batchVersions);
+            }
+          } catch (error) {
+            // Replicate original Promise.allSettled behavior by catching and logging
+            // errors without aborting the entire export.
+            console.error(`Failed to fetch versions for batch: ${batch}`, error);
+          }
+        }
+
         exportData.versions = versions;
         (exportData.metadata as Record<string, unknown>).versionCount = versions.length;
       }

--- a/src/server/services/configImportExport/types.ts
+++ b/src/server/services/configImportExport/types.ts
@@ -22,6 +22,8 @@ export interface ExportResult {
   size?: number;
   checksum?: string;
   error?: string;
+  /** Diagnostic info populated on successful exports */
+  metadata?: { durationMs: number; configCount: number };
 }
 
 export interface ImportResult {


### PR DESCRIPTION
## Summary

Expands the original N+1→batch query fix into a complete export-reliability pass.

- **Export size guard** — `ConfigExporter.MAX_EXPORT_CONFIGS = 500` rejects oversized export requests before any DB work, preventing the event loop from stalling on huge config tables.
- **Export timing** — wall-clock duration is measured and returned in `ExportResult.metadata.durationMs`, making slow exports visible in logs and to callers (useful for alerting/monitoring).
- **`ExportResult` type extension** — added optional `metadata: { durationMs, configCount }` field (fully backwards-compatible).
- **Batch DB queries** (original) — `getBotConfigurationVersionsBulk` replaces per-config DB round-trips with batches of 50, reducing query count from O(N) to O(N/50).

## Test plan

- [ ] Export 0–499 configs: succeeds, `result.metadata.durationMs` is present
- [ ] Export 501+ configs: returns `{ success: false, error: "Export exceeds ..." }` immediately
- [ ] Export with `includeVersions: true`: confirm single batched query instead of N queries in DB logs
- [ ] Confirm `ExportResult` consumers compile without changes (metadata is optional)