### PR TITLE
cleanup: remove last heroicon import, convert raw h1 to PageHeader

### DIFF
--- a/src/client/src/pages/AuditPage.tsx
+++ b/src/client/src/pages/AuditPage.tsx
@@ -1,12 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useEffect, useState, useCallback } from 'react';
 import { apiService } from '../services/api';
-import {
-  ArrowPathIcon,
-  FunnelIcon,
-  ExclamationCircleIcon,
-  ShieldCheckIcon,
-} from '@heroicons/react/24/outline';
+import { RefreshCw, Filter, AlertCircle, ShieldCheck } from 'lucide-react';
+import PageHeader from '../components/DaisyUI/PageHeader';
 import Button from '../components/DaisyUI/Button';
 
 interface AuditEvent {
@@ -78,22 +74,26 @@ const AuditPage: React.FC = () => {
 
   return (
     <div className="container mx-auto p-4">
-      <div className="flex justify-between items-center mb-6">
-        <h1 className="text-3xl font-bold">Audit Log</h1>
-        <Button
-          buttonStyle="outline"
-          onClick={fetchAuditEvents}
-          disabled={loading}
-          aria-label="Refresh audit logs"
-        >
-          <ArrowPathIcon className={`w-5 h-5 mr-2 ${loading ? 'animate-spin' : ''}`} />
-          Refresh
-        </Button>
-      </div>
+      <PageHeader
+        title="Audit Log"
+        icon={<ShieldCheck className="w-8 h-8" />}
+        gradient="warning"
+        actions={
+          <Button
+            buttonStyle="outline"
+            onClick={fetchAuditEvents}
+            disabled={loading}
+            aria-label="Refresh audit logs"
+          >
+            <RefreshCw className={`w-5 h-5 mr-2 ${loading ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+        }
+      />
 
       {error && (
         <div className="alert alert-error mb-4">
-          <ExclamationCircleIcon className="w-6 h-6" />
+          <AlertCircle className="w-6 h-6" />
           <span>{error}</span>
           <Button
             variant="ghost"
@@ -150,7 +150,7 @@ const AuditPage: React.FC = () => {
           disabled={!searchTerm && actionFilter === 'all' && resultFilter === 'all'}
           aria-label="Clear audit filters"
         >
-          <FunnelIcon className="w-4 h-4 mr-1" /> Clear Filters
+          <Filter className="w-4 h-4 mr-1" /> Clear Filters
         </Button>
       </div>
 
@@ -161,7 +161,7 @@ const AuditPage: React.FC = () => {
         </div>
       ) : filteredEvents.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-16 text-base-content/60">
-          <ShieldCheckIcon className="w-16 h-16 mb-4" />
+          <ShieldCheck className="w-16 h-16 mb-4" />
           <p className="text-lg font-semibold">No audit logs</p>
           <p className="text-sm mt-1">
             {auditEvents.length === 0

--- a/src/client/src/pages/DaisyUIShowcase.tsx
+++ b/src/client/src/pages/DaisyUIShowcase.tsx
@@ -6,6 +6,7 @@ import type { TabItem } from '../components/DaisyUI/Tabs';
 import { ButtonsDemo } from '../components/DaisyUI/demos/ButtonsDemo';
 import { AnimationShowcaseDemo } from '../components/DaisyUI/demos/AnimationShowcaseDemo';
 import { InputDemo, SelectDemo, CheckboxDemo, TextareaDemo, FileInputDemo } from '../components/DaisyUI/demos/FormsDemo';
+import PageHeader from '../components/DaisyUI/PageHeader';
 import {
   BadgeDemo,
   AlertDemo,
@@ -75,15 +76,16 @@ const DaisyUIShowcase: React.FC = () => {
   return (
     <div className="p-6">
       {/* Header */}
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold">DaisyUI Component Reference</h1>
-        <p className="text-base-content/60 mt-1">
-          Official DaisyUI components using raw CSS classes -
-          <Link href="https://daisyui.com/components/" target="_blank" rel="noopener noreferrer" color="primary" className="ml-1">
+      <PageHeader
+        title="DaisyUI Component Reference"
+        description="Official DaisyUI components using raw CSS classes"
+        gradient="secondary"
+        actions={
+          <Link href="https://daisyui.com/components/" target="_blank" rel="noopener noreferrer" color="primary">
             View Official Docs
           </Link>
-        </p>
-      </div>
+        }
+      />
 
       {/* Component Navigation */}
       <Tabs

--- a/src/client/src/pages/SpecDetailPage.tsx
+++ b/src/client/src/pages/SpecDetailPage.tsx
@@ -8,6 +8,7 @@ import Divider from '../components/DaisyUI/Divider';
 import Dropdown from '../components/DaisyUI/Dropdown';
 
 import { SkeletonList } from '../components/DaisyUI/Skeleton';
+import PageHeader from '../components/DaisyUI/PageHeader';
 import { ArrowLeft, Download } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import useSpec from '../hooks/useSpec';
@@ -104,29 +105,27 @@ ${spec.content.replace(/^/gm, '  ')}
       <div className="mt-6">
         <Card className="shadow-lg">
             {/* Header */}
-            <div className="flex items-center justify-between mb-6">
-              <div className="flex items-center gap-4">
-                <Button size="sm" className="btn-ghost" onClick={() => navigate(-1)}>
-                  <ArrowLeft className="w-4 h-4 mr-2" />
-                  Back
-                </Button>
-                <div>
-                  <h1 className="text-3xl font-bold">{spec.topic}</h1>
-                  <p className="opacity-70">
-                    By {spec.author} • {new Date(spec.timestamp).toLocaleDateString()}
-                  </p>
-                </div>
-              </div>
-              <Dropdown
-                trigger={
-                  <Button className="btn-primary">
-                    <Download className="w-4 h-4 mr-2" />
-                    Export
+            <PageHeader
+              title={spec.topic}
+              description={`By ${spec.author} \u2022 ${new Date(spec.timestamp).toLocaleDateString()}`}
+              actions={
+                <div className="flex items-center gap-2">
+                  <Button size="sm" className="btn-ghost" onClick={() => navigate(-1)}>
+                    <ArrowLeft className="w-4 h-4 mr-2" />
+                    Back
                   </Button>
-                }
-                items={exportItems}
-              />
-            </div>
+                  <Dropdown
+                    trigger={
+                      <Button className="btn-primary">
+                        <Download className="w-4 h-4 mr-2" />
+                        Export
+                      </Button>
+                    }
+                    items={exportItems}
+                  />
+                </div>
+              }
+            />
 
             {/* Tags */}
             <div className="flex flex-wrap gap-2 mb-6">

--- a/src/client/src/pages/SystemManagement/index.tsx
+++ b/src/client/src/pages/SystemManagement/index.tsx
@@ -15,6 +15,7 @@ import type { SystemConfig, BackupRecord } from './types';
 import { LoadingSpinner } from '../../components/DaisyUI/Loading';
 import Button from '../../components/DaisyUI/Button';
 import Input from '../../components/DaisyUI/Input';
+import PageHeader from '../../components/DaisyUI/PageHeader';
 
 const SystemManagement: React.FC = () => {
   const { alerts, performanceMetrics } = useWebSocket();
@@ -248,25 +249,20 @@ const SystemManagement: React.FC = () => {
   return (
     <div className="min-h-screen bg-base-200 p-6">
       {/* Header */}
-      <div className="mb-8">
-        <div className="flex justify-between items-center">
-          <div>
-            <h1 className="text-4xl font-bold mb-2">System Management</h1>
-            <p className="text-lg text-neutral-content/70">
-              Manage system configuration, alerts, and backups
-            </p>
-          </div>
-          <div className="flex gap-4">
-            <Button
-              className="btn-success"
-              onClick={openBackupModal}
-              disabled={isCreatingBackup}
-            >
-              {isCreatingBackup ? <LoadingSpinner size="sm" /> : '💾'} Create Backup
-            </Button>
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        title="System Management"
+        description="Manage system configuration, alerts, and backups"
+        gradient="accent"
+        actions={
+          <Button
+            className="btn-success"
+            onClick={openBackupModal}
+            disabled={isCreatingBackup}
+          >
+            {isCreatingBackup ? <LoadingSpinner size="sm" /> : '💾'} Create Backup
+          </Button>
+        }
+      />
 
       {/* System Status Cards */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">


### PR DESCRIPTION
## Summary
- Replaced the last `@heroicons/react` import in `AuditPage.tsx` with lucide-react equivalents (`RefreshCw`, `Filter`, `AlertCircle`, `ShieldCheck`)
- Converted raw `<h1>` elements to the `PageHeader` component in 4 pages: `SpecDetailPage`, `DaisyUIShowcase`, `AuditPage`, `SystemManagement`
- Left `LoadingPage` h1 as-is since it is a splash/loading screen with intentional standalone styling

## Test plan
- [ ] Verify AuditPage renders correctly with lucide-react icons (refresh, filter, error alert, empty state)
- [ ] Verify PageHeader appears correctly on SpecDetailPage, DaisyUIShowcase, AuditPage, and SystemManagement
- [ ] Verify LoadingPage still renders its splash screen correctly
- [ ] Run `npx tsc --noEmit` in `src/client/` -- only pre-existing jest/node type errors remain