### PR TITLE
security(memory): SSRF hardening across Mem4ai and Mem0 providers

### DIFF
--- a/packages/memory-mem0/src/Mem0Provider.test.ts
+++ b/packages/memory-mem0/src/Mem0Provider.test.ts
@@ -263,3 +263,21 @@ describe('legacy convenience methods', () => {
     await expect(p.delete('l5')).resolves.toBeUndefined();
   });
 });
+
+describe('SSRF protection', () => {
+  const { isSafeUrl } = jest.requireMock('@hivemind/shared-types');
+
+  it('blocks requests when isSafeUrl returns false', async () => {
+    isSafeUrl.mockResolvedValue(false);
+    const p = new Mem0Provider({ ...BASE_CONFIG, baseUrl: 'http://169.254.169.254', maxRetries: 0 });
+    await expect(p.addMemory({ userId: 'u1', content: 'x', role: 'user' }))
+      .rejects.toThrow('url is not safe');
+  });
+
+  it('allows requests when isSafeUrl returns true', async () => {
+    isSafeUrl.mockResolvedValue(true);
+    mockFetch(200, { results: [{ id: 'ssrf-ok', memory: 'safe', created_at: '2024-01-01T00:00:00Z' }] });
+    const p = new Mem0Provider(BASE_CONFIG);
+    await expect(p.addMemory({ userId: 'u1', content: 'safe', role: 'user' })).resolves.toBeDefined();
+  });
+});

--- a/packages/memory-mem0/src/Mem0Provider.ts
+++ b/packages/memory-mem0/src/Mem0Provider.ts
@@ -60,12 +60,6 @@ export class Mem0Provider implements IMemoryProvider {
       halfOpenMaxAttempts: config.circuitBreaker?.halfOpenMaxAttempts ?? 3,
     });
 
-    // Validate baseUrl eagerly — isSafeUrl is async so we schedule a check and
-    // throw on the first request if the URL is unsafe.
-    isSafeUrl(this.baseUrl).then((safe) => {
-      if (!safe) throw new Error(`Mem0Provider: baseUrl is not safe: ${this.baseUrl}`);
-    });
-
     debug(
       'Mem0Provider initialised (baseUrl=%s, userId=%s, agentId=%s)',
       this.baseUrl,
@@ -288,6 +282,11 @@ export class Mem0Provider implements IMemoryProvider {
 
   private async doRequest<T>(method: string, path: string, body?: unknown): Promise<T> {
     const url = `${this.baseUrl}${path}`;
+
+    if (!(await isSafeUrl(url))) {
+      throw new Error(`Mem0Provider: url is not safe: ${url}`);
+    }
+
     const headers: Record<string, string> = {
       Authorization: `Token ${this.apiKey}`,
       'Content-Type': 'application/json',

--- a/packages/memory-mem4ai/src/Mem4aiProvider.test.ts
+++ b/packages/memory-mem4ai/src/Mem4aiProvider.test.ts
@@ -1,3 +1,9 @@
+// Mock isSafeUrl so tests don't do real DNS lookups
+jest.mock('@hivemind/shared-types', () => ({
+  ...jest.requireActual('@hivemind/shared-types'),
+  isSafeUrl: jest.fn(async () => true),
+}));
+
 import { Mem4aiProvider } from './Mem4aiProvider';
 import { Mem4aiApiError } from './types';
 import { clearCircuitBreakerRegistry } from './CircuitBreaker';

--- a/packages/memory-mem4ai/src/Mem4aiProvider.ts
+++ b/packages/memory-mem4ai/src/Mem4aiProvider.ts
@@ -1,4 +1,5 @@
 import Debug from 'debug';
+import { isSafeUrl } from '@hivemind/shared-types';
 import type {
   IMemoryProvider,
   MemoryEntry,
@@ -289,6 +290,11 @@ export class Mem4aiProvider implements IMemoryProvider {
 
   private async doRequest<T>(method: string, path: string, body?: unknown): Promise<T> {
     const url = `${this.baseUrl}${path}`;
+
+    if (!(await isSafeUrl(url))) {
+      throw new Error(`Mem4aiProvider: url is not safe: ${url}`);
+    }
+
     const headers: Record<string, string> = {
       Authorization: `Bearer ${this.apiKey}`,
       'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary

Expands the original Mem4aiProvider SSRF fix to cover Mem0Provider, which had the same vulnerability pattern, and removes a racy constructor-level check that gave a false sense of security.

**Mem4aiProvider** (original fix):
- Per-request `isSafeUrl()` check inside `doRequest()` blocks any request to a private/loopback/link-local URL

**Mem0Provider** (this PR adds):
- Same per-request `isSafeUrl()` guard in `doRequest()` — previously the URL was fetched without any safety check
- Removes the async fire-and-forget `isSafeUrl` call in the constructor: it scheduled a Promise that threw into an unhandled rejection and could never block an actual request
- Adds two SSRF tests: reject on `169.254.169.254` baseUrl, pass on safe URL

## Impact

An attacker who can supply a custom `baseUrl` (e.g. via the settings API or environment config) could previously route memory requests to internal metadata services. Both providers now reject such requests at the point of every HTTP call.

## Test plan

- [ ] `Mem0Provider SSRF protection` test suite passes
- [ ] Existing `Mem0Provider` tests unaffected
- [ ] Same for Mem4aiProvider tests