### PR TITLE
refactor(config): complete UserConfigStore index with delete sync, findBot, and getAllBots

### DIFF
--- a/src/config/UserConfigStore.ts
+++ b/src/config/UserConfigStore.ts
@@ -28,6 +28,7 @@ export class UserConfigStore {
     generalSettings?: GeneralSettings;
   } = {};
   private configPath: string;
+  private botMap: Map<string, BotConfiguration> = new Map();
 
   public constructor() {
     this.configPath = path.join(process.cwd(), 'config', 'user-config.json');
@@ -42,6 +43,18 @@ export class UserConfigStore {
         bots: [],
         botDisabledStates: {},
       };
+    }
+    this.initializeBotMap();
+  }
+
+  private initializeBotMap(): void {
+    this.botMap.clear();
+    if (this.config.bots) {
+      for (const bot of this.config.bots) {
+        if (bot.name) {
+          this.botMap.set(bot.name, bot);
+        }
+      }
     }
   }
 
@@ -64,6 +77,7 @@ export class UserConfigStore {
         botDisabledStates: {},
       };
     }
+    this.initializeBotMap();
   }
 
   /**
@@ -141,7 +155,9 @@ export class UserConfigStore {
     if (!this.config.bots) {
       return undefined;
     }
-    const botConfig = this.config.bots.find(bot => bot.name === botName);
+    // ⚡ Bolt Optimization: Use the synchronized botMap for O(1) cache lookups
+    // instead of repeatedly executing O(N) Array.prototype.find operations.
+    const botConfig = this.botMap.get(botName);
     if (!botConfig) {
       return undefined;
     }
@@ -223,6 +239,7 @@ export class UserConfigStore {
     } else {
       this.config.bots.push(botConfig);
     }
+    this.botMap.set(botName, botConfig);
   }
 
   /**

--- a/src/config/UserConfigStore.ts
+++ b/src/config/UserConfigStore.ts
@@ -243,6 +243,36 @@ export class UserConfigStore {
   }
 
   /**
+   * Remove the user override for a bot and keep the botMap in sync.
+   * Returns true if a record was removed, false if no override existed.
+   */
+  public deleteBotOverride(botName: string): boolean {
+    const before = this.config.bots?.length ?? 0;
+    this.config.bots = (this.config.bots ?? []).filter((b) => b.name !== botName);
+    this.botMap.delete(botName);
+    return (this.config.bots?.length ?? 0) < before;
+  }
+
+  /**
+   * Find the first bot whose configuration satisfies a predicate.
+   * Useful for provider-based or platform-based lookups without iterating externally.
+   */
+  public findBot(predicate: (bot: BotConfiguration) => boolean): BotConfiguration | undefined {
+    for (const bot of this.botMap.values()) {
+      if (predicate(bot)) return bot;
+    }
+    return undefined;
+  }
+
+  /**
+   * Return all bot configurations as an array.
+   * Reads from the in-memory map so callers don't need to access the internal config object.
+   */
+  public getAllBots(): BotConfiguration[] {
+    return Array.from(this.botMap.values());
+  }
+
+  /**
    * Get general settings.
    * @returns The general settings object.
    */

--- a/src/message/helpers/processing/shouldReplyToMessage.ts
+++ b/src/message/helpers/processing/shouldReplyToMessage.ts
@@ -294,8 +294,7 @@ export async function shouldReplyToMessage(
     }
   }
 
-  const timeSinceLastPost =
-    lastPostTime > 0 ? Math.max(0, Date.now() - lastPostTime) : Infinity;
+  const timeSinceLastPost = lastPostTime > 0 ? Math.max(0, Date.now() - lastPostTime) : Infinity;
   const hasPostedRecently = timeSinceLastPost < SILENCE_THRESHOLD;
   const lastStr = lastPostTime > 0 ? `${Math.floor(timeSinceLastPost / 1000)}s ago` : 'never';
 

--- a/src/server/routes/marketplace.ts
+++ b/src/server/routes/marketplace.ts
@@ -3,7 +3,6 @@ import * as path from 'path';
 import Debug from 'debug';
 import { Router } from 'express';
 import { configLimiter } from '@src/middleware/rateLimiter';
-import type { PluginManifest } from '@src/plugins/PluginLoader';
 import {
   installPlugin,
   listInstalledPlugins,
@@ -183,7 +182,11 @@ async function scanBuiltInPackages(): Promise<MarketplacePackage[]> {
           : 'tool';
         packages.push({
           name: dir,
-          displayName: dir.replace(/^(llm|message|memory|tool|adapter)-/, '').split('-').map((w: string) => w.charAt(0).toUpperCase() + w.slice(1)).join(' '),
+          displayName: dir
+            .replace(/^(llm|message|memory|tool|adapter)-/, '')
+            .split('-')
+            .map((w: string) => w.charAt(0).toUpperCase() + w.slice(1))
+            .join(' '),
           description: 'Built-in package',
           type,
           version: '0.0.0',
@@ -285,7 +288,8 @@ async function getPackages(): Promise<MarketplacePackage[]> {
     packageMap.set('hivemind-plugin-weather', {
       name: 'hivemind-plugin-weather',
       displayName: 'Weather Tool',
-      description: 'Gives bots the ability to check weather conditions and forecasts for any location. Community-contributed MCP tool plugin.',
+      description:
+        'Gives bots the ability to check weather conditions and forecasts for any location. Community-contributed MCP tool plugin.',
       type: 'tool',
       version: '1.2.0',
       status: 'available',


### PR DESCRIPTION
## Summary

Expands the original O(1) `botMap` read path into a complete index lifecycle.

- **`deleteBotOverride(name)`** — the original PR added `botMap` for reads but had no delete path. This method removes the entry from both `config.bots[]` and `botMap` atomically so the index can never become stale after a deletion. Returns `true` if a record was removed.
- **`findBot(predicate)`** — walks the map once for arbitrary lookups (e.g. find bot by `messageProvider === 'discord'`). Avoids callers having to call `getBotNames()` and then `getBotOverride()` in a loop.
- **`getAllBots()`** — flat accessor that returns `Array.from(botMap.values())` so callers don't need to reach into `config.bots` directly.

## Test plan

- [ ] `deleteBotOverride('myBot')` returns `true` and subsequent `getBotOverride('myBot')` returns `undefined`
- [ ] `deleteBotOverride('nonExistent')` returns `false` without throwing
- [ ] `findBot(b => b.messageProvider === 'discord')` returns the first matching bot
- [ ] `getAllBots()` returns the same entries as `config.bots` after several `setBotOverride` calls