### PR TITLE
refactor: split index.ts into focused modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 # NOTE: split COPY (manifests-only → install → source) breaks pnpm workspace
 # resolution for hoisted deps like zustand. Full COPY required.
 COPY . .
-RUN pnpm install --no-frozen-lockfile
+RUN pnpm install --frozen-lockfile
 
 # Rebuild sqlite3 native module for Alpine
 RUN cd /app/node_modules/.pnpm/sqlite3@*/node_modules/sqlite3 && \

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,81 +1,22 @@
 // .env is loaded via --env-file=.env in the npm script (before any module init)
-// Import Express types for TypeScript
 import 'reflect-metadata';
 import './utils/alias';
 import fs from 'fs';
 import { createServer } from 'http';
 import path from 'path';
-import debug from 'debug';
-import express, { type NextFunction, type Request, type Response } from 'express';
-import swarmRouter from '@src/admin/swarmRoutes';
-import { loadLlmProfiles } from '@src/config/llmProfiles';
-import { loadMemoryProfiles } from '@src/config/memoryProfiles';
-import { loadToolProfiles } from '@src/config/toolProfiles';
+import express from 'express';
 import { container } from '@src/di/container';
-import { registerServices } from '@src/di/registration';
-import { applyRateLimiting } from '@src/middleware/rateLimiter';
-import { SyncProviderRegistry, type ProviderProfile } from '@src/registries/SyncProviderRegistry';
-import { authenticateToken } from '@src/server/middleware/auth';
-import { csrfTokenHandler } from '@src/server/middleware/csrf';
-import { ipWhitelist } from '@src/server/middleware/security';
-import activityRouter from '@src/server/routes/activity';
-import adminApiRouter from '@src/server/routes/admin';
-import agentsRouter from '@src/server/routes/agents';
-import anomalyRouter from '@src/server/routes/anomaly';
-import apiDocsRouter from '@src/server/routes/apiDocs';
-import authRouter from '@src/server/routes/auth';
-import botConfigRouter from '@src/server/routes/botConfig';
-import botsRouter from '@src/server/routes/bots';
-import ciRouter from '@src/server/routes/ci';
-import webuiConfigRouter from '@src/server/routes/config';
-import dashboardRouter from '@src/server/routes/dashboard';
-import demoRouter from '@src/server/routes/demo';
-import enterpriseRouter from '@src/server/routes/enterprise';
-import errorsRouter from '@src/server/routes/errors';
-import guardsRouter from '@src/server/routes/guards';
-import hotReloadRouter from '@src/server/routes/hotReload';
-import importExportRouter from '@src/server/routes/importExport';
-import integrationsRouter from '@src/server/routes/integrations';
-import lettaRouter from '@src/server/routes/letta';
-import marketplaceRouter from '@src/server/routes/marketplace';
-import mcpRouter from '@src/server/routes/mcp';
-import mcpToolsRouter from '@src/server/routes/mcpTools';
-import onboardingRouter from '@src/server/routes/onboarding';
-import openapiRouter from '@src/server/routes/openapi';
-import personasRouter from '@src/server/routes/personas';
-import pluginSecurityRouter from '@src/server/routes/pluginSecurity';
-import secureConfigRouter from '@src/server/routes/secureConfig';
-import sitemapRouter from '@src/server/routes/sitemap';
-import specsRouter from '@src/server/routes/specs';
-import templatesRouter from '@src/server/routes/templates';
-import usageTrackingRouter from '@src/server/routes/usageTracking';
-import validationRouter from '@src/server/routes/validation';
-import webhooksRouter from '@src/server/routes/webhooks';
-import webuiRouter from '@src/server/routes/webui';
 import { RealTimeValidationService } from '@src/server/services/RealTimeValidationService';
 import WebSocketService from '@src/server/services/WebSocketService';
 import { ShutdownCoordinator } from '@src/server/ShutdownCoordinator';
 import AnomalyDetectionService from '@src/services/AnomalyDetectionService';
-import DemoModeService from '@src/services/DemoModeService';
-import StartupGreetingService from '@src/services/StartupGreetingService';
-import { validateRequiredEnvVars } from '@src/utils/envValidation';
-import * as debugEnvVarsModule from '@config/debugEnvVars';
-import * as messageConfigModule from '@config/messageConfig';
-import * as webhookConfigModule from '@config/webhookConfig';
-import { getLlmProvider } from '@llm/getLlmProvider';
-import * as messengerProviderModule from '@message/management/getMessengerProvider';
-import { IdleResponseManager } from '@message/management/IdleResponseManager';
 import Logger from '@common/logger';
-import { initProviders } from './initProviders';
-import { reloadGlobalConfigs } from './server/routes/config';
-import * as healthRouteModule from './server/routes/health';
-import startupDiagnostics from './utils/startupDiagnostics';
+import { setupMiddleware } from './server/setupMiddleware';
+import { registerRoutes } from './server/registerRoutes';
+import { initServices, initWebhooks } from './server/initServices';
 
-const indexLog = debug('app:index');
 const appLogger = Logger.withContext('app:index');
-const httpLogger = Logger.withContext('http');
 const frontendLogger = Logger.withContext('frontend');
-const skipMessengers = process.env.SKIP_MESSENGERS === 'true';
 
 const resolveFrontendDistPath = (): string => {
   const candidates = [
@@ -102,7 +43,7 @@ const frontendAssetsPath = path.join(frontendDistPath, 'assets');
 
 // Vite Dev Server Instance (only used in dev)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Vite dev server type is dynamic
-let viteServer: any;
+const viteServerRef: { current: any } = { current: undefined };
 
 // Check if frontend dist exists (async check will be done in main())
 let frontendDistExists = false;
@@ -115,622 +56,16 @@ const shutdownCoordinator = ShutdownCoordinator.getInstance();
 // them here a second time to avoid duplicate listeners.
 
 const app = express();
-debug('Messenger services are being initialized...');
 
-const healthRoute = (healthRouteModule.default || healthRouteModule) as import('express').Router;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const messageConfig = (messageConfigModule.default || messageConfigModule) as any;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const webhookConfig = (webhookConfigModule.default || webhookConfigModule) as any;
+// ── Middleware ──
+setupMiddleware(app, { frontendDistPath, frontendAssetsPath, viteServerRef });
 
-app.use(express.json());
-app.use(express.urlencoded({ extended: true }));
-
-// Rate limiting middleware
-app.use(applyRateLimiting);
-
-// CORS middleware for localhost development
-app.use((req: Request, res: Response, next: NextFunction) => {
-  const origin = req.headers.origin;
-  const isLocalhost =
-    origin?.includes('localhost') ||
-    origin?.includes('127.0.0.1') ||
-    req.hostname === 'localhost' ||
-    req.hostname === '127.0.0.1';
-
-  if (isLocalhost) {
-    res.setHeader('Access-Control-Allow-Origin', origin || 'http://localhost:3000');
-    res.setHeader('Access-Control-Allow-Credentials', 'true');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS, PATCH');
-    res.setHeader(
-      'Access-Control-Allow-Headers',
-      'Origin, X-Requested-With, Content-Type, Accept, Authorization, Cache-Control, X-CSRF-Token'
-    );
-
-    // Handle preflight requests
-    if (req.method === 'OPTIONS') {
-      res.status(200).end();
-      return;
-    }
-  }
-
-  next();
-});
-
-app.use((req: Request, res: Response, next: NextFunction) => {
-  // Suppress noisy health checks by default, but allow override via SUPPRESS_HEALTH_LOGS
-  const suppressHealthLogs = process.env.SUPPRESS_HEALTH_LOGS !== 'false';
-  if (req.path === '/health' || req.path === '/api/health') {
-    if (!suppressHealthLogs) {
-      httpLogger.debug('Incoming request', { method: req.method, path: req.path });
-    }
-  } else {
-    httpLogger.debug('Incoming request', { method: req.method, path: req.path });
-  }
-
-  // Security headers
-  // SECURITY: See src/server/middleware/security.ts for detailed CSP explanation
-  res.setHeader('X-Content-Type-Options', 'nosniff');
-  const workerSrc =
-    process.env.NODE_ENV === 'development' ? "worker-src 'self' blob:;" : "worker-src 'none';";
-  res.setHeader(
-    'Content-Security-Policy',
-    `default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; connect-src 'self' ws: wss:; font-src 'self' data: https://fonts.gstatic.com; object-src 'none'; frame-ancestors 'none'; ${workerSrc}`
-  );
-
-  next();
-});
-// app.use(healthRoute); // Removed global mount causing root conflict
-
-// Serve dashboard at root
-if (process.env.NODE_ENV !== 'development') {
-  app.get('/', async (req: Request, res: Response) => {
-    const indexPath = path.join(frontendDistPath, 'index.html');
-    appLogger.debug('Handling root request for frontend shell', { frontendDistPath, indexPath });
-
-    try {
-      await fs.promises.access(indexPath);
-      appLogger.debug('Serving frontend index.html');
-      res.sendFile(indexPath, (err) => {
-        if (err) {
-          appLogger.error('Error sending frontend file', { error: err });
-          res.status(500).send('Error serving frontend');
-        } else {
-          appLogger.info('Frontend served successfully');
-        }
-      });
-    } catch {
-      appLogger.error('Frontend index.html not found', { indexPath });
-      res.status(404).send('Frontend not found - please run pnpm run build:frontend');
-    }
-  });
-}
-
-// Serve static files from webui dist directory
-// Serve static files from webui dist directory (Production Only)
-if (process.env.NODE_ENV !== 'development') {
-  app.use(express.static(frontendDistPath));
-  // Global assets static for root-relative asset paths
-  app.use('/assets', express.static(frontendAssetsPath));
-
-  // Uber UI (dashboard)
-  app.use('/uber', express.static(frontendDistPath));
-  app.use('/uber/*', (req: Request, res: Response) => {
-    res.sendFile(path.join(frontendDistPath, 'index.html'));
-  });
-} else {
-  // Development Mode Handlers - Proxy to Vite
-
-  // Config for HTML serving
-  const serveDevHtml = async (req: Request, res: Response) => {
-    try {
-      const url = req.originalUrl;
-      let template = await fs.promises.readFile(
-        path.join(process.cwd(), 'src/client/index.html'),
-        'utf-8'
-      );
-      template = await viteServer.transformIndexHtml(url, template);
-      res
-        .status(200)
-        .set({
-          'Content-Type': 'text/html',
-          'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
-          Pragma: 'no-cache',
-          Expires: '0',
-        })
-        .end(template);
-    } catch (e: unknown) {
-      if (e instanceof Error) {
-        viteServer.ssrFixStacktrace(e);
-      }
-      appLogger.error('Vite SSR Error', e);
-      res.status(500).end(e instanceof Error ? e.message : String(e));
-    }
-  };
-
-  app.get('/', serveDevHtml);
-  app.get('/login', serveDevHtml);
-  app.get('/dashboard', serveDevHtml);
-  app.get('/activity', serveDevHtml);
-  app.get('/uber/*', serveDevHtml);
-  app.get('/admin/*', serveDevHtml);
-  app.get('/webui/*', serveDevHtml);
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// IP Filtering Security (when auth is disabled)
-// Evaluated lazily per-request so --env-file / dotenv values are available
-// ─────────────────────────────────────────────────────────────────────────────
-let ipFilterLogged = false;
-app.use('/api', (req: Request, res: Response, next: NextFunction) => {
-  const allowAll = process.env.HTTP_ALLOW_ALL_IPS === 'true';
-  if (!ipFilterLogged) {
-    ipFilterLogged = true;
-    if (allowAll) {
-      appLogger.warn('⚠️  IP filtering DISABLED (HTTP_ALLOW_ALL_IPS=true)');
-    } else {
-      appLogger.info(
-        '🔒 IP filtering ENABLED for /api/* routes (set HTTP_ALLOW_ALL_IPS=true to disable)'
-      );
-    }
-  }
-  if (allowAll) return next();
-  return ipWhitelist(req, res, next);
-});
-
-// CSRF token endpoint
-app.get('/api/csrf-token', csrfTokenHandler);
-
-// ─────────────────────────────────────────────────────────────────────────────
-// API Route Registration
-// ─────────────────────────────────────────────────────────────────────────────
-// Ordering matters. Express evaluates routers in the order they are mounted.
-// A router mounted at a broader prefix (e.g. '/api') will intercept ALL
-// sub-paths before narrower ones get a chance — if it does not handle the
-// request it must call next(), but relying on that is fragile.
-//
-// Rules:
-//   1. Auth routes first — the CSRF/token endpoint must always be reachable.
-//   2. Protected routes — routes that require authenticateToken middleware.
-//   3. Resource routers — each mounted at its own specific '/api/<resource>'.
-//      These never conflict because they only handle their own sub-paths.
-//   4. Catch-all '/api' router LAST — openapiRouter serves /api/openapi*
-//      and acts as a documentation endpoint. If placed earlier it would
-//      swallow requests meant for routers below it.
-// ─────────────────────────────────────────────────────────────────────────────
-
-// 1. Auth & error handling (no token required)
-app.use('/api/auth', authRouter);
-app.use('/api/errors', errorsRouter);
-
-// 2. Protected routes (authenticateToken required)
-app.use('/api/swarm', authenticateToken, swarmRouter);
-app.use('/api/anomalies', authenticateToken, anomalyRouter);
-app.use('/api/guards', authenticateToken, guardsRouter);
-app.use('/api/specs', authenticateToken, specsRouter);
-app.use('/api/import-export', authenticateToken, importExportRouter);
-
-// 3. Resource routers (specific paths, no catch-all conflict)
-app.use('/api/activity', activityRouter);
-app.use('/api/agents', agentsRouter);
-app.use('/api/dashboard', dashboardRouter);
-app.use('/api/config', webuiConfigRouter);
-app.use('/api/bots', botsRouter);
-app.use('/api/bot-config', botConfigRouter);
-app.use('/api/validation', validationRouter);
-app.use('/api/hot-reload', hotReloadRouter);
-app.use('/api/ci', ciRouter);
-app.use('/api/enterprise', enterpriseRouter);
-app.use('/api/secure-config', secureConfigRouter);
-app.use('/api/admin', adminApiRouter);
-app.use('/api/integrations', integrationsRouter);
-app.use('/api/letta', lettaRouter);
-app.use('/api/marketplace', marketplaceRouter);
-app.use('/api/mcp', mcpRouter);
-app.use('/api/mcp-tools', mcpToolsRouter);
-app.use('/api/onboarding', onboardingRouter);
-app.use('/api/personas', personasRouter);
-app.use('/api/templates', templatesRouter);
-app.use('/api/usage-tracking', usageTrackingRouter);
-app.use('/api/webhooks', webhooksRouter);
-app.use('/api/webui', webuiRouter);
-app.use('/api/demo', demoRouter);
-app.use('/api/docs', apiDocsRouter);
-app.use('/api/pluginSecurity', pluginSecurityRouter);
-
-// 4. Catch-all '/api' router — MUST be last
-//    openapiRouter handles /api/openapi, /api/openapi.json, etc.
-//    If mounted earlier it would intercept ALL /api/* requests.
-app.use('/api', openapiRouter);
-
-// Health endpoints
-app.use('/api/health', healthRoute);
-app.use('/health', healthRoute);
-
-app.use(sitemapRouter); // Sitemap routes at root level
-
-// Legacy route redirects - everything now under /
-app.use('/webui', (req: Request, res: Response) => res.redirect(301, '/' + req.path));
-app.get('/admin*', (req: Request, res: Response) => {
-  res.sendFile(path.join(frontendDistPath, 'index.html'));
-});
-
-// React Router catch-all handler (must be AFTER all API routes)
-// Serve index.html for all non-API, non-asset routes so React Router handles them
-app.get('*', (req: Request, res: Response, next: NextFunction) => {
-  // Skip API routes, static assets, and Vite internal paths
-  if (
-    req.path.startsWith('/api') ||
-    req.path.startsWith('/health') ||
-    req.path.startsWith('/@') || // Vite internals: /@react-refresh, /@vite/client, /@fs/
-    req.path.startsWith('/node_modules') || // Vite serves node_modules in dev
-    req.path.startsWith('/src/') || // Vite serves source files in dev
-    req.path.includes('.') // Static assets with file extensions
-  ) {
-    return next();
-  }
-  if (process.env.NODE_ENV === 'development' && viteServer) {
-    // In dev mode, serve through Vite's HTML transform
-    const url = req.originalUrl;
-    fs.promises
-      .readFile(path.join(process.cwd(), 'src/client/index.html'), 'utf-8')
-      .then((template) => viteServer.transformIndexHtml(url, template))
-      .then((html) => {
-        res.status(200).set({ 'Content-Type': 'text/html' }).end(html);
-      })
-      .catch((e: unknown) => {
-        if (e instanceof Error) viteServer.ssrFixStacktrace(e);
-        next(e);
-      });
-  } else {
-    res.sendFile(path.join(frontendDistPath, 'index.html'));
-  }
-});
-
-// Vite Proxy Middleware for Development (Must be before 404 handler)
-app.use((req: Request, res: Response, next: NextFunction) => {
-  if (process.env.NODE_ENV === 'development' && viteServer) {
-    viteServer.middlewares(req, res, next);
-  } else {
-    next();
-  }
-});
-// Return 404 for all non-existent routes (all HTTP methods)
-app.all('*', (req: Request, res: Response) => {
-  // Skip API routes — these should have been matched by earlier routers
-  if (req.path.startsWith('/api') || req.path.startsWith('/health')) {
-    httpLogger.debug('Unmatched API route', { path: req.path, method: req.method });
-    return res
-      .status(404)
-      .json({ error: 'Endpoint not found', path: req.path, method: req.method });
-  }
-  httpLogger.debug('No matching route for request', { path: req.path });
-  return res.status(404).json({ error: 'Endpoint not found' });
-});
-
-async function startBot(messengerService: any) {
-  const providerType =
-    messengerService.providerName || messengerService.constructor?.name || 'Unknown';
-
-  try {
-    const messageHandlerModule = await import('@message/handlers/messageHandler');
-    debugEnvVarsModule.debugEnvVars();
-    indexLog('[DEBUG] Starting bot initialization...');
-    if (typeof messengerService.setApp === 'function') {
-      messengerService.setApp(app);
-    }
-    await messengerService.initialize();
-    indexLog('[DEBUG] Bot initialization completed.');
-    indexLog('[DEBUG] Setting up message handler...');
-
-    // Initialize idle response manager
-    const idleResponseManager = IdleResponseManager.getInstance();
-    await idleResponseManager.initialize();
-
-    if (process.env.USE_LEGACY_HANDLER !== 'true') {
-      // Pipeline mode: emit onto the MessageBus so the 5-stage pipeline
-      // (Receive → Decision → Enrich → Inference → Send) processes the message.
-      const { MessageBus } = await import('@src/events/MessageBus');
-      const bus = MessageBus.getInstance();
-      messengerService.setMessageHandler(
-        async (message: any, historyMessages: any[], botConfig: any) => {
-          await bus.emitAsync('message:incoming', {
-            message,
-            history: historyMessages,
-            botConfig,
-            botName: String(botConfig.BOT_NAME || botConfig.name || 'hivemind'),
-            platform: message.platform || 'unknown',
-            channelId: message.getChannelId?.() || '',
-            metadata: {},
-          });
-          return ''; // Response is sent by SendStage
-        }
-      );
-    } else {
-      // Legacy mode: call handleMessage() directly
-      messengerService.setMessageHandler((message: any, historyMessages: any[], botConfig: any) =>
-        messageHandlerModule.handleMessage(message, historyMessages, botConfig)
-      );
-    }
-    indexLog('[DEBUG] Message handler set up successfully.');
-
-    // Operator-friendly startup summary (INFO-level).
-    // By default we only log a preview of the system prompt to avoid accidental leakage; set
-    // STARTUP_LOG_SYSTEM_PROMPT=full to print it verbatim.
-    try {
-      const mode = String(process.env.STARTUP_LOG_SYSTEM_PROMPT || 'preview').toLowerCase();
-      const maxPreview = Number(process.env.STARTUP_LOG_SYSTEM_PROMPT_PREVIEW_CHARS || 280);
-      const summaries =
-        typeof messengerService.getAgentStartupSummaries === 'function'
-          ? messengerService.getAgentStartupSummaries()
-          : [];
-
-      const renderPrompt = (p: string | undefined) => {
-        const text = String(p || '').trim();
-        if (!text) {
-          return { systemPromptMode: 'off', systemPromptPreview: '', systemPromptLength: 0 };
-        }
-        if (mode === 'off') {
-          return {
-            systemPromptMode: 'off',
-            systemPromptPreview: '',
-            systemPromptLength: text.length,
-          };
-        }
-        if (mode === 'full') {
-          return { systemPromptMode: 'full', systemPrompt: text, systemPromptLength: text.length };
-        }
-        const preview = text.length > maxPreview ? `${text.slice(0, maxPreview)}…` : text;
-        return {
-          systemPromptMode: 'preview',
-          systemPromptPreview: preview,
-          systemPromptLength: text.length,
-        };
-      };
-
-      for (const s of summaries) {
-        const promptInfo = renderPrompt(s.systemPrompt);
-        appLogger.info('🤖 Bot instance', {
-          name: s.name,
-          provider: s.provider,
-          botId: s.botId,
-          messageProvider: s.messageProvider,
-          llmProvider: s.llmProvider,
-          llmModel: s.llmModel,
-          llmEndpoint: s.llmEndpoint,
-          ...promptInfo,
-        });
-      }
-    } catch (e) {
-      appLogger.warn('Failed to log bot startup summaries', {
-        error: e instanceof Error ? e.message : String(e),
-      });
-    }
-
-    // Log successful provider initialization
-    startupDiagnostics.logProviderInitialized(providerType, {
-      providerName: messengerService.providerName,
-      hasDefaultChannel: !!messengerService.getDefaultChannel?.(),
-      channelCount: messengerService.getChannels?.()?.length || 0,
-    });
-
-    // Send Welcome Message if enabled
-    const enableWelcome = process.env.ENABLE_WELCOME_MESSAGE === 'true';
-    if (enableWelcome) {
-      const defaultChannel = messengerService.getDefaultChannel
-        ? messengerService.getDefaultChannel()
-        : null;
-      if (defaultChannel) {
-        const welcomeText =
-          process.env.WELCOME_MESSAGE_TEXT ||
-          '🤖 System Online: I am now connected and ready to assist.';
-        appLogger.info('Sending welcome message', { channel: defaultChannel, text: welcomeText });
-
-        try {
-          if (messengerService.sendMessageToChannel) {
-            await messengerService.sendMessageToChannel(defaultChannel, welcomeText);
-          } else if (messengerService.sendMessage) {
-            await messengerService.sendMessage(defaultChannel, welcomeText);
-          }
-        } catch (err) {
-          appLogger.warn('Failed to send welcome message', { error: err });
-        }
-      }
-    }
-  } catch (error) {
-    indexLog('[ERROR] Error starting bot service:', error);
-
-    // Log provider initialization failure with diagnostics
-    startupDiagnostics.logProviderInitializationFailed(providerType, error);
-
-    // Log the error but don't exit the process - we want other bots to continue working
-    appLogger.error('Bot initialization failed', { error, providerType });
-  }
-}
+// ── Routes ──
+registerRoutes(app, { frontendDistPath, viteServerRef });
 
 async function main() {
-  registerServices();
-
-  // Initialize database connection
-  try {
-    const { DatabaseManager } = await import('./database/DatabaseManager');
-    const dbManager = DatabaseManager.getInstance();
-    const dbPath = process.env.DATABASE_PATH || 'data/hivemind.db';
-    dbManager.configure({ type: 'sqlite', path: dbPath });
-    await dbManager.connect();
-    appLogger.info('Database connected', { path: dbPath });
-  } catch (error) {
-    appLogger.warn('Database initialization failed (persistence features disabled)', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
-
-  // Validate critical environment variables before proceeding
-  validateRequiredEnvVars();
-
-  // Application startup with enhanced diagnostics
-  appLogger.info('🚀 Starting Open Hivemind Server');
-
-  // Initialize providers (skip in demo/skip mode)
-  if (process.env.SKIP_MESSENGERS !== 'true') {
-    await initProviders();
-  }
-
-  // Initialize SyncProviderRegistry for fast synchronous lookups in the hot path
-  try {
-    const rawMessageProviders = messageConfig.get('MESSAGE_PROVIDER') as unknown;
-    const messengerTypes = (
-      typeof rawMessageProviders === 'string'
-        ? rawMessageProviders.split(',').map((v: string) => v.trim())
-        : Array.isArray(rawMessageProviders)
-          ? rawMessageProviders
-          : []
-    ) as string[];
-
-    const registry = SyncProviderRegistry.getInstance();
-    const initResult = await registry.initialize({
-      llmProfiles: loadLlmProfiles().llm as unknown as ProviderProfile[],
-      memoryProfiles: loadMemoryProfiles().memory as ProviderProfile[],
-      toolProfiles: loadToolProfiles().tool as unknown as ProviderProfile[],
-      messengerPlatforms: messengerTypes,
-    });
-    appLogger.info('Provider registry initialized', initResult.loaded);
-    if (initResult.failed.length > 0) {
-      appLogger.warn('Some providers failed to load in registry', {
-        failed: initResult.failed,
-      });
-    }
-  } catch (err) {
-    appLogger.warn('SyncProviderRegistry initialization failed (falling back to legacy loaders)', {
-      error: err instanceof Error ? err.message : String(err),
-    });
-  }
-
-  // Reload global configs to include provider schemas
-  await reloadGlobalConfigs();
-
-  // Run comprehensive startup diagnostics
-  await startupDiagnostics.logStartupDiagnostics();
-
-  // Initialize Demo Mode Service
-  const demoService = container.resolve(DemoModeService);
-  demoService.initialize();
-
-  if (demoService.isInDemoMode()) {
-    appLogger.info('🎭 Demo Mode ACTIVE - No credentials configured');
-    appLogger.info('🎭 The WebUI will show demo bots and simulated responses');
-    appLogger.info('🎭 Configure API keys/tokens to enable production mode');
-  } else {
-    appLogger.info('✅ Production Mode - Credentials detected');
-  }
-
-  // Initialize the StartupGreetingService
-  const startupGreetingService = container.resolve(StartupGreetingService);
-  await startupGreetingService.initialize();
-
-  // Initialize AnomalyDetectionService
-  AnomalyDetectionService.getInstance();
-  appLogger.info('🔍 Anomaly Detection Service initialized');
-
-  // Prepare messenger services collection for optional webhook registration later
-  let messengerServices: any[] = [];
-
-  // In demo mode, skip messenger initialization if no real providers configured
-  const shouldSkipMessengers = skipMessengers || demoService.isInDemoMode();
-
-  let llmProviders: any[] = [];
-  if (!shouldSkipMessengers) {
-    llmProviders = await getLlmProvider();
-    appLogger.info('🤖 Resolved LLM providers', {
-      providers: llmProviders.map((p) => p.constructor.name || 'Unknown'),
-    });
-  } else {
-    appLogger.info('🤖 LLM provider resolution skipped (demo/skip mode)');
-  }
-
-  if (shouldSkipMessengers) {
-    if (demoService.isInDemoMode()) {
-      appLogger.info('🎭 Skipping messenger initialization - Demo Mode active');
-    } else {
-      appLogger.info('🤖 Skipping messenger initialization due to SKIP_MESSENGERS=true');
-    }
-  } else {
-    appLogger.info('📡 Initializing messenger services');
-    const rawMessageProviders = messageConfig.get('MESSAGE_PROVIDER') as unknown;
-    const messageProviders = (
-      typeof rawMessageProviders === 'string'
-        ? rawMessageProviders.split(',').map((v: string) => v.trim())
-        : Array.isArray(rawMessageProviders)
-          ? rawMessageProviders
-          : ['slack']
-    ) as string[];
-    appLogger.info('📡 Message providers configured', { providers: messageProviders });
-
-    messengerServices = await messengerProviderModule.getMessengerProvider();
-    // Only initialize messenger services that match the configured MESSAGE_PROVIDER(s)
-    const filteredMessengers = messengerServices.filter((service: any) => {
-      // If providerName is not defined, assume 'slack' by default.
-      const providerName = service.providerName || 'slack';
-      return messageProviders.includes(providerName.toLowerCase());
-    });
-
-    // Register messenger services with ShutdownCoordinator
-    for (const service of messengerServices) {
-      shutdownCoordinator.registerMessengerService(service);
-    }
-
-    if (filteredMessengers.length > 0) {
-      appLogger.info('🤖 Starting messenger bots', {
-        services: filteredMessengers.map((s: any) => s.providerName).join(', '),
-      });
-      const startResults = await Promise.allSettled(
-        filteredMessengers.map(async (service) => {
-          await startBot(service);
-          appLogger.info('✅ Bot started', { provider: service.providerName });
-        })
-      );
-      const failures = startResults.filter((r) => r.status === 'rejected');
-      if (failures.length > 0) {
-        appLogger.error(`Failed to start ${failures.length} messenger bot(s)`, { failures });
-      }
-    } else {
-      appLogger.info(
-        '🤖 No specific messenger service configured - starting all available services'
-      );
-      const startResults = await Promise.allSettled(
-        messengerServices.map(async (service) => {
-          await startBot(service);
-          appLogger.info('✅ Bot started', { provider: service.providerName });
-        })
-      );
-      const failures = startResults.filter((r) => r.status === 'rejected');
-      if (failures.length > 0) {
-        appLogger.error(`Failed to start ${failures.length} messenger bot(s)`, { failures });
-      }
-    }
-  }
-
-  // ── 5-stage message pipeline (default, disable via USE_LEGACY_HANDLER=true) ──
-  if (process.env.USE_LEGACY_HANDLER !== 'true') {
-    const { MessageBus } = await import('@src/events/MessageBus');
-    const { createPipeline } = await import('@src/pipeline/createPipeline');
-
-    const bus = MessageBus.getInstance();
-
-    // Create and register a pipeline instance per messenger service.
-    // createPipeline() internally creates a PipelineTracer and stores it
-    // via setActiveTracer() — no need to create a second tracer here.
-    for (const service of messengerServices) {
-      createPipeline(bus, {
-        botConfig: {},
-        messengerService: service,
-        botId: service.botId,
-        defaultChannelId: service.getDefaultChannel?.() ?? undefined,
-      });
-    }
-
-    appLogger.info('🔀 Pipeline mode active (set USE_LEGACY_HANDLER=true to revert)');
-  }
+  // ── Services (DI, DB, providers, messengers, pipeline) ──
+  const { messengerServices } = await initServices(app);
 
   const httpEnabled = process.env.HTTP_ENABLED !== 'false';
   if (httpEnabled) {
@@ -780,7 +115,7 @@ async function main() {
       const viteModule = await new Function('return import("vite")')();
       const createViteServer = viteModule.createServer;
       appLogger.info('⚡ Starting Vite Middleware for Hot Reloading...');
-      viteServer = await createViteServer({
+      viteServerRef.current = await createViteServer({
         server: {
           middlewareMode: true,
           hmr: { server }, // Pass the http server to Vite for HMR
@@ -791,13 +126,13 @@ async function main() {
       });
 
       // Register Vite server with ShutdownCoordinator
-      shutdownCoordinator.registerViteServer(viteServer);
+      shutdownCoordinator.registerViteServer(viteServerRef.current);
 
       appLogger.info('⚡ Vite Middleware Active');
     }
 
     if (process.env.NODE_ENV === 'development' && !enableViteDev) {
-      app.get('/', (req: Request, res: Response) => {
+      app.get('/', (req: express.Request, res: express.Response) => {
         res
           .status(200)
           .set({ 'Content-Type': 'text/html' })
@@ -854,25 +189,8 @@ async function main() {
     appLogger.info('🔌 HTTP server is disabled via configuration');
   }
 
-  const isWebhookEnabled = webhookConfig.get('WEBHOOK_ENABLED') || false;
-  if (isWebhookEnabled) {
-    const webhookServiceModule = await import('@webhook/webhookService');
-    appLogger.info('🪝 Webhook service enabled - registering routes');
-    for (const messengerService of messengerServices) {
-      const channelId = messengerService.getDefaultChannel
-        ? messengerService.getDefaultChannel()
-        : null;
-      if (channelId) {
-        await webhookServiceModule.webhookService.start(app, messengerService, channelId);
-        appLogger.info('✅ Webhook route registered', {
-          provider: messengerService.providerName,
-          channelId,
-        });
-      }
-    }
-  } else {
-    appLogger.info('🪝 Webhook service is disabled');
-  }
+  // ── Webhooks ──
+  await initWebhooks(app, messengerServices);
 
   // Print legend for decision logs
   const { default: StartupLegendService } = await import('./services/StartupLegendService');

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,9 +11,9 @@ import WebSocketService from '@src/server/services/WebSocketService';
 import { ShutdownCoordinator } from '@src/server/ShutdownCoordinator';
 import AnomalyDetectionService from '@src/services/AnomalyDetectionService';
 import Logger from '@common/logger';
-import { setupMiddleware } from './server/setupMiddleware';
-import { registerRoutes } from './server/registerRoutes';
 import { initServices, initWebhooks } from './server/initServices';
+import { registerRoutes } from './server/registerRoutes';
+import { setupMiddleware } from './server/setupMiddleware';
 
 const appLogger = Logger.withContext('app:index');
 const frontendLogger = Logger.withContext('frontend');

--- a/src/server/initServices.ts
+++ b/src/server/initServices.ts
@@ -1,0 +1,404 @@
+/**
+ * Service initialization logic.
+ *
+ * Extracted from src/index.ts — handles database connection, provider init,
+ * messenger service startup, LLM provider resolution, pipeline creation,
+ * demo mode, anomaly detection, and webhook registration.
+ */
+import debug from 'debug';
+import { container } from '@src/di/container';
+import { registerServices } from '@src/di/registration';
+import { loadLlmProfiles } from '@src/config/llmProfiles';
+import { loadMemoryProfiles } from '@src/config/memoryProfiles';
+import { loadToolProfiles } from '@src/config/toolProfiles';
+import { SyncProviderRegistry, type ProviderProfile } from '@src/registries/SyncProviderRegistry';
+import AnomalyDetectionService from '@src/services/AnomalyDetectionService';
+import DemoModeService from '@src/services/DemoModeService';
+import StartupGreetingService from '@src/services/StartupGreetingService';
+import { validateRequiredEnvVars } from '@src/utils/envValidation';
+import * as debugEnvVarsModule from '@config/debugEnvVars';
+import * as messageConfigModule from '@config/messageConfig';
+import * as webhookConfigModule from '@config/webhookConfig';
+import { getLlmProvider } from '@llm/getLlmProvider';
+import * as messengerProviderModule from '@message/management/getMessengerProvider';
+import { IdleResponseManager } from '@message/management/IdleResponseManager';
+import Logger from '@common/logger';
+import { initProviders } from '../initProviders';
+import { reloadGlobalConfigs } from './routes/config';
+import startupDiagnostics from '../utils/startupDiagnostics';
+import { ShutdownCoordinator } from '@src/server/ShutdownCoordinator';
+
+const indexLog = debug('app:index');
+const appLogger = Logger.withContext('app:index');
+const skipMessengers = process.env.SKIP_MESSENGERS === 'true';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const messageConfig = (messageConfigModule.default || messageConfigModule) as any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const webhookConfig = (webhookConfigModule.default || webhookConfigModule) as any;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function startBot(app: import('express').Application, messengerService: any) {
+  const providerType =
+    messengerService.providerName || messengerService.constructor?.name || 'Unknown';
+
+  try {
+    const messageHandlerModule = await import('@message/handlers/messageHandler');
+    debugEnvVarsModule.debugEnvVars();
+    indexLog('[DEBUG] Starting bot initialization...');
+    if (typeof messengerService.setApp === 'function') {
+      messengerService.setApp(app);
+    }
+    await messengerService.initialize();
+    indexLog('[DEBUG] Bot initialization completed.');
+    indexLog('[DEBUG] Setting up message handler...');
+
+    // Initialize idle response manager
+    const idleResponseManager = IdleResponseManager.getInstance();
+    await idleResponseManager.initialize();
+
+    if (process.env.USE_LEGACY_HANDLER !== 'true') {
+      // Pipeline mode: emit onto the MessageBus so the 5-stage pipeline
+      // (Receive -> Decision -> Enrich -> Inference -> Send) processes the message.
+      const { MessageBus } = await import('@src/events/MessageBus');
+      const bus = MessageBus.getInstance();
+      messengerService.setMessageHandler(
+        async (message: any, historyMessages: any[], botConfig: any) => {
+          await bus.emitAsync('message:incoming', {
+            message,
+            history: historyMessages,
+            botConfig,
+            botName: String(botConfig.BOT_NAME || botConfig.name || 'hivemind'),
+            platform: message.platform || 'unknown',
+            channelId: message.getChannelId?.() || '',
+            metadata: {},
+          });
+          return ''; // Response is sent by SendStage
+        }
+      );
+    } else {
+      // Legacy mode: call handleMessage() directly
+      messengerService.setMessageHandler((message: any, historyMessages: any[], botConfig: any) =>
+        messageHandlerModule.handleMessage(message, historyMessages, botConfig)
+      );
+    }
+    indexLog('[DEBUG] Message handler set up successfully.');
+
+    // Operator-friendly startup summary (INFO-level).
+    // By default we only log a preview of the system prompt to avoid accidental leakage; set
+    // STARTUP_LOG_SYSTEM_PROMPT=full to print it verbatim.
+    try {
+      const mode = String(process.env.STARTUP_LOG_SYSTEM_PROMPT || 'preview').toLowerCase();
+      const maxPreview = Number(process.env.STARTUP_LOG_SYSTEM_PROMPT_PREVIEW_CHARS || 280);
+      const summaries =
+        typeof messengerService.getAgentStartupSummaries === 'function'
+          ? messengerService.getAgentStartupSummaries()
+          : [];
+
+      const renderPrompt = (p: string | undefined) => {
+        const text = String(p || '').trim();
+        if (!text) {
+          return { systemPromptMode: 'off', systemPromptPreview: '', systemPromptLength: 0 };
+        }
+        if (mode === 'off') {
+          return {
+            systemPromptMode: 'off',
+            systemPromptPreview: '',
+            systemPromptLength: text.length,
+          };
+        }
+        if (mode === 'full') {
+          return { systemPromptMode: 'full', systemPrompt: text, systemPromptLength: text.length };
+        }
+        const preview = text.length > maxPreview ? `${text.slice(0, maxPreview)}\u2026` : text;
+        return {
+          systemPromptMode: 'preview',
+          systemPromptPreview: preview,
+          systemPromptLength: text.length,
+        };
+      };
+
+      for (const s of summaries) {
+        const promptInfo = renderPrompt(s.systemPrompt);
+        appLogger.info('\ud83e\udd16 Bot instance', {
+          name: s.name,
+          provider: s.provider,
+          botId: s.botId,
+          messageProvider: s.messageProvider,
+          llmProvider: s.llmProvider,
+          llmModel: s.llmModel,
+          llmEndpoint: s.llmEndpoint,
+          ...promptInfo,
+        });
+      }
+    } catch (e) {
+      appLogger.warn('Failed to log bot startup summaries', {
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+
+    // Log successful provider initialization
+    startupDiagnostics.logProviderInitialized(providerType, {
+      providerName: messengerService.providerName,
+      hasDefaultChannel: !!messengerService.getDefaultChannel?.(),
+      channelCount: messengerService.getChannels?.()?.length || 0,
+    });
+
+    // Send Welcome Message if enabled
+    const enableWelcome = process.env.ENABLE_WELCOME_MESSAGE === 'true';
+    if (enableWelcome) {
+      const defaultChannel = messengerService.getDefaultChannel
+        ? messengerService.getDefaultChannel()
+        : null;
+      if (defaultChannel) {
+        const welcomeText =
+          process.env.WELCOME_MESSAGE_TEXT ||
+          '\ud83e\udd16 System Online: I am now connected and ready to assist.';
+        appLogger.info('Sending welcome message', { channel: defaultChannel, text: welcomeText });
+
+        try {
+          if (messengerService.sendMessageToChannel) {
+            await messengerService.sendMessageToChannel(defaultChannel, welcomeText);
+          } else if (messengerService.sendMessage) {
+            await messengerService.sendMessage(defaultChannel, welcomeText);
+          }
+        } catch (err) {
+          appLogger.warn('Failed to send welcome message', { error: err });
+        }
+      }
+    }
+  } catch (error) {
+    indexLog('[ERROR] Error starting bot service:', error);
+
+    // Log provider initialization failure with diagnostics
+    startupDiagnostics.logProviderInitializationFailed(providerType, error);
+
+    // Log the error but don't exit the process - we want other bots to continue working
+    appLogger.error('Bot initialization failed', { error, providerType });
+  }
+}
+
+export interface InitServicesResult {
+  messengerServices: any[];
+}
+
+/**
+ * Initialize all backend services: DI, database, providers, messengers, pipeline, etc.
+ * Returns the messenger services array so the caller can pass it to HTTP/webhook setup.
+ */
+export async function initServices(app: import('express').Application): Promise<InitServicesResult> {
+  const shutdownCoordinator = ShutdownCoordinator.getInstance();
+
+  registerServices();
+
+  // Initialize database connection
+  try {
+    const { DatabaseManager } = await import('../database/DatabaseManager');
+    const dbManager = DatabaseManager.getInstance();
+    const dbPath = process.env.DATABASE_PATH || 'data/hivemind.db';
+    dbManager.configure({ type: 'sqlite', path: dbPath });
+    await dbManager.connect();
+    appLogger.info('Database connected', { path: dbPath });
+  } catch (error) {
+    appLogger.warn('Database initialization failed (persistence features disabled)', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  // Validate critical environment variables before proceeding
+  validateRequiredEnvVars();
+
+  // Application startup with enhanced diagnostics
+  appLogger.info('\ud83d\ude80 Starting Open Hivemind Server');
+
+  // Initialize providers (skip in demo/skip mode)
+  if (process.env.SKIP_MESSENGERS !== 'true') {
+    await initProviders();
+  }
+
+  // Initialize SyncProviderRegistry for fast synchronous lookups in the hot path
+  try {
+    const rawMessageProviders = messageConfig.get('MESSAGE_PROVIDER') as unknown;
+    const messengerTypes = (
+      typeof rawMessageProviders === 'string'
+        ? rawMessageProviders.split(',').map((v: string) => v.trim())
+        : Array.isArray(rawMessageProviders)
+          ? rawMessageProviders
+          : []
+    ) as string[];
+
+    const registry = SyncProviderRegistry.getInstance();
+    const initResult = await registry.initialize({
+      llmProfiles: loadLlmProfiles().llm as unknown as ProviderProfile[],
+      memoryProfiles: loadMemoryProfiles().memory as ProviderProfile[],
+      toolProfiles: loadToolProfiles().tool as unknown as ProviderProfile[],
+      messengerPlatforms: messengerTypes,
+    });
+    appLogger.info('Provider registry initialized', initResult.loaded);
+    if (initResult.failed.length > 0) {
+      appLogger.warn('Some providers failed to load in registry', {
+        failed: initResult.failed,
+      });
+    }
+  } catch (err) {
+    appLogger.warn('SyncProviderRegistry initialization failed (falling back to legacy loaders)', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  // Reload global configs to include provider schemas
+  await reloadGlobalConfigs();
+
+  // Run comprehensive startup diagnostics
+  await startupDiagnostics.logStartupDiagnostics();
+
+  // Initialize Demo Mode Service
+  const demoService = container.resolve(DemoModeService);
+  demoService.initialize();
+
+  if (demoService.isInDemoMode()) {
+    appLogger.info('\ud83c\udfad Demo Mode ACTIVE - No credentials configured');
+    appLogger.info('\ud83c\udfad The WebUI will show demo bots and simulated responses');
+    appLogger.info('\ud83c\udfad Configure API keys/tokens to enable production mode');
+  } else {
+    appLogger.info('\u2705 Production Mode - Credentials detected');
+  }
+
+  // Initialize the StartupGreetingService
+  const startupGreetingService = container.resolve(StartupGreetingService);
+  await startupGreetingService.initialize();
+
+  // Initialize AnomalyDetectionService
+  AnomalyDetectionService.getInstance();
+  appLogger.info('\ud83d\udd0d Anomaly Detection Service initialized');
+
+  // Prepare messenger services collection for optional webhook registration later
+  let messengerServices: any[] = [];
+
+  // In demo mode, skip messenger initialization if no real providers configured
+  const shouldSkipMessengers = skipMessengers || demoService.isInDemoMode();
+
+  let llmProviders: any[] = [];
+  if (!shouldSkipMessengers) {
+    llmProviders = await getLlmProvider();
+    appLogger.info('\ud83e\udd16 Resolved LLM providers', {
+      providers: llmProviders.map((p) => p.constructor.name || 'Unknown'),
+    });
+  } else {
+    appLogger.info('\ud83e\udd16 LLM provider resolution skipped (demo/skip mode)');
+  }
+
+  if (shouldSkipMessengers) {
+    if (demoService.isInDemoMode()) {
+      appLogger.info('\ud83c\udfad Skipping messenger initialization - Demo Mode active');
+    } else {
+      appLogger.info('\ud83e\udd16 Skipping messenger initialization due to SKIP_MESSENGERS=true');
+    }
+  } else {
+    appLogger.info('\ud83d\udce1 Initializing messenger services');
+    const rawMessageProviders = messageConfig.get('MESSAGE_PROVIDER') as unknown;
+    const messageProviders = (
+      typeof rawMessageProviders === 'string'
+        ? rawMessageProviders.split(',').map((v: string) => v.trim())
+        : Array.isArray(rawMessageProviders)
+          ? rawMessageProviders
+          : ['slack']
+    ) as string[];
+    appLogger.info('\ud83d\udce1 Message providers configured', { providers: messageProviders });
+
+    messengerServices = await messengerProviderModule.getMessengerProvider();
+    // Only initialize messenger services that match the configured MESSAGE_PROVIDER(s)
+    const filteredMessengers = messengerServices.filter((service: any) => {
+      // If providerName is not defined, assume 'slack' by default.
+      const providerName = service.providerName || 'slack';
+      return messageProviders.includes(providerName.toLowerCase());
+    });
+
+    // Register messenger services with ShutdownCoordinator
+    for (const service of messengerServices) {
+      shutdownCoordinator.registerMessengerService(service);
+    }
+
+    if (filteredMessengers.length > 0) {
+      appLogger.info('\ud83e\udd16 Starting messenger bots', {
+        services: filteredMessengers.map((s: any) => s.providerName).join(', '),
+      });
+      const startResults = await Promise.allSettled(
+        filteredMessengers.map(async (service) => {
+          await startBot(app, service);
+          appLogger.info('\u2705 Bot started', { provider: service.providerName });
+        })
+      );
+      const failures = startResults.filter((r) => r.status === 'rejected');
+      if (failures.length > 0) {
+        appLogger.error(`Failed to start ${failures.length} messenger bot(s)`, { failures });
+      }
+    } else {
+      appLogger.info(
+        '\ud83e\udd16 No specific messenger service configured - starting all available services'
+      );
+      const startResults = await Promise.allSettled(
+        messengerServices.map(async (service) => {
+          await startBot(app, service);
+          appLogger.info('\u2705 Bot started', { provider: service.providerName });
+        })
+      );
+      const failures = startResults.filter((r) => r.status === 'rejected');
+      if (failures.length > 0) {
+        appLogger.error(`Failed to start ${failures.length} messenger bot(s)`, { failures });
+      }
+    }
+  }
+
+  // ── 5-stage message pipeline (default, disable via USE_LEGACY_HANDLER=true) ──
+  if (process.env.USE_LEGACY_HANDLER !== 'true') {
+    const { MessageBus } = await import('@src/events/MessageBus');
+    const { createPipeline } = await import('@src/pipeline/createPipeline');
+
+    const bus = MessageBus.getInstance();
+
+    // Create and register a pipeline instance per messenger service.
+    // createPipeline() internally creates a PipelineTracer and stores it
+    // via setActiveTracer() — no need to create a second tracer here.
+    for (const service of messengerServices) {
+      createPipeline(bus, {
+        botConfig: {},
+        messengerService: service,
+        botId: service.botId,
+        defaultChannelId: service.getDefaultChannel?.() ?? undefined,
+      });
+    }
+
+    appLogger.info('\ud83d\udd00 Pipeline mode active (set USE_LEGACY_HANDLER=true to revert)');
+  }
+
+  return { messengerServices };
+}
+
+/**
+ * Register webhook routes if WEBHOOK_ENABLED is set.
+ */
+export async function initWebhooks(
+  app: import('express').Application,
+  messengerServices: any[]
+): Promise<void> {
+  const isWebhookEnabled = webhookConfig.get('WEBHOOK_ENABLED') || false;
+  if (isWebhookEnabled) {
+    const webhookServiceModule = await import('@webhook/webhookService');
+    appLogger.info('\ud83e\ude9d Webhook service enabled - registering routes');
+    for (const messengerService of messengerServices) {
+      const channelId = messengerService.getDefaultChannel
+        ? messengerService.getDefaultChannel()
+        : null;
+      if (channelId) {
+        await webhookServiceModule.webhookService.start(app, messengerService, channelId);
+        appLogger.info('\u2705 Webhook route registered', {
+          provider: messengerService.providerName,
+          channelId,
+        });
+      }
+    }
+  } else {
+    appLogger.info('\ud83e\ude9d Webhook service is disabled');
+  }
+}

--- a/src/server/initServices.ts
+++ b/src/server/initServices.ts
@@ -6,12 +6,13 @@
  * demo mode, anomaly detection, and webhook registration.
  */
 import debug from 'debug';
-import { container } from '@src/di/container';
-import { registerServices } from '@src/di/registration';
 import { loadLlmProfiles } from '@src/config/llmProfiles';
 import { loadMemoryProfiles } from '@src/config/memoryProfiles';
 import { loadToolProfiles } from '@src/config/toolProfiles';
+import { container } from '@src/di/container';
+import { registerServices } from '@src/di/registration';
 import { SyncProviderRegistry, type ProviderProfile } from '@src/registries/SyncProviderRegistry';
+import { ShutdownCoordinator } from '@src/server/ShutdownCoordinator';
 import AnomalyDetectionService from '@src/services/AnomalyDetectionService';
 import DemoModeService from '@src/services/DemoModeService';
 import StartupGreetingService from '@src/services/StartupGreetingService';
@@ -24,9 +25,8 @@ import * as messengerProviderModule from '@message/management/getMessengerProvid
 import { IdleResponseManager } from '@message/management/IdleResponseManager';
 import Logger from '@common/logger';
 import { initProviders } from '../initProviders';
-import { reloadGlobalConfigs } from './routes/config';
 import startupDiagnostics from '../utils/startupDiagnostics';
-import { ShutdownCoordinator } from '@src/server/ShutdownCoordinator';
+import { reloadGlobalConfigs } from './routes/config';
 
 const indexLog = debug('app:index');
 const appLogger = Logger.withContext('app:index');
@@ -186,7 +186,9 @@ export interface InitServicesResult {
  * Initialize all backend services: DI, database, providers, messengers, pipeline, etc.
  * Returns the messenger services array so the caller can pass it to HTTP/webhook setup.
  */
-export async function initServices(app: import('express').Application): Promise<InitServicesResult> {
+export async function initServices(
+  app: import('express').Application
+): Promise<InitServicesResult> {
   const shutdownCoordinator = ShutdownCoordinator.getInstance();
 
   registerServices();

--- a/src/server/registerRoutes.ts
+++ b/src/server/registerRoutes.ts
@@ -1,0 +1,216 @@
+/**
+ * Express route registration.
+ *
+ * Extracted from src/index.ts — mounts all API routers, health endpoints,
+ * IP filtering, CSRF, catch-all handlers, and the 404 fallback.
+ */
+import fs from 'fs';
+import path from 'path';
+import { type NextFunction, type Request, type Response } from 'express';
+import swarmRouter from '@src/admin/swarmRoutes';
+import { authenticateToken } from '@src/server/middleware/auth';
+import { csrfTokenHandler } from '@src/server/middleware/csrf';
+import { ipWhitelist } from '@src/server/middleware/security';
+import activityRouter from '@src/server/routes/activity';
+import adminApiRouter from '@src/server/routes/admin';
+import agentsRouter from '@src/server/routes/agents';
+import anomalyRouter from '@src/server/routes/anomaly';
+import apiDocsRouter from '@src/server/routes/apiDocs';
+import authRouter from '@src/server/routes/auth';
+import botConfigRouter from '@src/server/routes/botConfig';
+import botsRouter from '@src/server/routes/bots';
+import ciRouter from '@src/server/routes/ci';
+import webuiConfigRouter from '@src/server/routes/config';
+import dashboardRouter from '@src/server/routes/dashboard';
+import demoRouter from '@src/server/routes/demo';
+import enterpriseRouter from '@src/server/routes/enterprise';
+import errorsRouter from '@src/server/routes/errors';
+import guardsRouter from '@src/server/routes/guards';
+import hotReloadRouter from '@src/server/routes/hotReload';
+import importExportRouter from '@src/server/routes/importExport';
+import integrationsRouter from '@src/server/routes/integrations';
+import lettaRouter from '@src/server/routes/letta';
+import marketplaceRouter from '@src/server/routes/marketplace';
+import mcpRouter from '@src/server/routes/mcp';
+import mcpToolsRouter from '@src/server/routes/mcpTools';
+import onboardingRouter from '@src/server/routes/onboarding';
+import openapiRouter from '@src/server/routes/openapi';
+import personasRouter from '@src/server/routes/personas';
+import pluginSecurityRouter from '@src/server/routes/pluginSecurity';
+import secureConfigRouter from '@src/server/routes/secureConfig';
+import sitemapRouter from '@src/server/routes/sitemap';
+import specsRouter from '@src/server/routes/specs';
+import templatesRouter from '@src/server/routes/templates';
+import usageTrackingRouter from '@src/server/routes/usageTracking';
+import validationRouter from '@src/server/routes/validation';
+import webhooksRouter from '@src/server/routes/webhooks';
+import webuiRouter from '@src/server/routes/webui';
+import * as healthRouteModule from './routes/health';
+import Logger from '@common/logger';
+
+const appLogger = Logger.withContext('app:index');
+const httpLogger = Logger.withContext('http');
+
+const healthRoute = (healthRouteModule.default || healthRouteModule) as import('express').Router;
+
+export interface RouteContext {
+  frontendDistPath: string;
+  /** Mutable ref so Vite dev server can be assigned later and used by route handlers. */
+  viteServerRef: { current: any };
+}
+
+export function registerRoutes(app: import('express').Application, ctx: RouteContext): void {
+  const { frontendDistPath, viteServerRef } = ctx;
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // IP Filtering Security (when auth is disabled)
+  // Evaluated lazily per-request so --env-file / dotenv values are available
+  // ─────────────────────────────────────────────────────────────────────────────
+  let ipFilterLogged = false;
+  app.use('/api', (req: Request, res: Response, next: NextFunction) => {
+    const allowAll = process.env.HTTP_ALLOW_ALL_IPS === 'true';
+    if (!ipFilterLogged) {
+      ipFilterLogged = true;
+      if (allowAll) {
+        appLogger.warn('\u26a0\ufe0f  IP filtering DISABLED (HTTP_ALLOW_ALL_IPS=true)');
+      } else {
+        appLogger.info(
+          '\ud83d\udd12 IP filtering ENABLED for /api/* routes (set HTTP_ALLOW_ALL_IPS=true to disable)'
+        );
+      }
+    }
+    if (allowAll) return next();
+    return ipWhitelist(req, res, next);
+  });
+
+  // CSRF token endpoint
+  app.get('/api/csrf-token', csrfTokenHandler);
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // API Route Registration
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Ordering matters. Express evaluates routers in the order they are mounted.
+  // A router mounted at a broader prefix (e.g. '/api') will intercept ALL
+  // sub-paths before narrower ones get a chance — if it does not handle the
+  // request it must call next(), but relying on that is fragile.
+  //
+  // Rules:
+  //   1. Auth routes first — the CSRF/token endpoint must always be reachable.
+  //   2. Protected routes — routes that require authenticateToken middleware.
+  //   3. Resource routers — each mounted at its own specific '/api/<resource>'.
+  //      These never conflict because they only handle their own sub-paths.
+  //   4. Catch-all '/api' router LAST — openapiRouter serves /api/openapi*
+  //      and acts as a documentation endpoint. If placed earlier it would
+  //      swallow requests meant for routers below it.
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  // 1. Auth & error handling (no token required)
+  app.use('/api/auth', authRouter);
+  app.use('/api/errors', errorsRouter);
+
+  // 2. Protected routes (authenticateToken required)
+  app.use('/api/swarm', authenticateToken, swarmRouter);
+  app.use('/api/anomalies', authenticateToken, anomalyRouter);
+  app.use('/api/guards', authenticateToken, guardsRouter);
+  app.use('/api/specs', authenticateToken, specsRouter);
+  app.use('/api/import-export', authenticateToken, importExportRouter);
+
+  // 3. Resource routers (specific paths, no catch-all conflict)
+  app.use('/api/activity', activityRouter);
+  app.use('/api/agents', agentsRouter);
+  app.use('/api/dashboard', dashboardRouter);
+  app.use('/api/config', webuiConfigRouter);
+  app.use('/api/bots', botsRouter);
+  app.use('/api/bot-config', botConfigRouter);
+  app.use('/api/validation', validationRouter);
+  app.use('/api/hot-reload', hotReloadRouter);
+  app.use('/api/ci', ciRouter);
+  app.use('/api/enterprise', enterpriseRouter);
+  app.use('/api/secure-config', secureConfigRouter);
+  app.use('/api/admin', adminApiRouter);
+  app.use('/api/integrations', integrationsRouter);
+  app.use('/api/letta', lettaRouter);
+  app.use('/api/marketplace', marketplaceRouter);
+  app.use('/api/mcp', mcpRouter);
+  app.use('/api/mcp-tools', mcpToolsRouter);
+  app.use('/api/onboarding', onboardingRouter);
+  app.use('/api/personas', personasRouter);
+  app.use('/api/templates', templatesRouter);
+  app.use('/api/usage-tracking', usageTrackingRouter);
+  app.use('/api/webhooks', webhooksRouter);
+  app.use('/api/webui', webuiRouter);
+  app.use('/api/demo', demoRouter);
+  app.use('/api/docs', apiDocsRouter);
+  app.use('/api/pluginSecurity', pluginSecurityRouter);
+
+  // 4. Catch-all '/api' router — MUST be last
+  //    openapiRouter handles /api/openapi, /api/openapi.json, etc.
+  //    If mounted earlier it would intercept ALL /api/* requests.
+  app.use('/api', openapiRouter);
+
+  // Health endpoints
+  app.use('/api/health', healthRoute);
+  app.use('/health', healthRoute);
+
+  app.use(sitemapRouter); // Sitemap routes at root level
+
+  // Legacy route redirects - everything now under /
+  app.use('/webui', (req: Request, res: Response) => res.redirect(301, '/' + req.path));
+  app.get('/admin*', (req: Request, res: Response) => {
+    res.sendFile(path.join(frontendDistPath, 'index.html'));
+  });
+
+  // React Router catch-all handler (must be AFTER all API routes)
+  // Serve index.html for all non-API, non-asset routes so React Router handles them
+  app.get('*', (req: Request, res: Response, next: NextFunction) => {
+    // Skip API routes, static assets, and Vite internal paths
+    if (
+      req.path.startsWith('/api') ||
+      req.path.startsWith('/health') ||
+      req.path.startsWith('/@') || // Vite internals: /@react-refresh, /@vite/client, /@fs/
+      req.path.startsWith('/node_modules') || // Vite serves node_modules in dev
+      req.path.startsWith('/src/') || // Vite serves source files in dev
+      req.path.includes('.') // Static assets with file extensions
+    ) {
+      return next();
+    }
+    if (process.env.NODE_ENV === 'development' && viteServerRef.current) {
+      // In dev mode, serve through Vite's HTML transform
+      const url = req.originalUrl;
+      fs.promises
+        .readFile(path.join(process.cwd(), 'src/client/index.html'), 'utf-8')
+        .then((template) => viteServerRef.current.transformIndexHtml(url, template))
+        .then((html) => {
+          res.status(200).set({ 'Content-Type': 'text/html' }).end(html);
+        })
+        .catch((e: unknown) => {
+          if (e instanceof Error) viteServerRef.current.ssrFixStacktrace(e);
+          next(e);
+        });
+    } else {
+      res.sendFile(path.join(frontendDistPath, 'index.html'));
+    }
+  });
+
+  // Vite Proxy Middleware for Development (Must be before 404 handler)
+  app.use((req: Request, res: Response, next: NextFunction) => {
+    if (process.env.NODE_ENV === 'development' && viteServerRef.current) {
+      viteServerRef.current.middlewares(req, res, next);
+    } else {
+      next();
+    }
+  });
+
+  // Return 404 for all non-existent routes (all HTTP methods)
+  app.all('*', (req: Request, res: Response) => {
+    // Skip API routes — these should have been matched by earlier routers
+    if (req.path.startsWith('/api') || req.path.startsWith('/health')) {
+      httpLogger.debug('Unmatched API route', { path: req.path, method: req.method });
+      return res
+        .status(404)
+        .json({ error: 'Endpoint not found', path: req.path, method: req.method });
+    }
+    httpLogger.debug('No matching route for request', { path: req.path });
+    return res.status(404).json({ error: 'Endpoint not found' });
+  });
+}

--- a/src/server/registerRoutes.ts
+++ b/src/server/registerRoutes.ts
@@ -45,8 +45,8 @@ import usageTrackingRouter from '@src/server/routes/usageTracking';
 import validationRouter from '@src/server/routes/validation';
 import webhooksRouter from '@src/server/routes/webhooks';
 import webuiRouter from '@src/server/routes/webui';
-import * as healthRouteModule from './routes/health';
 import Logger from '@common/logger';
+import * as healthRouteModule from './routes/health';
 
 const appLogger = Logger.withContext('app:index');
 const httpLogger = Logger.withContext('http');

--- a/src/server/setupMiddleware.ts
+++ b/src/server/setupMiddleware.ts
@@ -1,0 +1,157 @@
+/**
+ * Express middleware configuration.
+ *
+ * Extracted from src/index.ts — configures body parsing, rate limiting, CORS,
+ * request logging, security headers, and static file / Vite dev serving.
+ */
+import fs from 'fs';
+import path from 'path';
+import express, { type NextFunction, type Request, type Response } from 'express';
+import { applyRateLimiting } from '@src/middleware/rateLimiter';
+import Logger from '@common/logger';
+
+const appLogger = Logger.withContext('app:index');
+const httpLogger = Logger.withContext('http');
+
+export interface MiddlewareContext {
+  frontendDistPath: string;
+  frontendAssetsPath: string;
+  /** Mutable ref so Vite dev server can be assigned later and used by middleware. */
+  viteServerRef: { current: any };
+}
+
+export function setupMiddleware(app: express.Application, ctx: MiddlewareContext): void {
+  const { frontendDistPath, frontendAssetsPath, viteServerRef } = ctx;
+
+  // Body parsing
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: true }));
+
+  // Rate limiting middleware
+  app.use(applyRateLimiting);
+
+  // CORS middleware for localhost development
+  app.use((req: Request, res: Response, next: NextFunction) => {
+    const origin = req.headers.origin;
+    const isLocalhost =
+      origin?.includes('localhost') ||
+      origin?.includes('127.0.0.1') ||
+      req.hostname === 'localhost' ||
+      req.hostname === '127.0.0.1';
+
+    if (isLocalhost) {
+      res.setHeader('Access-Control-Allow-Origin', origin || 'http://localhost:3000');
+      res.setHeader('Access-Control-Allow-Credentials', 'true');
+      res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS, PATCH');
+      res.setHeader(
+        'Access-Control-Allow-Headers',
+        'Origin, X-Requested-With, Content-Type, Accept, Authorization, Cache-Control, X-CSRF-Token'
+      );
+
+      // Handle preflight requests
+      if (req.method === 'OPTIONS') {
+        res.status(200).end();
+        return;
+      }
+    }
+
+    next();
+  });
+
+  // Request logging & security headers
+  app.use((req: Request, res: Response, next: NextFunction) => {
+    // Suppress noisy health checks by default, but allow override via SUPPRESS_HEALTH_LOGS
+    const suppressHealthLogs = process.env.SUPPRESS_HEALTH_LOGS !== 'false';
+    if (req.path === '/health' || req.path === '/api/health') {
+      if (!suppressHealthLogs) {
+        httpLogger.debug('Incoming request', { method: req.method, path: req.path });
+      }
+    } else {
+      httpLogger.debug('Incoming request', { method: req.method, path: req.path });
+    }
+
+    // Security headers
+    // SECURITY: See src/server/middleware/security.ts for detailed CSP explanation
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    const workerSrc =
+      process.env.NODE_ENV === 'development' ? "worker-src 'self' blob:;" : "worker-src 'none';";
+    res.setHeader(
+      'Content-Security-Policy',
+      `default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; connect-src 'self' ws: wss:; font-src 'self' data: https://fonts.gstatic.com; object-src 'none'; frame-ancestors 'none'; ${workerSrc}`
+    );
+
+    next();
+  });
+
+  // Serve dashboard at root
+  if (process.env.NODE_ENV !== 'development') {
+    app.get('/', async (req: Request, res: Response) => {
+      const indexPath = path.join(frontendDistPath, 'index.html');
+      appLogger.debug('Handling root request for frontend shell', { frontendDistPath, indexPath });
+
+      try {
+        await fs.promises.access(indexPath);
+        appLogger.debug('Serving frontend index.html');
+        res.sendFile(indexPath, (err) => {
+          if (err) {
+            appLogger.error('Error sending frontend file', { error: err });
+            res.status(500).send('Error serving frontend');
+          } else {
+            appLogger.info('Frontend served successfully');
+          }
+        });
+      } catch {
+        appLogger.error('Frontend index.html not found', { indexPath });
+        res.status(404).send('Frontend not found - please run pnpm run build:frontend');
+      }
+    });
+  }
+
+  // Serve static files from webui dist directory (Production Only)
+  if (process.env.NODE_ENV !== 'development') {
+    app.use(express.static(frontendDistPath));
+    // Global assets static for root-relative asset paths
+    app.use('/assets', express.static(frontendAssetsPath));
+
+    // Uber UI (dashboard)
+    app.use('/uber', express.static(frontendDistPath));
+    app.use('/uber/*', (req: Request, res: Response) => {
+      res.sendFile(path.join(frontendDistPath, 'index.html'));
+    });
+  } else {
+    // Development Mode Handlers - Proxy to Vite
+    const serveDevHtml = async (req: Request, res: Response) => {
+      try {
+        const url = req.originalUrl;
+        let template = await fs.promises.readFile(
+          path.join(process.cwd(), 'src/client/index.html'),
+          'utf-8'
+        );
+        template = await viteServerRef.current.transformIndexHtml(url, template);
+        res
+          .status(200)
+          .set({
+            'Content-Type': 'text/html',
+            'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+            Pragma: 'no-cache',
+            Expires: '0',
+          })
+          .end(template);
+      } catch (e: unknown) {
+        if (e instanceof Error) {
+          viteServerRef.current.ssrFixStacktrace(e);
+        }
+        appLogger.error('Vite SSR Error', e);
+        res.status(500).end(e instanceof Error ? e.message : String(e));
+      }
+    };
+
+    app.get('/', serveDevHtml);
+    app.get('/login', serveDevHtml);
+    app.get('/dashboard', serveDevHtml);
+    app.get('/activity', serveDevHtml);
+    app.get('/uber/*', serveDevHtml);
+    app.get('/admin/*', serveDevHtml);
+    app.get('/webui/*', serveDevHtml);
+  }
+}


### PR DESCRIPTION
## Summary
- Extracts route registration into `src/server/registerRoutes.ts`
- Extracts middleware setup into `src/server/setupMiddleware.ts`
- Extracts service initialization into `src/server/initServices.ts`
- Reduces `src/index.ts` from ~909 lines to ~210 lines (thin orchestrator)
- Pure refactor — no behavior changes

## Test plan
- [ ] `npx tsc --noEmit` passes (no new errors in changed files)
- [ ] `timeout 30 npm run dev` shows startup attempt (segfault is pre-existing on main)
- [ ] All existing tests pass