### PR TITLE
chore: fix error handling patterns

### DIFF
--- a/src/client/src/services/api/core.ts
+++ b/src/client/src/services/api/core.ts
@@ -308,7 +308,7 @@ export class ApiService {
       if ((error instanceof Error ? error.name : 'Error') === 'AbortError') {
         throw new Error(`Request timed out after ${options?.timeout || 15000}ms`);
       }
-      const errorMessage = error instanceof Error ? (error instanceof Error ? error.message : String(error)) : String(error);
+      const errorMessage = error instanceof Error ? error.message : String(error);
       debug('ERROR:', `API request failed for ${endpoint}:`, errorMessage);
       throw error;
     }

--- a/src/message/helpers/handler/processCommand.ts
+++ b/src/message/helpers/handler/processCommand.ts
@@ -47,11 +47,7 @@ export async function processCommand(
   } catch (error: unknown) {
     debug(
       '[processCommand] Error processing message: ' +
-        (error instanceof Error
-          ? error instanceof Error
-            ? error.message
-            : String(error)
-          : String(error))
+        (error instanceof Error ? error.message : String(error))
     );
     return false;
   }

--- a/src/message/helpers/handler/sendTyping.ts
+++ b/src/message/helpers/handler/sendTyping.ts
@@ -41,11 +41,7 @@ export async function sendTyping(client: Client, channelId: string): Promise<voi
       'Failed to start typing in channel ID: ' +
         channelId +
         ': ' +
-        (error instanceof Error
-          ? error instanceof Error
-            ? error.message
-            : String(error)
-          : String(error))
+        (error instanceof Error ? error.message : String(error))
     );
   }
 }

--- a/src/server/routes/personas.ts
+++ b/src/server/routes/personas.ts
@@ -248,7 +248,9 @@ router.delete(
             systemInstruction: 'You are a helpful assistant.',
           });
         } catch (error: unknown) {
-          logger.warn(`Failed to revert bot ${bot.id} to default persona`, { error });
+          logger.warn(`Failed to revert bot ${bot.id} to default persona`, {
+            error: error instanceof Error ? error.message : String(error),
+          });
           // Continue with deletion even if bot update fails
         }
       }
@@ -282,7 +284,10 @@ router.delete(
         botsReverted: botsToRevert.length,
       });
     } catch (error: unknown) {
-      logger.error('Bulk delete personas failed', error);
+      logger.error(
+        'Bulk delete personas failed',
+        error instanceof Error ? error : new Error(String(error))
+      );
       return res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({
         error: 'Failed to delete personas',
         details: error instanceof Error ? error.message : String(error),

--- a/src/utils/startupDiagnostics.ts
+++ b/src/utils/startupDiagnostics.ts
@@ -202,12 +202,7 @@ export class StartupDiagnostics {
             return {
               path: configPath,
               exists: false,
-              error:
-                error instanceof Error
-                  ? error instanceof Error
-                    ? error.message
-                    : String(error)
-                  : String(error),
+              error: error instanceof Error ? error.message : String(error),
             };
           }
         }


### PR DESCRIPTION
## Summary
- Replace `catch (err: any)` with `catch (err: unknown)` + proper type narrowing across ~78 files (183 catch blocks)
- Fix 7 bugs where `catch (_err)` bound unused var but body referenced `err` (the error was silently undefined)
- Replace `console.error` with project logger in frontend app code

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` passes
- [ ] Error handling in UI still works (bot actions, settings, auth)