### PR TITLE
fix(tests): resolve broken test imports and module issues

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -29,6 +29,7 @@ module.exports = {
         "loose": true
       }
     ],
-    "@babel/plugin-transform-object-rest-spread"
+    "@babel/plugin-transform-object-rest-spread",
+    require("path").resolve(__dirname, "tests/babel-plugin-import-meta-env")
   ]
 };

--- a/tests/babel-plugin-import-meta-env.js
+++ b/tests/babel-plugin-import-meta-env.js
@@ -1,0 +1,38 @@
+/**
+ * Custom Babel plugin that transforms `import.meta.env` references into
+ * `process.env` so that Jest (which runs in CommonJS/Node) can evaluate
+ * Vite-style environment access without throwing a SyntaxError.
+ *
+ * Covers patterns like:
+ *   import.meta.env.DEV        -> process.env.DEV
+ *   import.meta.env.VITE_FOO   -> process.env.VITE_FOO
+ *   import.meta.env             -> process.env
+ */
+module.exports = function ({ types: t }) {
+  return {
+    visitor: {
+      MetaProperty(path) {
+        // Match `import.meta`
+        if (
+          path.node.meta.name === 'import' &&
+          path.node.property.name === 'meta'
+        ) {
+          const parent = path.parentPath;
+          // Match `import.meta.env` (MemberExpression with property `env`)
+          if (
+            parent.isMemberExpression() &&
+            parent.node.property.name === 'env'
+          ) {
+            // Replace `import.meta.env` with `process.env`
+            parent.replaceWith(
+              t.memberExpression(
+                t.identifier('process'),
+                t.identifier('env')
+              )
+            );
+          }
+        }
+      },
+    },
+  };
+};

--- a/tests/unit/initProviders.test.ts
+++ b/tests/unit/initProviders.test.ts
@@ -69,7 +69,7 @@ jest.mock('../../src/registries/ProviderRegistry', () => {
   };
 });
 
-jest.mock('../../src/integrations/openswarm/SwarmInstaller', () => ({
+jest.mock('@integrations/openswarm/SwarmInstaller', () => ({
   SwarmInstaller: jest.fn().mockImplementation(() => ({
     id: 'swarm-installer',
   })),


### PR DESCRIPTION
## Summary
- **initProviders.test.ts**: Updated `jest.mock` path for `SwarmInstaller` from the stale `../../src/integrations/openswarm/SwarmInstaller` to `@integrations/openswarm/SwarmInstaller`, matching the Jest `moduleNameMapper` alias that resolves to `packages/llm-openswarm/src/SwarmInstaller`.
- **modals.a11y.test.tsx**: Added a custom Babel plugin (`tests/babel-plugin-import-meta-env.js`) that transforms Vite-style `import.meta.env` references into `process.env`, allowing Jest to parse client source files without a `SyntaxError`.
- **babel.config.js**: Registered the new plugin so all test transforms handle `import.meta.env` automatically.

## Test plan
- [x] `npx jest tests/unit/initProviders.test.ts --no-coverage` passes (11 tests)
- [x] `npx jest tests/accessibility/modals.a11y.test.tsx --no-coverage` passes (25 tests)