### PR TITLE
fix(ui): deduplicate dashboard components

### DIFF
--- a/src/client/src/components/Dashboard.tsx
+++ b/src/client/src/components/Dashboard.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { apiService, type Bot, type StatusResponse } from '../services/api';
 import { Alert } from './DaisyUI/Alert';
 import Button from './DaisyUI/Button';
@@ -9,11 +8,7 @@ import RadialProgress from './DaisyUI/RadialProgress';
 import { SkeletonCard } from './DaisyUI/Skeleton';
 import { Stat, Stats } from './DaisyUI/Stat';
 import DashboardBotCard from './DashboardBotCard';
-import TipRotator from './TipRotator';
-import QuickActions from './QuickActions';
 import AgentGrid from './Dashboard/AgentGrid';
-import Carousel from './DaisyUI/Carousel';
-import { useMediaQuery } from '../hooks/useBreakpoint';
 
 const getStatusColor = (botStatus: string) => {
   switch (botStatus.toLowerCase()) {
@@ -47,9 +42,6 @@ const getProviderIcon = (provider: string) => {
 };
 
 const Dashboard: React.FC = () => {
-  const navigate = useNavigate();
-  const isDesktop = useMediaQuery({ minWidth: 1024 });
-  const isWide = useMediaQuery({ minWidth: 1440 });
   const [bots, setBots] = useState<Bot[]>([]);
   const [status, setStatus] = useState<StatusResponse | null>(null);
   const [loading, setLoading] = useState(true);
@@ -57,7 +49,6 @@ const Dashboard: React.FC = () => {
   const [botRatings, setBotRatings] = useState<Record<string, number>>({});
   const [showToast, setShowToast] = useState(false);
   const [toastMessage, setToastMessage] = useState('');
-  const [announcement, setAnnouncement] = useState<string>('');
 
   const fetchData = useCallback(async () => {
     try {
@@ -83,10 +74,6 @@ const Dashboard: React.FC = () => {
 
   useEffect(() => {
     fetchData();
-    // Fetch announcement
-    apiService.get<{ announcement?: string }>('/api/dashboard/announcement')
-      .then((data: any) => { if (data?.announcement) setAnnouncement(data.announcement); })
-      .catch(() => { /* no announcement */ });
   }, [fetchData]);
 
   const handleRatingChange = useCallback((botName: string, rating: number) => {
@@ -218,44 +205,8 @@ const Dashboard: React.FC = () => {
         </div>
       )}
 
-      {/* Quick Actions — flush to top, full width */}
-      <QuickActions onRefresh={fetchData} />
-
-      <div className="px-2 mb-2">
-        {/* Getting Started Carousel — full width */}
-        <div className="mb-4">
-          <h3 className="text-xs font-bold uppercase tracking-wider text-base-content/40 mb-1">Getting Started</h3>
-          <Carousel
-            items={[
-              { image: '', title: '🤖 Configure Your First Bot', description: 'Set up an AI agent with a persona and LLM provider.', bgGradient: 'linear-gradient(135deg, #4f46e5, #7c3aed)', link: '/admin/bots' },
-              { image: '', title: '🧠 Connect an LLM Provider', description: 'Add your OpenAI, Anthropic, or Ollama API key.', bgGradient: 'linear-gradient(135deg, #059669, #10b981)', link: '/admin/providers/llm' },
-              { image: '', title: '🎭 Create a Persona', description: 'Give your bot a unique personality and response behavior.', bgGradient: 'linear-gradient(135deg, #0891b2, #06b6d4)', link: '/admin/personas' },
-              { image: '', title: '🛡️ Set Up Guard Profiles', description: 'Add safety rules for access control and rate limiting.', bgGradient: 'linear-gradient(135deg, #d97706, #f59e0b)', link: '/admin/guards' },
-              { image: '', title: '📊 Real-time Monitoring', description: 'Monitor performance, messages, and system health.', bgGradient: 'linear-gradient(135deg, #7c3aed, #a855f7)', link: '/admin/monitoring' },
-              ...(announcement ? [{ image: '', title: '📋 Announcements', description: announcement, bgGradient: 'linear-gradient(135deg, #1e40af, #3b82f6)' }] : []),
-            ]}
-            autoplay
-            interval={6000}
-            variant="full-width"
-            visibleCount={isWide ? 4 : isDesktop ? 3 : 1}
-            onSlideClick={(item) => item.link && navigate(item.link)}
-          />
-        </div>
-
-        {/* Stats Overview — full width below carousel */}
-        <div>
-          <h3 className="text-xs font-bold uppercase tracking-wider text-base-content/40 mb-1">Overview</h3>
-          <Stats className="shadow-sm bg-base-200/50 w-full">
-            <Stat title="Active Bots" value={activeBots} valueClassName="text-primary text-xl" description={`out of ${bots.length} total`} />
-            <Stat title="Total Messages" value={totalMessages.toLocaleString()} valueClassName="text-secondary text-xl" description="processed today" />
-            <Stat title="System Uptime" value={<>{uptimeHours}h {uptimeMinutes}m</>} valueClassName="text-accent text-xl" description="running smoothly" />
-          </Stats>
-        </div>
-      </div>
-
       {/* Main Content */}
       <div className="px-2 py-2">
-        <TipRotator className="mb-4 px-2" />
 
         {/* Bot Cards Grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">

--- a/src/client/src/components/WelcomeSplash.tsx
+++ b/src/client/src/components/WelcomeSplash.tsx
@@ -17,7 +17,6 @@ import { Badge } from './DaisyUI/Badge';
 import Steps from './DaisyUI/Steps';
 import { apiService } from '../services/api';
 import AnnouncementBanner from './AnnouncementBanner';
-import TipRotator from './TipRotator';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -170,9 +169,6 @@ const WelcomeSplash: React.FC = () => {
 
       {/* Announcement Banner */}
       <AnnouncementBanner />
-
-      {/* User Tips */}
-      <TipRotator className="flex items-center gap-2 text-sm text-base-content/70 px-4" />
 
       {/* Configuration Progress */}
       <Card className="bg-base-100 shadow-lg">

--- a/src/client/src/pages/Dashboard/index.tsx
+++ b/src/client/src/pages/Dashboard/index.tsx
@@ -12,6 +12,7 @@ import Toggle from '../../components/DaisyUI/Toggle';
 import Carousel from '../../components/DaisyUI/Carousel';
 import DashboardWidgetSystem from '../../components/DaisyUI/DashboardWidgetSystem';
 import WelcomeSplash from '../../components/WelcomeSplash';
+import QuickActions from '../../components/QuickActions';
 
 const SystemHealth = lazy(() => import('../../components/SystemHealth'));
 
@@ -22,6 +23,20 @@ const DashboardPage: React.FC = () => {
   const [checked, setChecked] = useState(false);
   const [needsSetup, setNeedsSetup] = useState(false);
   const [showWelcome, setShowWelcome] = useState(false);
+  const [announcementDesc, setAnnouncementDesc] = useState<string>('');
+
+  // Fetch announcement text
+  useEffect(() => {
+    apiService.get<{ announcement?: string }>('/api/dashboard/announcement')
+      .then((data: any) => {
+        const text = data?.announcement || '';
+        if (text) {
+          const firstLine = text.split('\n').find((l: string) => l.trim()) || '';
+          setAnnouncementDesc(firstLine.length > 120 ? firstLine.slice(0, 120) + '...' : firstLine);
+        }
+      })
+      .catch(() => { /* no announcement */ });
+  }, []);
 
   // Track preference for widget vs static layout
   const [useWidgetLayout, setUseWidgetLayout] = useState(() => {
@@ -77,7 +92,18 @@ const DashboardPage: React.FC = () => {
     { image: '', title: '🛡️ Set Up Guard Profiles', description: 'Add safety rules — access control, rate limiting, and content filtering for your bots.', bgGradient: 'linear-gradient(135deg, #d97706, #f59e0b)' },
     { image: '', title: '📡 Multi-Platform Support', description: 'Connect to Discord, Slack, Mattermost — run coordinated bots across all platforms.', bgGradient: 'linear-gradient(135deg, #dc2626, #ef4444)' },
     { image: '', title: '📊 Real-time Monitoring', description: 'Monitor bot performance, message volume, response times, and system health.', bgGradient: 'linear-gradient(135deg, #7c3aed, #a855f7)' },
+    { image: '', title: '📋 Announcements', description: announcementDesc || 'Check out what\'s new and what\'s coming next.', bgGradient: 'linear-gradient(135deg, #1e40af, #3b82f6)', link: 'https://github.com/matthewhand/open-hivemind/blob/main/ANNOUNCEMENT.md' },
   ];
+
+  const handleSlideClick = (item: { link?: string }) => {
+    if (item.link) {
+      if (item.link.startsWith('http')) {
+        window.open(item.link, '_blank');
+      } else {
+        navigate(item.link);
+      }
+    }
+  };
 
   const setTab = (tab: string) => {
     if (tab === 'dashboard') {
@@ -137,6 +163,8 @@ const DashboardPage: React.FC = () => {
         <h3 className="text-sm font-bold uppercase tracking-wider text-base-content/40 mb-2">Getting Started</h3>
         <Carousel items={carouselItems} autoplay={true} interval={6000} variant="full-width" />
       </div>
+
+      <QuickActions onRefresh={() => {}} />
 
       <div className="flex justify-end items-center mb-4 px-4 gap-3 bg-base-100/50 p-2 rounded-lg shadow-sm w-fit ml-auto">
         <span className="text-sm font-medium opacity-80">Static Layout</span>


### PR DESCRIPTION
## Summary
- Remove duplicate "Getting Started" carousel, Stats Overview, QuickActions, and TipRotator from `Dashboard.tsx` — the canonical versions live in `DashboardPage` and `WelcomeSplash`
- Remove duplicate TipRotator from `WelcomeSplash.tsx`
- Add `QuickActions` to `DashboardPage` as the single render location
- Clean up unused imports (`Carousel`, `useMediaQuery`, `QuickActions`, `TipRotator`, `useNavigate`) and dead `announcement` state/fetch from `Dashboard.tsx`

## Test plan
- [ ] Verify dashboard loads with a single carousel, single QuickActions bar, and single System Information card
- [ ] Verify WelcomeSplash no longer shows a TipRotator
- [ ] Verify `npx tsc --noEmit` passes cleanly