### PR TITLE
fix(ui): announcements as carousel item linking to GitHub

### DIFF
--- a/src/client/src/components/WelcomeSplash.tsx
+++ b/src/client/src/components/WelcomeSplash.tsx
@@ -16,7 +16,7 @@ import { Alert } from './DaisyUI/Alert';
 import { Badge } from './DaisyUI/Badge';
 import Steps from './DaisyUI/Steps';
 import { apiService } from '../services/api';
-import AnnouncementBanner from './AnnouncementBanner';
+import TipRotator from './TipRotator';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -167,8 +167,8 @@ const WelcomeSplash: React.FC = () => {
         </p>
       </div>
 
-      {/* Announcement Banner */}
-      <AnnouncementBanner />
+      {/* User Tips */}
+      <TipRotator className="flex items-center gap-2 text-sm text-base-content/70 px-4" />
 
       {/* Configuration Progress */}
       <Card className="bg-base-100 shadow-lg">


### PR DESCRIPTION
## Summary
- Adds an "Announcements" carousel item to the Getting Started carousel in `DashboardPage`, fetching the first line of `ANNOUNCEMENT.md` as the description and linking to the GitHub-hosted file
- Removes the raw-markdown `<AnnouncementBanner />` from `WelcomeSplash` (import and render)
- Removes the duplicate announcement state, fetch, and carousel item from `Dashboard.tsx`

## Test plan
- [ ] Verify the Getting Started carousel in `DashboardPage` shows the new "Announcements" slide with a blue gradient
- [ ] Click the Announcements slide and confirm it opens `https://github.com/matthewhand/open-hivemind/blob/main/ANNOUNCEMENT.md` in a new tab
- [ ] Verify WelcomeSplash no longer renders the raw-text announcement banner
- [ ] Verify `npx tsc --noEmit` passes with no errors