### PR TITLE
feat(ui): tabbed Overview page with consolidated navigation

### DIFF
--- a/src/client/src/components/Settings/SettingsGeneral.tsx
+++ b/src/client/src/components/Settings/SettingsGeneral.tsx
@@ -66,6 +66,9 @@ const SettingsGeneral: React.FC = () => {
     defaultValues,
   });
 
+  const [showGettingStartedPref, setShowGettingStartedPref] = useState(
+    () => localStorage.getItem('hivemind-show-getting-started') !== 'false',
+  );
   const [loading, setLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [alert, setAlert] = useState<{ type: 'success' | 'error', message: string } | null>(null);
@@ -294,6 +297,30 @@ const SettingsGeneral: React.FC = () => {
               ]}
             />
           </FormField>
+        </Card>
+
+        {/* Aesthetic Preferences */}
+        <Card className="bg-base-100 border border-base-300 shadow-sm p-4 h-full">
+          <h6 className="text-md font-semibold mb-4 flex items-center gap-2">
+            <span className="w-2 h-2 bg-info rounded-full"></span>
+            Aesthetic Preferences
+          </h6>
+
+          <div className="space-y-3">
+            <Toggle
+              label="Show Getting Started tab"
+              checked={showGettingStartedPref}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                const val = e.target.checked;
+                setShowGettingStartedPref(val);
+                localStorage.setItem('hivemind-show-getting-started', val ? 'true' : 'false');
+              }}
+              size="sm"
+            />
+            <p className="text-xs text-base-content/50 pl-1">
+              When enabled, shows the Getting Started tab on the Overview page with setup guides and tips.
+            </p>
+          </div>
         </Card>
 
         {/* Logging */}

--- a/src/client/src/config/navigation.tsx
+++ b/src/client/src/config/navigation.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-refresh/only-export-components, no-empty, no-case-declarations */
 import {
   LayoutDashboard, Bot,
-  Settings, Cog, Activity, Component, MessageSquare, Brain,
+  Settings, Cog, Component, MessageSquare, Brain,
   Map, Webhook, FileText, Store, BarChart3, ClipboardList,
   FileDown, HeartPulse, HelpCircle, FileCode, Info,
 } from 'lucide-react';
@@ -64,13 +64,6 @@ export const hivemindNavItems: NavItem[] = [
     label: 'System',
     icon: null as unknown as React.ReactNode,
     divider: true,
-    visible: true,
-  },
-  {
-    id: 'activity',
-    label: 'Activity',
-    icon: <NavIcon><Activity className="w-4 h-4" /></NavIcon>,
-    path: '/admin/activity',
     visible: true,
   },
   {

--- a/src/client/src/pages/GuardsPage.tsx
+++ b/src/client/src/pages/GuardsPage.tsx
@@ -1,13 +1,15 @@
 import React, { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { authFetch } from '../utils/authFetch';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Shield, RefreshCw, AlertTriangle, Plus, Copy, Trash2, Edit2, CheckCircle, XCircle } from 'lucide-react';
+import { Shield, RefreshCw, AlertTriangle, Plus, Copy, Trash2, Edit2, CheckCircle, XCircle, Settings, Users } from 'lucide-react';
 import Card from '../components/DaisyUI/Card';
 import Divider from '../components/DaisyUI/Divider';
 import Input from '../components/DaisyUI/Input';
 import Button from '../components/DaisyUI/Button';
 import Toggle from '../components/DaisyUI/Toggle';
 import Select from '../components/DaisyUI/Select';
+import Tabs from '../components/DaisyUI/Tabs';
 import Textarea from '../components/DaisyUI/Textarea';
 import { ConfirmModal } from '../components/DaisyUI/Modal';
 import ModalForm from '../components/DaisyUI/ModalForm';
@@ -137,14 +139,122 @@ const GuardStatusRow: React.FC<{ icon: React.ReactNode; label: string; enabled: 
   </div>
 );
 
+/** Guard Settings tab (placeholder — no settings API yet) */
+const GuardSettingsTab: React.FC = () => {
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  return (
+    <div className="space-y-6">
+      <Card className="shadow-md border border-base-200">
+        <div className="flex items-center gap-2 mb-4">
+          <Settings className="w-5 h-5 text-primary" />
+          <h3 className="text-lg font-semibold">Global Guard Defaults</h3>
+        </div>
+
+        <div className="space-y-4">
+          {/* Default rate limit */}
+          <div className="form-control opacity-50 pointer-events-none">
+            <label className="label"><span className="label-text font-medium">Default Rate Limit</span></label>
+            <div className="grid grid-cols-2 gap-4">
+              <Input
+                label="Max Requests"
+                type="number"
+                value={100}
+                readOnly
+                disabled
+              />
+              <Input
+                label="Window (seconds)"
+                type="number"
+                value={60}
+                readOnly
+                disabled
+              />
+            </div>
+            <label className="label">
+              <span className="label-text-alt text-base-content/50">
+                Applied to new guard profiles by default.
+              </span>
+            </label>
+          </div>
+
+          <Divider>Content Filtering</Divider>
+
+          {/* Default content filter level */}
+          <div className="form-control opacity-50 pointer-events-none">
+            <label className="label"><span className="label-text font-medium">Default Content Filter Level</span></label>
+            <Select
+              disabled
+              value="medium"
+              options={[
+                { value: 'low', label: 'Low' },
+                { value: 'medium', label: 'Medium' },
+                { value: 'high', label: 'High' },
+              ]}
+            />
+          </div>
+        </div>
+
+        <div className="mt-6 p-4 bg-info/10 rounded-lg text-info text-sm">
+          Guard settings coming soon. These controls will be connected in a future release.
+        </div>
+      </Card>
+
+      {/* Advanced toggle */}
+      <Card className="shadow-md border border-base-200">
+        <Toggle
+          label="Advanced"
+          checked={showAdvanced}
+          onChange={() => setShowAdvanced(v => !v)}
+          color="primary"
+        />
+        {showAdvanced && (
+          <div className="mt-4 space-y-4 animate-fadeIn">
+            <Divider>Advanced Guard Settings</Divider>
+            <div className="form-control opacity-50 pointer-events-none">
+              <label className="label"><span className="label-text">Custom Rule Configuration</span></label>
+              <Textarea
+                disabled
+                placeholder="Define custom guard rules in JSON format..."
+                rows={4}
+              />
+            </div>
+            <div className="form-control opacity-50 pointer-events-none">
+              <label className="label"><span className="label-text">Guard Evaluation Order</span></label>
+              <Select
+                disabled
+                value="sequential"
+                options={[
+                  { value: 'sequential', label: 'Sequential (all guards run in order)' },
+                  { value: 'parallel', label: 'Parallel (all guards run simultaneously)' },
+                  { value: 'fail-fast', label: 'Fail-Fast (stop on first failure)' },
+                ]}
+              />
+            </div>
+            <div className="p-4 bg-info/10 rounded-lg text-info text-sm">
+              Advanced guard settings coming soon.
+            </div>
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+};
+
 const GuardsPage: React.FC = () => {
   const { addToast } = useToast();
   const queryClient = useQueryClient();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [editingProfile, setEditingProfile] = useState<Partial<GuardProfile> | null>(null);
   const [deleteConfirm, setDeleteConfirm] = useState<GuardProfile | null>(null);
   const [selectedProfileId, setSelectedProfileId] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
   const pageSize = 12;
+
+  const activeTab = searchParams.get('tab') || 'profiles';
+  const handleTabChange = (tabId: string) => {
+    setSearchParams(tabId === 'profiles' ? {} : { tab: tabId }, { replace: true });
+  };
 
   const { data: response, isLoading } = useQuery<{ data: GuardProfile[] }>({
     queryKey: ['guardProfiles'],
@@ -470,102 +580,126 @@ const GuardsPage: React.FC = () => {
 
   return (
     <div className="container mx-auto p-4 max-w-7xl">
-      {profiles.length === 0 ? (
-        <div className="text-center py-16 bg-base-200 rounded-box">
-          <Shield className="w-16 h-16 mx-auto text-base-content/30 mb-4" />
-          <h3 className="text-xl font-bold mb-2">No Guard Profiles</h3>
-          <p className="text-base-content/70 mb-6">Create your first guard profile to secure your bots.</p>
-          <Button color="primary" onClick={() => setEditingProfile(defaultNewProfile as any)}>
-            <Plus className="w-4 h-4 mr-2" /> Create Profile
-          </Button>
-        </div>
-      ) : (
-        <><div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {paginatedProfiles.map(profile => (
-            <Card
-              key={profile.id}
-              className="hover:shadow-lg transition-shadow cursor-pointer border border-base-200"
-              onClick={() => setSelectedProfileId(profile.id)}
-            >
-              <div className="flex justify-between items-start mb-4">
-                <div>
-                  <h3 className="text-lg font-bold">{profile.name}</h3>
-                  <p className="text-sm text-base-content/70 line-clamp-2 min-h-[2.5rem] mt-1">
-                    {profile.description || 'No description'}
-                  </p>
-                </div>
-              </div>
-
-              <div className="space-y-3 mb-6">
-                <div className="flex justify-between items-center text-sm">
-                  <span className="flex items-center gap-2">
-                    <Shield className="w-4 h-4 opacity-70" /> Access Control
-                  </span>
-                  <div className={`badge ${profile.guards.mcpGuard.enabled ? 'badge-primary badge-outline' : 'badge-ghost'}`}>
-                    {profile.guards.mcpGuard.enabled ? profile.guards.mcpGuard.type : 'Disabled'}
+      <Tabs
+        variant="lifted"
+        activeTab={activeTab}
+        onChange={handleTabChange}
+        tabs={[
+          {
+            id: 'profiles',
+            label: 'Profiles',
+            icon: <Users className="w-4 h-4" />,
+            content: (
+              <>
+                {profiles.length === 0 ? (
+                  <div className="text-center py-16 bg-base-200 rounded-box">
+                    <Shield className="w-16 h-16 mx-auto text-base-content/30 mb-4" />
+                    <h3 className="text-xl font-bold mb-2">No Guard Profiles</h3>
+                    <p className="text-base-content/70 mb-6">Create your first guard profile to secure your bots.</p>
+                    <Button color="primary" onClick={() => setEditingProfile(defaultNewProfile as any)}>
+                      <Plus className="w-4 h-4 mr-2" /> Create Profile
+                    </Button>
                   </div>
-                </div>
+                ) : (
+                  <>
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                      {paginatedProfiles.map(profile => (
+                        <Card
+                          key={profile.id}
+                          className="hover:shadow-lg transition-shadow cursor-pointer border border-base-200"
+                          onClick={() => setSelectedProfileId(profile.id)}
+                        >
+                          <div className="flex justify-between items-start mb-4">
+                            <div>
+                              <h3 className="text-lg font-bold">{profile.name}</h3>
+                              <p className="text-sm text-base-content/70 line-clamp-2 min-h-[2.5rem] mt-1">
+                                {profile.description || 'No description'}
+                              </p>
+                            </div>
+                          </div>
 
-                <div className="flex justify-between items-center text-sm">
-                  <span className="flex items-center gap-2">
-                    <RefreshCw className="w-4 h-4 opacity-70" /> Rate Limit
-                  </span>
-                  <div className={`badge ${profile.guards.rateLimit?.enabled ? 'badge-primary badge-outline' : 'badge-ghost'}`}>
-                    {profile.guards.rateLimit?.enabled ? `${profile.guards.rateLimit.maxRequests}/${profile.guards.rateLimit.windowMs / 1000}s` : 'Disabled'}
-                  </div>
-                </div>
+                          <div className="space-y-3 mb-6">
+                            <div className="flex justify-between items-center text-sm">
+                              <span className="flex items-center gap-2">
+                                <Shield className="w-4 h-4 opacity-70" /> Access Control
+                              </span>
+                              <div className={`badge ${profile.guards.mcpGuard.enabled ? 'badge-primary badge-outline' : 'badge-ghost'}`}>
+                                {profile.guards.mcpGuard.enabled ? profile.guards.mcpGuard.type : 'Disabled'}
+                              </div>
+                            </div>
 
-                <div className="flex justify-between items-center text-sm">
-                  <span className="flex items-center gap-2">
-                    <AlertTriangle className="w-4 h-4 opacity-70" /> Content Filter
-                  </span>
-                  <div className={`badge ${profile.guards.contentFilter?.enabled ? 'badge-error badge-outline' : 'badge-ghost'}`}>
-                    {profile.guards.contentFilter?.enabled ? profile.guards.contentFilter.strictness : 'Disabled'}
-                  </div>
-                </div>
-              </div>
+                            <div className="flex justify-between items-center text-sm">
+                              <span className="flex items-center gap-2">
+                                <RefreshCw className="w-4 h-4 opacity-70" /> Rate Limit
+                              </span>
+                              <div className={`badge ${profile.guards.rateLimit?.enabled ? 'badge-primary badge-outline' : 'badge-ghost'}`}>
+                                {profile.guards.rateLimit?.enabled ? `${profile.guards.rateLimit.maxRequests}/${profile.guards.rateLimit.windowMs / 1000}s` : 'Disabled'}
+                              </div>
+                            </div>
 
-              <div className="flex justify-end gap-2 mt-auto">
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={(e) => { e.stopPropagation(); handleDuplicate(profile); }}
-                  title="Duplicate Profile"
-                  aria-label="Duplicate profile"
-                >
-                  <Copy className="w-4 h-4" />
-                </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={(e) => { e.stopPropagation(); setEditingProfile(profile); }}
-                  title="Edit Profile"
-                >
-                  <Edit2 className="w-4 h-4" />
-                </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  color="error"
-                  onClick={(e) => { e.stopPropagation(); setDeleteConfirm(profile); }}
-                  title="Delete Profile"
-                >
-                  <Trash2 className="w-4 h-4" />
-                </Button>
-              </div>
-            </Card>
-          ))}
-        </div>
-        <div className="flex justify-center mt-6">
-          <Pagination
-            currentPage={currentPage}
-            totalItems={profiles.length}
-            pageSize={pageSize}
-            onPageChange={setCurrentPage}
-            style="standard"
-          />
-        </div></>
-      )}
+                            <div className="flex justify-between items-center text-sm">
+                              <span className="flex items-center gap-2">
+                                <AlertTriangle className="w-4 h-4 opacity-70" /> Content Filter
+                              </span>
+                              <div className={`badge ${profile.guards.contentFilter?.enabled ? 'badge-error badge-outline' : 'badge-ghost'}`}>
+                                {profile.guards.contentFilter?.enabled ? profile.guards.contentFilter.strictness : 'Disabled'}
+                              </div>
+                            </div>
+                          </div>
+
+                          <div className="flex justify-end gap-2 mt-auto">
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={(e) => { e.stopPropagation(); handleDuplicate(profile); }}
+                              title="Duplicate Profile"
+                              aria-label="Duplicate profile"
+                            >
+                              <Copy className="w-4 h-4" />
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={(e) => { e.stopPropagation(); setEditingProfile(profile); }}
+                              title="Edit Profile"
+                            >
+                              <Edit2 className="w-4 h-4" />
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              color="error"
+                              onClick={(e) => { e.stopPropagation(); setDeleteConfirm(profile); }}
+                              title="Delete Profile"
+                            >
+                              <Trash2 className="w-4 h-4" />
+                            </Button>
+                          </div>
+                        </Card>
+                      ))}
+                    </div>
+                    <div className="flex justify-center mt-6">
+                      <Pagination
+                        currentPage={currentPage}
+                        totalItems={profiles.length}
+                        pageSize={pageSize}
+                        onPageChange={setCurrentPage}
+                        style="standard"
+                      />
+                    </div>
+                  </>
+                )}
+              </>
+            ),
+          },
+          {
+            id: 'settings',
+            label: 'Settings',
+            icon: <Settings className="w-4 h-4" />,
+            content: <GuardSettingsTab />,
+          },
+        ]}
+      />
 
       {/* Guard Profile Detail Drawer */}
       <DetailDrawer

--- a/src/client/src/pages/OverviewPage.tsx
+++ b/src/client/src/pages/OverviewPage.tsx
@@ -1,8 +1,277 @@
-import React from 'react';
+import React, { lazy, Suspense, useEffect, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Cpu, Rocket, X, HelpCircle } from 'lucide-react';
 import Dashboard from '../components/Dashboard';
+import { apiService } from '../services/api';
+import { Alert } from '../components/DaisyUI/Alert';
+import Button from '../components/DaisyUI/Button';
+import Card from '../components/DaisyUI/Card';
+import { LoadingSpinner } from '../components/DaisyUI/Loading';
+import Tabs from '../components/DaisyUI/Tabs';
+import Toggle from '../components/DaisyUI/Toggle';
+import Carousel from '../components/DaisyUI/Carousel';
+import DashboardWidgetSystem from '../components/DaisyUI/DashboardWidgetSystem';
+import WelcomeSplash from '../components/WelcomeSplash';
+import QuickActions from '../components/QuickActions';
+
+const SystemHealth = lazy(() => import('../components/SystemHealth'));
+const ActivityPage = lazy(() => import('./ActivityPage'));
+const MonitoringDashboard = lazy(() => import('./MonitoringDashboard'));
+
+const SuspenseFallback: React.FC = () => (
+  <div className="flex justify-center items-center min-h-[200px]">
+    <LoadingSpinner size="lg" />
+  </div>
+);
 
 const OverviewPage: React.FC = () => {
-  return <Dashboard />;
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = searchParams.get('tab') || 'overview';
+  const [checked, setChecked] = useState(false);
+  const [needsSetup, setNeedsSetup] = useState(false);
+  const [showWelcome, setShowWelcome] = useState(false);
+  const [announcementDesc, setAnnouncementDesc] = useState<string>('');
+  const [showGettingStarted, setShowGettingStarted] = useState(
+    () => localStorage.getItem('hivemind-show-getting-started') !== 'false',
+  );
+
+  // Fetch announcement text
+  useEffect(() => {
+    apiService.get<{ announcement?: string }>('/api/dashboard/announcement')
+      .then((data: any) => {
+        const text = data?.announcement || '';
+        if (text) {
+          const firstLine = text.split('\n').find((l: string) => l.trim()) || '';
+          setAnnouncementDesc(firstLine.length > 120 ? firstLine.slice(0, 120) + '...' : firstLine);
+        }
+      })
+      .catch(() => { /* no announcement */ });
+  }, []);
+
+  // Track preference for widget vs static layout
+  const [useWidgetLayout, setUseWidgetLayout] = useState(() => {
+    const saved = localStorage.getItem('hivemind-dashboard-layout');
+    return saved === 'widget';
+  });
+
+  // Save preference when it changes
+  useEffect(() => {
+    localStorage.setItem('hivemind-dashboard-layout', useWidgetLayout ? 'widget' : 'static');
+  }, [useWidgetLayout]);
+
+  useEffect(() => {
+    const checkOnboarding = async (): Promise<void> => {
+      try {
+        const data = await apiService.get<any>('/api/onboarding/status');
+        if (!data.completed) {
+          navigate('/onboarding', { replace: true });
+          return;
+        }
+
+        try {
+          const configStatus = await apiService.get<any>('/api/dashboard/config-status');
+          const status = configStatus?.data || configStatus;
+          const anyIncomplete = !status.llmConfigured || !status.botConfigured || !status.messengerConfigured;
+          setShowWelcome(anyIncomplete);
+          if (anyIncomplete) {
+            setNeedsSetup(true);
+          }
+        } catch { /* proceed normally */ }
+      } catch {
+        // If the endpoint is unavailable, proceed to dashboard normally
+      }
+      setChecked(true);
+    };
+    checkOnboarding();
+
+    const interval = setInterval(checkOnboarding, 5000);
+    return () => clearInterval(interval);
+  }, [navigate]);
+
+  // Listen for changes to the Getting Started localStorage preference
+  useEffect(() => {
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === 'hivemind-show-getting-started') {
+        setShowGettingStarted(e.newValue !== 'false');
+      }
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
+
+  if (!checked) {
+    return null;
+  }
+
+  const dismissGettingStarted = () => {
+    localStorage.setItem('hivemind-show-getting-started', 'false');
+    setShowGettingStarted(false);
+  };
+
+  const restoreGettingStarted = () => {
+    localStorage.setItem('hivemind-show-getting-started', 'true');
+    setShowGettingStarted(true);
+  };
+
+  const carouselItems = [
+    { image: '', title: '🤖 Configure Your First Bot', description: 'Set up an AI agent — assign a persona, connect a messaging platform, and choose an LLM provider.', bgGradient: 'linear-gradient(135deg, #4f46e5, #7c3aed)', link: '/admin/bots' },
+    { image: '', title: '🧠 Connect an LLM Provider', description: 'Add your OpenAI, Anthropic, Flowise, or Ollama API key to power bot responses.', bgGradient: 'linear-gradient(135deg, #059669, #10b981)', link: '/admin/providers/llm' },
+    { image: '', title: '🎭 Create a Persona', description: 'Give your bot a unique personality — name, system prompt, response behavior, and avatar.', bgGradient: 'linear-gradient(135deg, #0891b2, #06b6d4)', link: '/admin/personas' },
+    { image: '', title: '🛡️ Set Up Guard Profiles', description: 'Add safety rules — access control, rate limiting, and content filtering for your bots.', bgGradient: 'linear-gradient(135deg, #d97706, #f59e0b)', link: '/admin/guards' },
+    { image: '', title: '📊 Real-time Monitoring', description: 'Monitor bot performance, message volume, response times, and system health.', bgGradient: 'linear-gradient(135deg, #7c3aed, #a855f7)', link: '/admin/overview?tab=monitoring' },
+    { image: '', title: '📋 Announcements', description: announcementDesc || 'Check out what\'s new and what\'s coming next.', bgGradient: 'linear-gradient(135deg, #1e40af, #3b82f6)', link: 'https://github.com/matthewhand/open-hivemind/blob/main/ANNOUNCEMENT.md' },
+  ];
+
+  const handleSlideClick = (item: { link?: string }) => {
+    if (item.link) {
+      if (item.link.startsWith('http')) {
+        window.open(item.link, '_blank');
+      } else {
+        navigate(item.link);
+      }
+    }
+  };
+
+  const gettingStartedVisible = showGettingStarted || needsSetup;
+
+  const setTab = (tab: string) => {
+    if (tab === 'overview') {
+      searchParams.delete('tab');
+      setSearchParams(searchParams);
+    } else {
+      setSearchParams({ tab });
+    }
+  };
+
+  // Build tab list dynamically — Getting Started tab is conditional
+  const tabs = [
+    ...(gettingStartedVisible
+      ? [{ key: 'getting-started', label: 'Getting Started' }]
+      : []),
+    { key: 'overview', label: 'Overview' },
+    { key: 'activity', label: 'Activity' },
+    { key: 'monitoring', label: 'Monitoring' },
+  ];
+
+  return (
+    <div>
+      <div className="p-6">
+        <Card className="shadow-xl">
+          <Tabs
+            variant="lifted"
+            tabs={tabs}
+            activeTab={activeTab}
+            onChange={(tab) => setTab(tab)}
+            className="mb-6"
+          />
+          <div className="mt-4">
+            {activeTab === 'getting-started' && gettingStartedVisible && (
+              <div className="mx-4 mb-6 rounded-xl bg-base-200/50 border border-base-300 p-5">
+                <div className="flex items-center justify-between mb-3">
+                  <h3 className="text-sm font-bold uppercase tracking-wider text-base-content/60">Getting Started</h3>
+                  <button
+                    className="btn btn-ghost btn-xs gap-1 text-base-content/40 hover:text-base-content/70"
+                    onClick={dismissGettingStarted}
+                    title="Hide Getting Started"
+                  >
+                    <X className="w-4 h-4" />
+                    Hide
+                  </button>
+                </div>
+
+                {showWelcome && (
+                  <div className="max-w-7xl mx-auto mb-4">
+                    <WelcomeSplash />
+                  </div>
+                )}
+
+                {needsSetup && !showWelcome && (
+                  <div className="max-w-7xl mx-auto mb-4">
+                    <Alert status="warning" className="shadow-lg" onClose={() => setNeedsSetup(false)}>
+                      <Cpu className="w-5 h-5 shrink-0" />
+                      <div className="flex-1">
+                        <strong>Setup incomplete</strong> — no LLM provider is configured yet. Your bots won't be able to generate responses.
+                      </div>
+                      <Button variant="primary" size="sm" onClick={() => navigate('/onboarding')}>
+                        <Rocket className="w-4 h-4 mr-1" />
+                        Run Setup Wizard
+                      </Button>
+                    </Alert>
+                  </div>
+                )}
+
+                <Carousel items={carouselItems} autoplay={true} interval={6000} variant="full-width" onSlideClick={handleSlideClick} />
+              </div>
+            )}
+
+            {activeTab === 'overview' && (
+              <div>
+                <div className="flex items-center justify-between mb-4 px-4">
+                  <div className="flex items-center gap-3">
+                    <h3 className="text-sm font-bold uppercase tracking-wider text-base-content/60">Overview</h3>
+                    {!gettingStartedVisible && (
+                      <button
+                        className="btn btn-ghost btn-xs gap-1 text-base-content/40 hover:text-primary"
+                        onClick={restoreGettingStarted}
+                        title="Show Getting Started guide"
+                      >
+                        <HelpCircle className="w-3.5 h-3.5" />
+                        Getting Started
+                      </button>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-3 bg-base-100/50 p-2 rounded-lg shadow-sm">
+                    <span className="text-sm font-medium opacity-80">Static Layout</span>
+                    <Toggle
+                      color="primary"
+                      checked={useWidgetLayout}
+                      onChange={(e) => setUseWidgetLayout(e.target.checked)}
+                      aria-label="Toggle widget dashboard layout"
+                    />
+                    <span className="text-sm font-medium text-primary">Widgets Layout</span>
+                  </div>
+                </div>
+
+                <QuickActions onRefresh={() => {}} />
+
+                {useWidgetLayout ? (
+                  <div className="animate-in fade-in duration-300">
+                    <DashboardWidgetSystem />
+                  </div>
+                ) : (
+                  <div className="animate-in fade-in duration-300">
+                    <Dashboard />
+                  </div>
+                )}
+
+                <div className="divider mx-4" />
+
+                <div className="px-4 pb-4">
+                  <h3 className="text-sm font-bold uppercase tracking-wider text-base-content/60 mb-4">System Health</h3>
+                  <Suspense fallback={<SuspenseFallback />}>
+                    <SystemHealth refreshInterval={30000} />
+                  </Suspense>
+                </div>
+              </div>
+            )}
+
+            {activeTab === 'activity' && (
+              <Suspense fallback={<SuspenseFallback />}>
+                <ActivityPage />
+              </Suspense>
+            )}
+
+            {activeTab === 'monitoring' && (
+              <Suspense fallback={<SuspenseFallback />}>
+                <MonitoringDashboard />
+              </Suspense>
+            )}
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
 };
 
 export default OverviewPage;

--- a/src/client/src/pages/PersonasPage/index.tsx
+++ b/src/client/src/pages/PersonasPage/index.tsx
@@ -1,5 +1,6 @@
-import { Copy, Edit2, Filter, Plus, Trash2 } from 'lucide-react';
+import { Copy, Edit2, Filter, Plus, Settings, Trash2, Users } from 'lucide-react';
 import React, { useCallback, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Alert } from '../../components/DaisyUI/Alert';
 import { Badge } from '../../components/DaisyUI/Badge';
 import Button from '../../components/DaisyUI/Button';
@@ -10,6 +11,8 @@ import Divider from '../../components/DaisyUI/Divider';
 import Join from '../../components/DaisyUI/Join';
 import Select from '../../components/DaisyUI/Select';
 import { SkeletonPage } from '../../components/DaisyUI/Skeleton';
+import Tabs from '../../components/DaisyUI/Tabs';
+import Toggle from '../../components/DaisyUI/Toggle';
 import { useSuccessToast, useErrorToast, useInfoToast } from '../../components/DaisyUI/ToastNotification';
 import Tooltip from '../../components/DaisyUI/Tooltip';
 import SearchFilterBar from '../../components/SearchFilterBar';
@@ -31,11 +34,130 @@ const CATEGORIES = [
   { id: 'support', label: 'Customer Support' },
 ];
 
+/** Persona Settings tab (placeholder — no settings API yet) */
+const PersonaSettingsTab: React.FC<{ personas: Persona[] }> = ({ personas }) => {
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  return (
+    <div className="space-y-6">
+      <Card className="shadow-md border border-base-200">
+        <div className="flex items-center gap-2 mb-4">
+          <Settings className="w-5 h-5 text-primary" />
+          <h3 className="text-lg font-semibold">Persona Defaults</h3>
+        </div>
+
+        <div className="space-y-4">
+          {/* Default persona selection */}
+          <div className="form-control">
+            <label className="label">
+              <span className="label-text font-medium">Default Persona</span>
+            </label>
+            <Select
+              disabled
+              value=""
+              options={[
+                { value: '', label: 'Select a default persona...' },
+                ...personas.map((p) => ({ value: p.id, label: p.name })),
+              ]}
+            />
+            <label className="label">
+              <span className="label-text-alt text-base-content/50">
+                The persona assigned to new bots by default.
+              </span>
+            </label>
+          </div>
+
+          {/* Response behavior defaults */}
+          <Divider>Response Behavior</Divider>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 opacity-50 pointer-events-none">
+            <div className="form-control">
+              <label className="label">
+                <span className="label-text">Temperature</span>
+              </label>
+              <input
+                type="range"
+                className="range range-primary range-sm"
+                min={0}
+                max={100}
+                value={70}
+                readOnly
+              />
+              <span className="text-xs text-base-content/50 mt-1">0.7</span>
+            </div>
+            <div className="form-control">
+              <label className="label">
+                <span className="label-text">Max Tokens</span>
+              </label>
+              <input
+                type="number"
+                className="input input-bordered input-sm"
+                value={2048}
+                readOnly
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-6 p-4 bg-info/10 rounded-lg text-info text-sm">
+          Persona settings coming soon. These controls will be connected in a future release.
+        </div>
+      </Card>
+
+      {/* Advanced toggle */}
+      <Card className="shadow-md border border-base-200">
+        <Toggle
+          label="Advanced"
+          checked={showAdvanced}
+          onChange={() => setShowAdvanced((v) => !v)}
+          color="primary"
+        />
+        {showAdvanced && (
+          <div className="mt-4 space-y-4 animate-fadeIn">
+            <Divider>Advanced Persona Settings</Divider>
+            <div className="form-control opacity-50 pointer-events-none">
+              <label className="label">
+                <span className="label-text">Persona Ordering</span>
+              </label>
+              <Select
+                disabled
+                value="alphabetical"
+                options={[
+                  { value: 'alphabetical', label: 'Alphabetical' },
+                  { value: 'custom', label: 'Custom Order' },
+                  { value: 'most-used', label: 'Most Used First' },
+                ]}
+              />
+            </div>
+            <div className="form-control opacity-50 pointer-events-none">
+              <label className="label">
+                <span className="label-text">Auto-Assignment Rules</span>
+              </label>
+              <Select
+                disabled
+                value="none"
+                options={[
+                  { value: 'none', label: 'No Auto-Assignment' },
+                  { value: 'round-robin', label: 'Round Robin' },
+                  { value: 'category-match', label: 'Category Match' },
+                ]}
+              />
+            </div>
+            <div className="p-4 bg-info/10 rounded-lg text-info text-sm">
+              Advanced persona settings coming soon.
+            </div>
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+};
+
 const PersonasPage: React.FC = () => {
   const successToast = useSuccessToast();
   const errorToast = useErrorToast();
   const infoToast = useInfoToast();
   const isMobile = useIsBelowBreakpoint('md');
+  const [searchParams, setSearchParams] = useSearchParams();
   const [error, setError] = useState<string | null>(null);
   const [selectedPersona, setSelectedPersona] = useState<Persona | null>(null);
 
@@ -119,43 +241,72 @@ const PersonasPage: React.FC = () => {
     onReorder: handlePersonaReorder,
   });
 
+  const activeTab = searchParams.get('tab') || 'profiles';
+  const handleTabChange = (tabId: string) => {
+    setSearchParams(tabId === 'profiles' ? {} : { tab: tabId }, { replace: true });
+  };
+
   if (dataLoading) return <SkeletonPage variant="cards" statsCount={3} showFilters />;
 
   const displayError = error || dataError;
 
   return (
     <div className="space-y-6">
-      {displayError && <Alert status="error" message={displayError} onClose={() => setError(null)} />}
+      {displayError && (
+        <Alert status="error" message={displayError} onClose={() => setError(null)} />
+      )}
 
-      <PersonaStats personas={personas} />
+      <Tabs
+        variant="lifted"
+        activeTab={activeTab}
+        onChange={handleTabChange}
+        tabs={[
+          {
+            id: 'profiles',
+            label: 'Profiles',
+            icon: <Users className="w-4 h-4" />,
+            content: (
+              <div className="space-y-6">
+                <PersonaStats personas={personas} />
 
-      <Card className="shadow-xl border border-base-200">
-          <SearchFilterBar
-            searchValue={searchQuery}
-            onSearchChange={setSearchQuery}
-            searchPlaceholder="Search personas by name or description..."
-          >
-            {/* Category filter hidden — roadmap: user-defined categories */}
-          </SearchFilterBar>
+                <Card className="shadow-xl border border-base-200">
+                  <SearchFilterBar
+                    searchValue={searchQuery}
+                    onSearchChange={setSearchQuery}
+                    searchPlaceholder="Search personas by name or description..."
+                  >
+                    {/* Category filter hidden — roadmap: user-defined categories */}
+                  </SearchFilterBar>
 
-          {!displayError && filteredPersonas.length > 0 && (
-            <PersonaList
-              filteredPersonas={filteredPersonas}
-              filteredPersonaIds={filteredPersonaIds}
-              bulk={bulk}
-              bulkDeleting={bulkDeleting}
-              handleBulkDeletePersonas={handleBulkDeletePersonas}
-              openEditModal={openEditModal}
-              onSelectPersona={setSelectedPersona}
-              isMobile={isMobile}
-              onDragStart={onDragStart}
-              onDragOver={onDragOver}
-              onDragEnd={onDragEnd}
-              onDrop={onDrop}
-              getItemStyle={getItemStyle}
-            />
-          )}
-      </Card>
+                  {!displayError && filteredPersonas.length > 0 && (
+                    <PersonaList
+                      filteredPersonas={filteredPersonas}
+                      filteredPersonaIds={filteredPersonaIds}
+                      bulk={bulk}
+                      bulkDeleting={bulkDeleting}
+                      handleBulkDeletePersonas={handleBulkDeletePersonas}
+                      openEditModal={openEditModal}
+                      onSelectPersona={setSelectedPersona}
+                      isMobile={isMobile}
+                      onDragStart={onDragStart}
+                      onDragOver={onDragOver}
+                      onDragEnd={onDragEnd}
+                      onDrop={onDrop}
+                      getItemStyle={getItemStyle}
+                    />
+                  )}
+                </Card>
+              </div>
+            ),
+          },
+          {
+            id: 'settings',
+            label: 'Settings',
+            icon: <Settings className="w-4 h-4" />,
+            content: <PersonaSettingsTab personas={personas} />,
+          },
+        ]}
+      />
 
       {/* Persona Detail Drawer */}
       <DetailDrawer
@@ -214,18 +365,20 @@ const PersonasPage: React.FC = () => {
               {selectedPersona.category && (
                 <Badge variant="neutral">{selectedPersona.category}</Badge>
               )}
-              {selectedPersona.isBuiltIn && (
-                <Badge variant="info">Built-in</Badge>
-              )}
+              {selectedPersona.isBuiltIn && <Badge variant="info">Built-in</Badge>}
             </div>
 
             {/* Assigned Bots */}
             {(selectedPersona.assignedBotNames?.length ?? 0) > 0 && (
               <Card className="bg-base-200">
-                <h4 className="font-semibold text-sm uppercase tracking-wide text-base-content/60 mb-2">Assigned Bots</h4>
+                <h4 className="font-semibold text-sm uppercase tracking-wide text-base-content/60 mb-2">
+                  Assigned Bots
+                </h4>
                 <div className="flex flex-wrap gap-2">
                   {selectedPersona.assignedBotNames?.map((name) => (
-                    <Badge key={name} variant="primary" size="sm">{name}</Badge>
+                    <Badge key={name} variant="primary" size="sm">
+                      {name}
+                    </Badge>
                   ))}
                 </div>
               </Card>
@@ -234,7 +387,9 @@ const PersonasPage: React.FC = () => {
             {/* System Prompt */}
             {selectedPersona.systemPrompt && (
               <div>
-                <h4 className="font-semibold text-sm uppercase tracking-wide text-base-content/60 mb-2">System Prompt</h4>
+                <h4 className="font-semibold text-sm uppercase tracking-wide text-base-content/60 mb-2">
+                  System Prompt
+                </h4>
                 <div className="bg-base-200 rounded-lg p-3 max-h-64 overflow-y-auto">
                   <pre className="text-sm whitespace-pre-wrap break-words font-mono text-base-content/80">
                     {selectedPersona.systemPrompt}
@@ -275,10 +430,17 @@ const PersonasPage: React.FC = () => {
       {/* Delete Confirmation Modal */}
       <ConfirmModal
         isOpen={showDeleteModal && !!deletingPersona}
-        onClose={() => { setShowDeleteModal(false); setDeletingPersona(null); }}
+        onClose={() => {
+          setShowDeleteModal(false);
+          setDeletingPersona(null);
+        }}
         onConfirm={handleConfirmDelete}
         title="Delete Persona"
-        message={deletingPersona ? `Are you sure you want to delete "${deletingPersona.name}"? Any bots assigned to this persona will be reset to the default persona.` : ''}
+        message={
+          deletingPersona
+            ? `Are you sure you want to delete "${deletingPersona.name}"? Any bots assigned to this persona will be reset to the default persona.`
+            : ''
+        }
         confirmText="Delete"
         cancelText="Cancel"
         confirmVariant="error"

--- a/src/client/src/router/AppRouter.tsx
+++ b/src/client/src/router/AppRouter.tsx
@@ -182,10 +182,10 @@ const AppRouter: React.FC = () => {
 
           <Route path="guards" element={<Navigate to="/admin/bots?tab=guards" replace />} />
 
-          {/* Activity — tabbed page (Feed, Monitoring, Live Dashboard) */}
-          <Route path="activity" element={<RouteErrorBoundary pageName="Activity"><ActivityManagementPage /></RouteErrorBoundary>} />
-          <Route path="monitoring" element={<Navigate to="/admin/activity?tab=monitoring" replace />} />
-          <Route path="monitoring-dashboard" element={<Navigate to="/admin/activity?tab=live" replace />} />
+          {/* Activity & Monitoring — now consolidated into Overview tabs */}
+          <Route path="activity" element={<Navigate to="/admin/overview?tab=activity" replace />} />
+          <Route path="monitoring" element={<Navigate to="/admin/overview?tab=monitoring" replace />} />
+          <Route path="monitoring-dashboard" element={<Navigate to="/admin/overview?tab=monitoring" replace />} />
           <Route path="analytics" element={<RouteErrorBoundary pageName="Analytics"><AnalyticsDashboard /></RouteErrorBoundary>} />
           <Route path="system-management" element={<RouteErrorBoundary pageName="System Management"><SystemManagement /></RouteErrorBoundary>} />
 


### PR DESCRIPTION
## Summary
- Refactored the Overview/Dashboard page into a tabbed layout with **Getting Started**, **Overview**, **Activity**, and **Monitoring** tabs using `<Tabs variant="lifted">`
- The Getting Started tab is conditional — it appears only when `localStorage('hivemind-show-getting-started')` is not `'false'` (default: visible for new users), and disappears when toggled off in Settings
- Activity and Monitoring pages are lazy-loaded as tabs, consolidating them from standalone sidebar items into the Overview page
- Merged the old Health tab content into the Overview tab as a "System Health" section
- Removed Activity from the sidebar navigation; old `/admin/activity` and `/admin/monitoring` routes now redirect to the appropriate Overview tab
- Added an "Aesthetic Preferences" card in Settings > General with a "Show Getting Started tab" toggle

## Test plan
- [ ] Navigate to `/admin/overview` — should show the tabbed layout with Overview as default tab
- [ ] Click each tab (Getting Started, Overview, Activity, Monitoring) — verify content loads and URL updates with `?tab=` param
- [ ] Go to Settings > General — verify the "Aesthetic Preferences" card appears with a "Show Getting Started tab" toggle
- [ ] Disable the toggle — Getting Started tab should disappear from the Overview page
- [ ] Re-enable it — tab reappears
- [ ] Navigate to `/admin/activity` — should redirect to `/admin/overview?tab=activity`
- [ ] Navigate to `/admin/monitoring` — should redirect to `/admin/overview?tab=monitoring`
- [ ] Verify sidebar no longer shows Activity as a standalone item