### PR TITLE
feat(ui): tabbed layout for LLM Providers page

### DIFF
--- a/src/client/src/components/Marketplace/MarketplaceCard.tsx
+++ b/src/client/src/components/Marketplace/MarketplaceCard.tsx
@@ -1,0 +1,217 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from 'react';
+import Card from '../DaisyUI/Card';
+import Button from '../DaisyUI/Button';
+import Badge from '../DaisyUI/Badge';
+import {
+  Download as DownloadIcon,
+  RefreshCw as UpdateIcon,
+  Trash2 as UninstallIcon,
+  Star as StarIcon,
+  ExternalLink as ExternalLinkIcon,
+  Brain as LLMIcon,
+  MessageCircle as MessageIcon,
+  Database as MemoryIcon,
+  Wrench as ToolIcon,
+} from 'lucide-react';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MarketplacePackage {
+  name: string;
+  displayName: string;
+  description: string;
+  type: 'llm' | 'message' | 'memory' | 'tool';
+  version: string;
+  status: 'built-in' | 'installed' | 'available';
+  repoUrl?: string;
+  feedbackUrl?: string;
+  rating?: number;
+  installedAt?: string;
+  updatedAt?: string;
+}
+
+export interface MarketplaceCardProps {
+  pkg: MarketplacePackage;
+  isBusy?: boolean;
+  actionInProgress?: string | null;
+  userRating?: number;
+  onRate?: (pkgName: string, star: number) => void;
+  onInstall?: (pkg: MarketplacePackage) => void;
+  onUpdate?: (name: string) => void;
+  onUninstall?: (name: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TYPE_ICONS = {
+  llm: LLMIcon,
+  message: MessageIcon,
+  memory: MemoryIcon,
+  tool: ToolIcon,
+} as const;
+
+const TYPE_COLORS = {
+  llm: 'secondary',
+  message: 'primary',
+  memory: 'accent',
+  tool: 'info',
+} as const;
+
+const STATUS_BADGES = {
+  'built-in': { label: 'Built-in', color: 'neutral' as const },
+  installed: { label: 'Installed', color: 'success' as const },
+  available: { label: 'Available', color: 'info' as const },
+} as const;
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+const MarketplaceCard: React.FC<MarketplaceCardProps> = ({
+  pkg,
+  isBusy = false,
+  actionInProgress,
+  userRating,
+  onRate,
+  onInstall,
+  onUpdate,
+  onUninstall,
+}) => {
+  const Icon = TYPE_ICONS[pkg.type];
+  const color = TYPE_COLORS[pkg.type];
+  const statusBadge = STATUS_BADGES[pkg.status];
+
+  return (
+    <Card className="bg-base-200 hover:bg-base-300 transition-colors">
+      <Card.Body className="p-4">
+        <div className="flex items-start justify-between mb-2">
+          <div className="flex items-center gap-2">
+            <div className={`p-2 rounded-lg bg-${color}/10`}>
+              <Icon className={`w-5 h-5 text-${color}`} />
+            </div>
+            <div>
+              <h3 className="font-semibold">{pkg.displayName}</h3>
+              <p className="text-xs text-base-content/50 font-mono">{pkg.name}</p>
+            </div>
+          </div>
+          <Badge variant={statusBadge.color} size="sm">
+            {statusBadge.label}
+          </Badge>
+        </div>
+
+        <p className="text-sm text-base-content/70 mb-3 line-clamp-2">
+          {pkg.description}
+        </p>
+
+        <div className="flex items-center justify-between text-xs text-base-content/50 mb-3">
+          <span>v{pkg.version}</span>
+          <span className="uppercase badge badge-sm badge-outline">{pkg.type}</span>
+        </div>
+
+        {/* Star Rating & Feedback */}
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-1" data-testid={`star-rating-${pkg.name}`}>
+            {[1, 2, 3, 4, 5].map((star) => (
+              <Button
+                key={star}
+                variant="ghost"
+                size="xs"
+                className="p-0"
+                data-testid={`star-${star}`}
+                onClick={() => onRate?.(pkg.name, star)}
+                aria-label={`Rate ${star} star${star > 1 ? 's' : ''}`}
+              >
+                <StarIcon
+                  className={`w-4 h-4 ${
+                    (userRating ?? pkg.rating ?? 0) >= star
+                      ? 'fill-warning text-warning'
+                      : 'text-base-content/30'
+                  }`}
+                />
+              </Button>
+            ))}
+          </div>
+          {pkg.feedbackUrl ? (
+            <a
+              href={pkg.feedbackUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="link link-primary text-xs flex items-center gap-1"
+              data-testid={`feedback-link-${pkg.name}`}
+            >
+              Feedback <ExternalLinkIcon className="w-3 h-3" />
+            </a>
+          ) : pkg.repoUrl ? (
+            <a
+              href={`${pkg.repoUrl}/issues`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="link link-primary text-xs flex items-center gap-1"
+              data-testid={`feedback-link-${pkg.name}`}
+            >
+              Feedback <ExternalLinkIcon className="w-3 h-3" />
+            </a>
+          ) : null}
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-2">
+          {pkg.status === 'installed' && (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                className="flex-1"
+                onClick={() => onUpdate?.(pkg.name)}
+                disabled={isBusy}
+              >
+                {actionInProgress === `update-${pkg.name}` ? (
+                  <span className="loading loading-spinner loading-xs" aria-hidden="true"></span>
+                ) : (
+                  <UpdateIcon className="w-4 h-4" />
+                )}
+                Update
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onUninstall?.(pkg.name)}
+                disabled={isBusy}
+              >
+                {actionInProgress === `uninstall-${pkg.name}` ? (
+                  <span className="loading loading-spinner loading-xs" aria-hidden="true"></span>
+                ) : (
+                  <UninstallIcon className="w-4 h-4 text-error" />
+                )}
+              </Button>
+            </>
+          )}
+          {pkg.status === 'available' && (
+            <Button
+              variant="primary"
+              size="sm"
+              className="flex-1"
+              onClick={() => onInstall?.(pkg)}
+              disabled={isBusy}
+            >
+              <DownloadIcon className="w-4 h-4 mr-1" />
+              Install
+            </Button>
+          )}
+          {pkg.status === 'built-in' && (
+            <span className="text-xs text-base-content/50 italic w-full text-center">
+              Included with open-hivemind
+            </span>
+          )}
+        </div>
+      </Card.Body>
+    </Card>
+  );
+};
+
+export default MarketplaceCard;

--- a/src/client/src/components/Marketplace/MarketplaceGrid.tsx
+++ b/src/client/src/components/Marketplace/MarketplaceGrid.tsx
@@ -1,0 +1,269 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React, { useState, useEffect, useMemo } from 'react';
+import { apiService } from '../../services/api';
+import Button from '../DaisyUI/Button';
+import {
+  Store as StoreIcon,
+  Search as SearchIcon,
+  AlertCircle as AlertIcon,
+  CheckCircle as CheckIcon,
+  X as CloseIcon,
+  AlertTriangle as WarningIcon,
+} from 'lucide-react';
+import MarketplaceCard from './MarketplaceCard';
+import type { MarketplacePackage } from './MarketplaceCard';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MarketplaceGridProps {
+  /** Filter packages by type (e.g. "llm", "message") */
+  filter?: string;
+  onInstall?: (pkg: MarketplacePackage) => void;
+  onUninstall?: (name: string) => void;
+  onUpdate?: (name: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+const MarketplaceGrid: React.FC<MarketplaceGridProps> = ({
+  filter,
+  onInstall: externalOnInstall,
+  onUninstall: externalOnUninstall,
+  onUpdate: externalOnUpdate,
+}) => {
+  const [packages, setPackages] = useState<MarketplacePackage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [actionInProgress, setActionInProgress] = useState<string | null>(null);
+  const [actionMessage, setActionMessage] = useState<{
+    type: 'success' | 'error';
+    text: string;
+  } | null>(null);
+  const [ratings, setRatings] = useState<Record<string, number>>({});
+
+  const hasCommunityPackages = useMemo(
+    () => packages.some((pkg) => pkg.status !== 'built-in'),
+    [packages],
+  );
+
+  const fetchPackages = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data: any = await apiService.get('/api/marketplace/packages');
+      setPackages(data?.data || data || []);
+    } catch (err: unknown) {
+      setError(
+        (err instanceof Error ? err.message : String(err)) || 'Failed to load marketplace',
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchPackages();
+  }, []);
+
+  const filteredPackages = useMemo(() => {
+    return packages.filter((pkg) => {
+      const matchesType = !filter || pkg.type === filter;
+      const matchesSearch =
+        searchQuery === '' ||
+        pkg.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        pkg.displayName.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        pkg.description.toLowerCase().includes(searchQuery.toLowerCase());
+      return matchesType && matchesSearch;
+    });
+  }, [packages, filter, searchQuery]);
+
+  const handleRating = (pkgName: string, starValue: number) => {
+    setRatings((prev) => ({ ...prev, [pkgName]: starValue }));
+  };
+
+  const handleInstall = (pkg: MarketplacePackage) => {
+    if (externalOnInstall) {
+      externalOnInstall(pkg);
+      return;
+    }
+    if (!pkg.repoUrl) return;
+    (async () => {
+      setActionInProgress('install-url');
+      setActionMessage(null);
+      try {
+        const result: any = await apiService.post('/api/marketplace/install', {
+          repoUrl: pkg.repoUrl,
+        });
+        const data = result?.data || result;
+        setActionMessage({
+          type: 'success',
+          text: `Installed ${data?.package?.displayName || pkg.displayName} successfully!`,
+        });
+        await fetchPackages();
+      } catch (err: unknown) {
+        setActionMessage({
+          type: 'error',
+          text: (err instanceof Error ? err.message : String(err)) || 'Installation failed',
+        });
+      } finally {
+        setActionInProgress(null);
+      }
+    })();
+  };
+
+  const handleUpdate = async (name: string) => {
+    if (externalOnUpdate) {
+      externalOnUpdate(name);
+      return;
+    }
+    setActionInProgress(`update-${name}`);
+    setActionMessage(null);
+    try {
+      const result: any = await apiService.post(`/api/marketplace/update/${name}`, {});
+      const data = result?.data || result;
+      setActionMessage({
+        type: 'success',
+        text: `Updated ${data?.package?.displayName || name} successfully!`,
+      });
+      await fetchPackages();
+    } catch (err: unknown) {
+      setActionMessage({
+        type: 'error',
+        text: (err instanceof Error ? err.message : String(err)) || 'Update failed',
+      });
+    } finally {
+      setActionInProgress(null);
+    }
+  };
+
+  const handleUninstall = async (name: string) => {
+    if (externalOnUninstall) {
+      externalOnUninstall(name);
+      return;
+    }
+    if (!confirm(`Are you sure you want to uninstall ${name}?`)) return;
+    setActionInProgress(`uninstall-${name}`);
+    setActionMessage(null);
+    try {
+      await apiService.post(`/api/marketplace/uninstall/${name}`, {});
+      setActionMessage({ type: 'success', text: `Uninstalled ${name} successfully!` });
+      await fetchPackages();
+    } catch (err: unknown) {
+      setActionMessage({
+        type: 'error',
+        text: (err instanceof Error ? err.message : String(err)) || 'Uninstall failed',
+      });
+    } finally {
+      setActionInProgress(null);
+    }
+  };
+
+  return (
+    <div>
+      {/* Alert Messages */}
+      {actionMessage && (
+        <div
+          className={`alert mb-4 ${actionMessage.type === 'success' ? 'alert-success' : 'alert-error'}`}
+        >
+          {actionMessage.type === 'success' ? (
+            <CheckIcon className="w-5 h-5" />
+          ) : (
+            <AlertIcon className="w-5 h-5" />
+          )}
+          <span>{actionMessage.text}</span>
+          <Button variant="ghost" size="xs" onClick={() => setActionMessage(null)}>
+            <CloseIcon className="w-4 h-4" />
+          </Button>
+        </div>
+      )}
+
+      {/* Community Packages Warning */}
+      {hasCommunityPackages && (
+        <div className="alert alert-warning mb-4" data-testid="community-warning-banner">
+          <WarningIcon className="w-5 h-5" />
+          <span>
+            Community packages are not officially maintained. Review source code and permissions
+            before installing.
+          </span>
+        </div>
+      )}
+
+      {/* Error State */}
+      {error && (
+        <div className="alert alert-error mb-4">
+          <AlertIcon className="w-5 h-5" />
+          <span>{error}</span>
+          <Button variant="outline" size="xs" onClick={fetchPackages}>
+            Retry
+          </Button>
+        </div>
+      )}
+
+      {/* Search */}
+      <div className="mb-6">
+        <div className="relative">
+          <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-base-content/50" />
+          <input
+            type="text"
+            placeholder="Search packages..."
+            className="input input-bordered w-full pl-10"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
+        </div>
+      </div>
+
+      {/* Loading State */}
+      {loading && (
+        <div className="flex items-center justify-center py-12">
+          <span
+            className="loading loading-spinner loading-lg text-primary"
+            aria-hidden="true"
+          ></span>
+        </div>
+      )}
+
+      {/* Empty State */}
+      {!loading && filteredPackages.length === 0 && (
+        <div className="text-center py-12">
+          <StoreIcon className="w-16 h-16 mx-auto text-base-content/30 mb-4" />
+          <p className="text-lg text-base-content/70">No packages found</p>
+          <p className="text-sm text-base-content/50">Try adjusting your search or filter</p>
+        </div>
+      )}
+
+      {/* Package Grid */}
+      {!loading && filteredPackages.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {filteredPackages.map((pkg) => {
+            const isBusy =
+              actionInProgress?.startsWith(pkg.name) ||
+              actionInProgress === `update-${pkg.name}` ||
+              actionInProgress === `uninstall-${pkg.name}`;
+
+            return (
+              <MarketplaceCard
+                key={pkg.name}
+                pkg={pkg}
+                isBusy={!!isBusy}
+                actionInProgress={actionInProgress}
+                userRating={ratings[pkg.name]}
+                onRate={handleRating}
+                onInstall={handleInstall}
+                onUpdate={handleUpdate}
+                onUninstall={handleUninstall}
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MarketplaceGrid;

--- a/src/client/src/components/Marketplace/index.ts
+++ b/src/client/src/components/Marketplace/index.ts
@@ -1,0 +1,4 @@
+export { default as MarketplaceCard } from './MarketplaceCard';
+export { default as MarketplaceGrid } from './MarketplaceGrid';
+export type { MarketplacePackage, MarketplaceCardProps } from './MarketplaceCard';
+export type { MarketplaceGridProps } from './MarketplaceGrid';

--- a/src/client/src/pages/LLMProvidersPage.tsx
+++ b/src/client/src/pages/LLMProvidersPage.tsx
@@ -1,14 +1,18 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars */
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { useModal } from '../hooks/useModal';
 import Card from '../components/DaisyUI/Card';
 import Button from '../components/DaisyUI/Button';
 import Badge from '../components/DaisyUI/Badge';
+import Tabs from '../components/DaisyUI/Tabs';
+import Toggle from '../components/DaisyUI/Toggle';
 import { Alert } from '../components/DaisyUI/Alert';
 import StatsCards from '../components/DaisyUI/StatsCards';
 import EmptyState from '../components/DaisyUI/EmptyState';
 import { LoadingSpinner } from '../components/DaisyUI/Loading';
 import SearchFilterBar from '../components/SearchFilterBar';
+import { MarketplaceGrid } from '../components/Marketplace';
 import {
   Brain as BrainIcon,
   Plus as AddIcon,
@@ -27,6 +31,12 @@ import {
   RefreshCw,
   ToggleLeft as ToggleOffIcon,
   ToggleRight as ToggleOnIcon,
+  Search as SearchIcon,
+  Clock as ClockIcon,
+  Reply as ReplyIcon,
+  Coffee as CoffeeIcon,
+  Monitor as MonitorIcon,
+  Store as StoreIcon,
 } from 'lucide-react';
 import type { LLMProviderType } from '../types/bot';
 import { LLM_PROVIDER_CONFIGS } from '../types/bot';
@@ -52,16 +62,580 @@ const isEmbeddingCapable = (profile: any): boolean => {
   return modelType === 'embedding' || modelType === 'both';
 };
 
+// ---------------------------------------------------------------------------
+// Profiles Tab Content
+// ---------------------------------------------------------------------------
+
+const ProfilesTab: React.FC<{
+  profiles: any[];
+  filteredProfiles: any[];
+  providerTypes: { label: string; value: string }[];
+  stats: any[];
+  loading: boolean;
+  error: string | null;
+  searchQuery: string;
+  filterType: string;
+  defaultChatbotProfile: string;
+  webuiIntelligenceProvider: string;
+  defaultEmbeddingProvider: string;
+  libraryStatus: Record<string, { installed: boolean; package: string }>;
+  expandedProfile: string | null;
+  onSearchChange: (q: string) => void;
+  onFilterChange: (f: string) => void;
+  onClearError: () => void;
+  onRefresh: () => void;
+  onAddProfile: () => void;
+  onEditProfile: (profile: any) => void;
+  onDeleteProfile: (key: string) => void;
+  onToggleExpand: (key: string) => void;
+}> = ({
+  profiles,
+  filteredProfiles,
+  providerTypes,
+  stats,
+  loading,
+  error,
+  searchQuery,
+  filterType,
+  defaultChatbotProfile,
+  webuiIntelligenceProvider,
+  defaultEmbeddingProvider,
+  libraryStatus,
+  expandedProfile,
+  onSearchChange,
+  onFilterChange,
+  onClearError,
+  onRefresh,
+  onAddProfile,
+  onEditProfile,
+  onDeleteProfile,
+  onToggleExpand,
+}) => {
+  const getProviderIcon = (type: string) => {
+    const config = LLM_PROVIDER_CONFIGS[type as LLMProviderType];
+    return config?.icon || <BrainIcon className="w-5 h-5" />;
+  };
+
+  const renderLibraryCheck = (type: string) => {
+    const status = libraryStatus[type];
+    if (!status?.installed)
+      return status ? (
+        <div className="tooltip tooltip-bottom" data-tip={`Missing: ${status.package}`}>
+          <Badge variant="error" size="small" className="gap-1 cursor-help">
+            <XIcon className="w-3 h-3" /> Lib Missing
+          </Badge>
+        </div>
+      ) : null;
+    return null;
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-end mb-4">
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={onRefresh} disabled={loading} aria-busy={loading}>
+            <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} /> Refresh
+          </Button>
+          <Button variant="primary" onClick={onAddProfile}>
+            <AddIcon className="w-4 h-4 mr-2" /> Create Profile
+          </Button>
+        </div>
+      </div>
+
+      <StatsCards stats={stats} isLoading={loading} />
+
+      {error && (
+        <Alert status="error" icon={<XIcon />} message={error} onClose={onClearError} />
+      )}
+
+      <SearchFilterBar
+        searchValue={searchQuery}
+        onSearchChange={onSearchChange}
+        searchPlaceholder="Search profiles..."
+        filters={[
+          {
+            key: 'type',
+            value: filterType,
+            onChange: onFilterChange,
+            options: [{ label: 'All Types', value: 'all' }, ...providerTypes],
+            className: 'w-48',
+          },
+        ]}
+      />
+
+      {loading ? (
+        <div className="flex justify-center py-12">
+          <LoadingSpinner size="lg" />
+        </div>
+      ) : profiles.length === 0 ? (
+        <EmptyState
+          icon={BrainIcon}
+          title="No Profiles Created"
+          description="Create a custom profile to override system defaults for specific bots."
+          actionLabel="Create Profile"
+          actionIcon={AddIcon}
+          onAction={onAddProfile}
+          variant="noData"
+        />
+      ) : filteredProfiles.length === 0 ? (
+        <EmptyState
+          icon={Search}
+          title="No matching profiles"
+          description="Try adjusting your search or filters."
+          actionLabel="Clear Filters"
+          onAction={() => {
+            onSearchChange('');
+            onFilterChange('all');
+          }}
+          variant="noResults"
+        />
+      ) : (
+        <div className="grid grid-cols-1 gap-4">
+          {filteredProfiles.map((profile) => (
+            <Card
+              key={profile.key}
+              className="bg-base-100 shadow-sm border border-base-200 transition-all hover:shadow-md"
+            >
+              <div className="card-body p-0">
+                <div
+                  className="p-4 flex items-center justify-between cursor-pointer"
+                  onClick={() => onToggleExpand(profile.key)}
+                >
+                  <div className="flex items-center gap-4">
+                    <div className="p-3 bg-primary/10 text-primary rounded-xl">
+                      {getProviderIcon(profile.provider)}
+                    </div>
+                    <div>
+                      <h3 className="font-bold text-lg flex items-center gap-2">
+                        {profile.name}
+                        <span className="text-xs font-normal opacity-50 px-2 py-0.5 bg-base-200 rounded-full font-mono">
+                          {profile.key}
+                        </span>
+                      </h3>
+                      <div className="flex items-center gap-2 mt-1">
+                        <Badge variant="secondary" size="small" style="outline">
+                          {profile.provider}
+                        </Badge>
+                        <Badge
+                          variant={
+                            normalizeModelType(profile.modelType) === 'embedding'
+                              ? 'warning'
+                              : normalizeModelType(profile.modelType) === 'both'
+                                ? 'info'
+                                : 'neutral'
+                          }
+                          size="small"
+                        >
+                          {normalizeModelType(profile.modelType)}
+                        </Badge>
+                        {renderLibraryCheck(profile.provider)}
+                        {profile.key === defaultChatbotProfile && (
+                          <Badge variant="primary" size="small">
+                            Default Chatbot
+                          </Badge>
+                        )}
+                        {profile.key === webuiIntelligenceProvider && (
+                          <Badge variant="warning" size="small">
+                            WebUI AI
+                          </Badge>
+                        )}
+                        {profile.key === defaultEmbeddingProvider && (
+                          <Badge variant="secondary" size="small">
+                            Default Embedding
+                          </Badge>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex gap-2" onClick={(e) => e.stopPropagation()}>
+                    <Button size="sm" variant="outline" onClick={() => onEditProfile(profile)}>
+                      <EditIcon className="w-4 h-4" />
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="text-error hover:bg-error/10"
+                      onClick={() => onDeleteProfile(profile.key)}
+                    >
+                      <DeleteIcon className="w-4 h-4" />
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => onToggleExpand(profile.key)}
+                    >
+                      {expandedProfile === profile.key ? (
+                        <CollapseIcon className="w-4 h-4" />
+                      ) : (
+                        <ExpandIcon className="w-4 h-4" />
+                      )}
+                    </Button>
+                  </div>
+                </div>
+
+                {expandedProfile === profile.key && (
+                  <div className="px-4 pb-4 pt-0">
+                    <div className="bg-base-200/50 rounded-xl p-4 border border-base-200">
+                      <h4 className="text-xs font-bold uppercase opacity-50 mb-3 flex items-center gap-2">
+                        <ConfigIcon className="w-3 h-3" /> Configuration
+                      </h4>
+                      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                        {Object.entries(profile.config || {}).map(([k, v]) => (
+                          <div
+                            key={k}
+                            className="bg-base-100 p-2 rounded border border-base-200/50 flex flex-col"
+                          >
+                            <span className="font-mono text-[10px] opacity-50 uppercase tracking-wider mb-1">
+                              {k}
+                            </span>
+                            <span className="font-medium text-sm truncate" title={String(v)}>
+                              {String(k).toLowerCase().includes('key') ||
+                              String(k).toLowerCase().includes('token') ||
+                              String(k).toLowerCase().includes('password')
+                                ? '\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022'
+                                : String(v)}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Settings Tab Content
+// ---------------------------------------------------------------------------
+
+const SettingsTab: React.FC<{
+  profiles: any[];
+  defaultStatus: any;
+  loading: boolean;
+  defaultChatbotProfile: string;
+  defaultEmbeddingProvider: string;
+  webuiIntelligenceProvider: string;
+  perUseCaseEnabled: boolean;
+  taskProfiles: Record<string, string>;
+  chatProfiles: any[];
+  embeddingProfiles: any[];
+  onDefaultChatbotChange: (val: string) => void;
+  onDefaultEmbeddingChange: (val: string) => void;
+  onWebuiIntelligenceChange: (val: string) => void;
+  onPerUseCaseChange: (val: boolean) => void;
+  onTaskProfileChange: (key: string, val: string) => void;
+}> = ({
+  defaultStatus,
+  loading,
+  defaultChatbotProfile,
+  defaultEmbeddingProvider,
+  webuiIntelligenceProvider,
+  perUseCaseEnabled,
+  taskProfiles,
+  chatProfiles,
+  embeddingProfiles,
+  onDefaultChatbotChange,
+  onDefaultEmbeddingChange,
+  onWebuiIntelligenceChange,
+  onPerUseCaseChange,
+  onTaskProfileChange,
+}) => {
+  const [advancedMode, setAdvancedMode] = useState(false);
+
+  const getProviderIcon = (type: string) => {
+    const config = LLM_PROVIDER_CONFIGS[type as LLMProviderType];
+    return config?.icon || <BrainIcon className="w-5 h-5" />;
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Basic Settings -- always visible */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {/* Default Chatbot LLM Profile */}
+        <Card className="bg-base-100 shadow-sm border border-base-200">
+          <div className="card-body p-5">
+            <h3 className="font-bold flex items-center gap-2 mb-1">
+              <ChatIcon className="w-4 h-4 text-primary" /> Default Chatbot Profile
+            </h3>
+            <p className="text-xs opacity-60 mb-3">
+              Profile used for all bot chat responses when per-use-case mode is off.
+            </p>
+            <div className="form-control w-full">
+              <select
+                className="select select-bordered select-sm w-full"
+                value={defaultChatbotProfile}
+                onChange={(e) => onDefaultChatbotChange(e.target.value)}
+                disabled={loading}
+                aria-busy={loading}
+              >
+                <option value="">Use System Default</option>
+                {chatProfiles.map((p) => (
+                  <option key={p.key} value={p.key}>
+                    {p.name} ({p.provider})
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </Card>
+
+        {/* Default Embedding Provider */}
+        <Card className="bg-base-100 shadow-sm border border-base-200">
+          <div className="card-body p-5">
+            <h3 className="font-bold flex items-center gap-2 mb-1">
+              <CpuIcon className="w-4 h-4 text-secondary" /> Default Embedding Provider
+            </h3>
+            <p className="text-xs opacity-60 mb-3">
+              Embedding-capable provider/profile used by memory and semantic search features.
+            </p>
+            <div className="form-control w-full">
+              <select
+                className="select select-bordered select-sm w-full"
+                value={defaultEmbeddingProvider}
+                onChange={(e) => onDefaultEmbeddingChange(e.target.value)}
+                disabled={loading}
+                aria-busy={loading}
+              >
+                <option value="">None Selected</option>
+                {embeddingProfiles.map((p) => (
+                  <option key={p.key} value={p.key}>
+                    {p.name} ({p.provider})
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </Card>
+      </div>
+
+      {/* Advanced Toggle */}
+      <div className="flex items-center gap-3 pt-2">
+        <Toggle
+          label="Advanced"
+          color="primary"
+          size="sm"
+          checked={advancedMode}
+          onChange={(e) => setAdvancedMode(e.target.checked)}
+        />
+      </div>
+
+      {/* Advanced Settings -- hidden behind toggle */}
+      {advancedMode && (
+        <div className="space-y-4">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            {/* System Default (env-var fallback) */}
+            <Card
+              className={`bg-base-100 shadow-sm border ${defaultStatus?.configured ? 'border-success/20' : 'border-warning/20'}`}
+            >
+              <div className="card-body p-5">
+                <div className="flex items-center justify-between mb-1">
+                  <h3 className="font-bold flex items-center gap-2">
+                    <ConfigIcon className="w-4 h-4" /> System Default
+                  </h3>
+                  {defaultStatus?.configured ? (
+                    <Badge variant="success" size="small">
+                      Active
+                    </Badge>
+                  ) : (
+                    <Badge variant="warning" size="small">
+                      Not Set
+                    </Badge>
+                  )}
+                </div>
+                <p className="text-xs opacity-60 mb-3">
+                  Fallback loaded from environment variables. Used when no profile is assigned.
+                </p>
+                {defaultStatus?.providers?.map((p: any) => (
+                  <div
+                    key={p.id}
+                    className="flex items-center gap-2 p-2 bg-base-200/50 rounded text-sm"
+                  >
+                    {getProviderIcon(p.type)}
+                    <span className="font-medium">{p.name}</span>
+                    <Badge variant="neutral" size="small" className="ml-auto">
+                      Read-Only
+                    </Badge>
+                  </div>
+                ))}
+                {!defaultStatus?.providers?.length && (
+                  <div className="alert alert-warning text-xs p-2">
+                    <WarningIcon className="w-4 h-4" />
+                    <span>No default provider in .env. Bots without a profile will fail.</span>
+                  </div>
+                )}
+              </div>
+            </Card>
+
+            {/* WebUI Intelligence */}
+            <Card className="bg-base-100 shadow-sm border border-base-200">
+              <div className="card-body p-5">
+                <h3 className="font-bold flex items-center gap-2 mb-1">
+                  <ZapIcon className="w-4 h-4 text-warning" /> WebUI Intelligence
+                </h3>
+                <p className="text-xs opacity-60 mb-3">
+                  Powers AI assistance features inside the WebUI (e.g. generating bot names).
+                </p>
+                <div className="form-control w-full">
+                  <select
+                    className="select select-bordered select-sm w-full"
+                    value={webuiIntelligenceProvider}
+                    onChange={(e) => onWebuiIntelligenceChange(e.target.value)}
+                    disabled={loading}
+                    aria-busy={loading}
+                  >
+                    <option value="">None (Disabled)</option>
+                    {chatProfiles.map((p) => (
+                      <option key={p.key} value={p.key}>
+                        {p.name} ({p.provider})
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+            </Card>
+          </div>
+
+          {/* Per-use-case toggle */}
+          <Card className="bg-base-100 shadow-sm border border-base-200">
+            <div className="card-body p-5 flex flex-row items-center justify-between">
+              <div>
+                <h3 className="font-bold flex items-center gap-2">
+                  {perUseCaseEnabled ? (
+                    <ToggleOnIcon className="w-5 h-5 text-primary" />
+                  ) : (
+                    <ToggleOffIcon className="w-5 h-5 opacity-40" />
+                  )}
+                  Per-Use-Case LLM Profiles
+                </h3>
+                <p className="text-xs opacity-60 mt-0.5">
+                  When enabled, assign different profiles to summarisation, moderation, and other
+                  tasks independently.
+                </p>
+              </div>
+              <input
+                type="checkbox"
+                className="toggle toggle-primary"
+                checked={perUseCaseEnabled}
+                onChange={(e) => onPerUseCaseChange(e.target.checked)}
+              />
+            </div>
+          </Card>
+
+          {/* Per-use-case task profile assignments */}
+          {perUseCaseEnabled && (
+            <Card className="bg-base-100 shadow-sm border border-primary/20">
+              <div className="card-body p-5">
+                <h3 className="font-bold flex items-center gap-2 mb-1">
+                  <BrainIcon className="w-4 h-4 text-primary" /> Task Profile Assignments
+                </h3>
+                <p className="text-xs opacity-60 mb-4">
+                  Assign a specific LLM profile to each task type. Leave as &quot;Use Default&quot;
+                  to fall back to the default chatbot profile.
+                </p>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  {(
+                    [
+                      {
+                        key: 'LLM_TASK_SEMANTIC_PROVIDER',
+                        label: 'Semantic Relevance',
+                        icon: <SearchIcon className="w-4 h-4 text-info" />,
+                        description:
+                          "Determines if a message is relevant to a bot's topic",
+                      },
+                      {
+                        key: 'LLM_TASK_SUMMARY_PROVIDER',
+                        label: 'Summarization',
+                        icon: <ClockIcon className="w-4 h-4 text-success" />,
+                        description: 'Generates conversation summaries and log prose',
+                      },
+                      {
+                        key: 'LLM_TASK_FOLLOWUP_PROVIDER',
+                        label: 'Follow-up',
+                        icon: <ReplyIcon className="w-4 h-4 text-warning" />,
+                        description: 'Generates follow-up questions and continuations',
+                      },
+                      {
+                        key: 'LLM_TASK_IDLE_PROVIDER',
+                        label: 'Idle Response',
+                        icon: <CoffeeIcon className="w-4 h-4 text-secondary" />,
+                        description: 'Handles idle/scheduled responses when no user input',
+                      },
+                      {
+                        key: 'LLM_TASK_WEBUI_PROVIDER',
+                        label: 'WebUI Intelligence',
+                        icon: <MonitorIcon className="w-4 h-4 text-accent" />,
+                        description:
+                          'Powers AI-assisted features within the web interface',
+                      },
+                    ] as const
+                  ).map(({ key, label, icon, description }) => (
+                    <div
+                      key={key}
+                      className="flex items-start gap-3 p-3 bg-base-200/40 rounded-lg border border-base-200"
+                    >
+                      <div className="mt-0.5">{icon}</div>
+                      <div className="flex-1 min-w-0">
+                        <label className="font-medium text-sm">{label}</label>
+                        <p className="text-[11px] opacity-50 mb-2">{description}</p>
+                        <select
+                          className="select select-bordered select-sm w-full"
+                          value={taskProfiles[key] || ''}
+                          onChange={(e) => onTaskProfileChange(key, e.target.value)}
+                          disabled={loading}
+                          aria-busy={loading}
+                        >
+                          <option value="">Use Default</option>
+                          {chatProfiles.map((p) => (
+                            <option key={p.key} value={p.key}>
+                              {p.name} ({p.provider})
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </Card>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Main Page Component
+// ---------------------------------------------------------------------------
+
 const LLMProvidersPage: React.FC = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = searchParams.get('tab') || 'profiles';
+
   const { modalState, openAddModal, openEditModal, closeModal } = useModal();
   const [profiles, setProfiles] = useState<any[]>([]);
   const [defaultStatus, setDefaultStatus] = useState<any>(null);
   const [expandedProfile, setExpandedProfile] = useState<string | null>(null);
-  const [libraryStatus, setLibraryStatus] = useState<Record<string, { installed: boolean; package: string }>>({});
+  const [libraryStatus, setLibraryStatus] = useState<
+    Record<string, { installed: boolean; package: string }>
+  >({});
   const [webuiIntelligenceProvider, setWebuiIntelligenceProvider] = useState<string>('');
   const [defaultChatbotProfile, setDefaultChatbotProfile] = useState<string>('');
   const [defaultEmbeddingProvider, setDefaultEmbeddingProvider] = useState<string>('');
   const [perUseCaseEnabled, setPerUseCaseEnabled] = useState<boolean>(false);
+  const [taskProfiles, setTaskProfiles] = useState<Record<string, string>>({
+    LLM_TASK_SEMANTIC_PROVIDER: '',
+    LLM_TASK_SUMMARY_PROVIDER: '',
+    LLM_TASK_FOLLOWUP_PROVIDER: '',
+    LLM_TASK_IDLE_PROVIDER: '',
+    LLM_TASK_WEBUI_PROVIDER: '',
+  });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
@@ -78,23 +652,41 @@ const LLMProvidersPage: React.FC = () => {
       const profilesRes = profilesResult.status === 'fulfilled' ? profilesResult.value : {};
       const statusRes = statusResult.status === 'fulfilled' ? statusResult.value : {};
       const globalRes = globalResult.status === 'fulfilled' ? globalResult.value : {};
-      setProfiles((profilesRes as any).llm || (profilesRes as any).profiles?.llm || []);
+      setProfiles(
+        (profilesRes as any).llm || (profilesRes as any).profiles?.llm || [],
+      );
       setDefaultStatus(statusRes);
       const gs = (globalRes as any)._userSettings?.values || {};
       const llmValues = (globalRes as any).llm?.values || {};
       setWebuiIntelligenceProvider(gs.webuiIntelligenceProvider || '');
       setDefaultChatbotProfile(gs.defaultChatbotProfile || '');
-      setDefaultEmbeddingProvider(llmValues.DEFAULT_EMBEDDING_PROVIDER || gs.defaultEmbeddingProfile || '');
+      setDefaultEmbeddingProvider(
+        llmValues.DEFAULT_EMBEDDING_PROVIDER || gs.defaultEmbeddingProfile || '',
+      );
       setPerUseCaseEnabled(!!gs.perUseCaseEnabled);
-      if ((statusRes as any).libraryStatus) setLibraryStatus((statusRes as any).libraryStatus);
+      setTaskProfiles((prev) => ({
+        ...prev,
+        LLM_TASK_SEMANTIC_PROVIDER: llmValues.LLM_TASK_SEMANTIC_PROVIDER || '',
+        LLM_TASK_SUMMARY_PROVIDER: llmValues.LLM_TASK_SUMMARY_PROVIDER || '',
+        LLM_TASK_FOLLOWUP_PROVIDER: llmValues.LLM_TASK_FOLLOWUP_PROVIDER || '',
+        LLM_TASK_IDLE_PROVIDER: llmValues.LLM_TASK_IDLE_PROVIDER || '',
+        LLM_TASK_WEBUI_PROVIDER:
+          llmValues.LLM_TASK_WEBUI_PROVIDER || gs.webuiIntelligenceProvider || '',
+      }));
+      if ((statusRes as any).libraryStatus)
+        setLibraryStatus((statusRes as any).libraryStatus);
     } catch (err: unknown) {
-      setError((err instanceof Error ? err.message : String(err)) || 'Failed to load configuration');
+      setError(
+        (err instanceof Error ? err.message : String(err)) || 'Failed to load configuration',
+      );
     } finally {
       setLoading(false);
     }
   }, []);
 
-  useEffect(() => { fetchProfiles(); }, [fetchProfiles]);
+  useEffect(() => {
+    fetchProfiles();
+  }, [fetchProfiles]);
 
   const saveGlobal = async (patch: Record<string, any>) => {
     await apiService.put('/api/config/global', patch);
@@ -111,7 +703,12 @@ const LLMProvidersPage: React.FC = () => {
 
   const handleEditProfile = (profile: any) => {
     openEditModal('global', 'llm', {
-      id: profile.key, name: profile.name, type: profile.provider, config: profile.config, modelType: profile.modelType, enabled: true,
+      id: profile.key,
+      name: profile.name,
+      type: profile.provider,
+      config: profile.config,
+      modelType: profile.modelType,
+      enabled: true,
     } as any);
   };
 
@@ -120,7 +717,9 @@ const LLMProvidersPage: React.FC = () => {
     try {
       await apiService.delete(`/api/config/llm-profiles/${key}`);
       fetchProfiles();
-    } catch (err: unknown) { alert(`Failed to delete: ${(err instanceof Error ? err.message : String(err))}`); }
+    } catch (err: unknown) {
+      alert(`Failed to delete: ${err instanceof Error ? err.message : String(err)}`);
+    }
   };
 
   const handleProviderSubmit = async (providerData: any) => {
@@ -142,7 +741,8 @@ const LLMProvidersPage: React.FC = () => {
           try {
             await apiService.post('/api/config/llm-profiles', payload);
           } catch (e: unknown) {
-            if (backup) await apiService.post('/api/config/llm-profiles', backup).catch(() => {});
+            if (backup)
+              await apiService.post('/api/config/llm-profiles', backup).catch(() => {});
             throw e;
           }
         }
@@ -151,186 +751,151 @@ const LLMProvidersPage: React.FC = () => {
       }
       closeModal();
       fetchProfiles();
-    } catch (err: unknown) { alert(`Failed to save: ${(err instanceof Error ? err.message : String(err))}`); }
+    } catch (err: unknown) {
+      alert(`Failed to save: ${err instanceof Error ? err.message : String(err)}`);
+    }
   };
 
-  const getProviderIcon = (type: string) => {
-    const config = LLM_PROVIDER_CONFIGS[type as LLMProviderType];
-    return config?.icon || <BrainIcon className="w-5 h-5" />;
-  };
+  const toggleExpand = (key: string) =>
+    setExpandedProfile(expandedProfile === key ? null : key);
 
-  const toggleExpand = (key: string) => setExpandedProfile(expandedProfile === key ? null : key);
-
-  const renderLibraryCheck = (type: string) => {
-    const status = libraryStatus[type];
-    if (!status?.installed) return status ? (
-      <div className="tooltip tooltip-bottom" data-tip={`Missing: ${status.package}`}>
-        <Badge variant="error" size="small" className="gap-1 cursor-help">
-          <XIcon className="w-3 h-3" /> Lib Missing
-        </Badge>
-      </div>
-    ) : null;
-    return null;
-  };
-
-  const filteredProfiles = useMemo(() =>
-    profiles.filter(p => {
-      const matchesSearch = p.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-                            p.provider.toLowerCase().includes(searchQuery.toLowerCase());
-      return matchesSearch && (filterType === 'all' || p.provider === filterType);
-    }), [profiles, searchQuery, filterType]);
+  const filteredProfiles = useMemo(
+    () =>
+      profiles.filter((p) => {
+        const matchesSearch =
+          p.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+          p.provider.toLowerCase().includes(searchQuery.toLowerCase());
+        return matchesSearch && (filterType === 'all' || p.provider === filterType);
+      }),
+    [profiles, searchQuery, filterType],
+  );
 
   const providerTypes = useMemo(() => {
-    const types = new Set(profiles.map(p => p.provider));
-    return Array.from(types).map(type => ({ label: type, value: type }));
+    const types = new Set(profiles.map((p) => p.provider));
+    return Array.from(types).map((type) => ({ label: type, value: type }));
   }, [profiles]);
 
   const chatProfiles = useMemo(() => profiles.filter(isChatCapable), [profiles]);
   const embeddingProfiles = useMemo(() => profiles.filter(isEmbeddingCapable), [profiles]);
 
   const stats = [
-    { id: 'total', title: 'Total Profiles', value: profiles.length, icon: 'brain', color: 'primary' as const },
-    { id: 'types', title: 'Provider Types', value: providerTypes.length, icon: 'cpu', color: 'secondary' as const },
-    { id: 'default', title: 'System Default', value: defaultStatus?.configured ? 'Active' : 'Missing', icon: defaultStatus?.configured ? 'check' : 'alert', color: defaultStatus?.configured ? 'success' as const : 'warning' as const },
+    {
+      id: 'total',
+      title: 'Total Profiles',
+      value: profiles.length,
+      icon: 'brain',
+      color: 'primary' as const,
+    },
+    {
+      id: 'types',
+      title: 'Provider Types',
+      value: providerTypes.length,
+      icon: 'cpu',
+      color: 'secondary' as const,
+    },
+    {
+      id: 'default',
+      title: 'System Default',
+      value: defaultStatus?.configured ? 'Active' : 'Missing',
+      icon: defaultStatus?.configured ? 'check' : 'alert',
+      color: defaultStatus?.configured ? ('success' as const) : ('warning' as const),
+    },
+  ];
+
+  const handleTabChange = (tabId: string) => {
+    setSearchParams({ tab: tabId });
+  };
+
+  const tabs = [
+    {
+      id: 'profiles',
+      label: 'Profiles',
+      icon: <BrainIcon className="w-4 h-4" />,
+      content: (
+        <ProfilesTab
+          profiles={profiles}
+          filteredProfiles={filteredProfiles}
+          providerTypes={providerTypes}
+          stats={stats}
+          loading={loading}
+          error={error}
+          searchQuery={searchQuery}
+          filterType={filterType}
+          defaultChatbotProfile={defaultChatbotProfile}
+          webuiIntelligenceProvider={webuiIntelligenceProvider}
+          defaultEmbeddingProvider={defaultEmbeddingProvider}
+          libraryStatus={libraryStatus}
+          expandedProfile={expandedProfile}
+          onSearchChange={setSearchQuery}
+          onFilterChange={setFilterType}
+          onClearError={() => setError(null)}
+          onRefresh={fetchProfiles}
+          onAddProfile={handleAddProfile}
+          onEditProfile={handleEditProfile}
+          onDeleteProfile={handleDeleteProfile}
+          onToggleExpand={toggleExpand}
+        />
+      ),
+    },
+    {
+      id: 'settings',
+      label: 'Settings',
+      icon: <ConfigIcon className="w-4 h-4" />,
+      content: (
+        <SettingsTab
+          profiles={profiles}
+          defaultStatus={defaultStatus}
+          loading={loading}
+          defaultChatbotProfile={defaultChatbotProfile}
+          defaultEmbeddingProvider={defaultEmbeddingProvider}
+          webuiIntelligenceProvider={webuiIntelligenceProvider}
+          perUseCaseEnabled={perUseCaseEnabled}
+          taskProfiles={taskProfiles}
+          chatProfiles={chatProfiles}
+          embeddingProfiles={embeddingProfiles}
+          onDefaultChatbotChange={async (val) => {
+            setDefaultChatbotProfile(val);
+            await saveGlobal({ defaultChatbotProfile: val }).catch(() => {});
+          }}
+          onDefaultEmbeddingChange={async (val) => {
+            setDefaultEmbeddingProvider(val);
+            await saveLlmConfig({ DEFAULT_EMBEDDING_PROVIDER: val }).catch(() => {});
+          }}
+          onWebuiIntelligenceChange={async (val) => {
+            setWebuiIntelligenceProvider(val);
+            await saveGlobal({ webuiIntelligenceProvider: val }).catch(() => {});
+          }}
+          onPerUseCaseChange={async (val) => {
+            setPerUseCaseEnabled(val);
+            await saveGlobal({ perUseCaseEnabled: val }).catch(() => {});
+          }}
+          onTaskProfileChange={async (key, val) => {
+            setTaskProfiles((prev) => ({ ...prev, [key]: val }));
+            if (key === 'LLM_TASK_WEBUI_PROVIDER') {
+              await saveGlobal({ webuiIntelligenceProvider: val }).catch(() => {});
+            } else {
+              await saveLlmConfig({ [key]: val }).catch(() => {});
+            }
+          }}
+        />
+      ),
+    },
+    {
+      id: 'community',
+      label: 'Community',
+      icon: <StoreIcon className="w-4 h-4" />,
+      content: <MarketplaceGrid filter="llm" />,
+    },
   ];
 
   return (
     <div className="space-y-6">
-      <div className="flex justify-end mb-4">
-        <div className="flex gap-2">
-          <Button variant="outline" onClick={fetchProfiles} disabled={loading} aria-busy={loading}>
-            <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} /> Refresh
-          </Button>
-          <Button variant="primary" onClick={handleAddProfile}>
-            <AddIcon className="w-4 h-4 mr-2" /> Create Profile
-          </Button>
-        </div>
-      </div>
-
-      <StatsCards stats={stats} isLoading={loading} />
-
-      {error && <Alert status="error" icon={<XIcon />} message={error} onClose={() => setError(null)} />}
-
-      <div className="alert alert-info text-sm">
-        <ConfigIcon className="w-4 h-4" />
-        <span>Default provider assignments, embedding config, and per-use-case settings have moved to <strong>Settings &gt; LLM</strong>.</span>
-      </div>
-
-      <SearchFilterBar
-        searchValue={searchQuery}
-        onSearchChange={setSearchQuery}
-        searchPlaceholder="Search profiles..."
-        filters={[{
-          key: 'type',
-          value: filterType,
-          onChange: setFilterType,
-          options: [{ label: 'All Types', value: 'all' }, ...providerTypes],
-          className: 'w-48',
-        }]}
+      <Tabs
+        tabs={tabs}
+        variant="lifted"
+        activeTab={activeTab}
+        onChange={handleTabChange}
       />
-
-      {loading ? (
-        <div className="flex justify-center py-12"><LoadingSpinner size="lg" /></div>
-      ) : profiles.length === 0 ? (
-        <EmptyState
-          icon={BrainIcon}
-          title="No Profiles Created"
-          description="Create a custom profile to override system defaults for specific bots."
-          actionLabel="Create Profile"
-          actionIcon={AddIcon}
-          onAction={handleAddProfile}
-          variant="noData"
-        />
-      ) : filteredProfiles.length === 0 ? (
-        <EmptyState
-          icon={Search}
-          title="No matching profiles"
-          description="Try adjusting your search or filters."
-          actionLabel="Clear Filters"
-          onAction={() => { setSearchQuery(''); setFilterType('all'); }}
-          variant="noResults"
-        />
-      ) : (
-        <div className="grid grid-cols-1 gap-4">
-          {filteredProfiles.map((profile) => (
-            <Card key={profile.key} className="bg-base-100 shadow-sm border border-base-200 transition-all hover:shadow-md">
-              <div className="card-body p-0">
-                <div className="p-4 flex items-center justify-between cursor-pointer" onClick={() => toggleExpand(profile.key)}>
-                  <div className="flex items-center gap-4">
-                    <div className="p-3 bg-primary/10 text-primary rounded-xl">
-                      {getProviderIcon(profile.provider)}
-                    </div>
-                    <div>
-                      <h3 className="font-bold text-lg flex items-center gap-2">
-                        {profile.name}
-                        <span className="text-xs font-normal opacity-50 px-2 py-0.5 bg-base-200 rounded-full font-mono">{profile.key}</span>
-                      </h3>
-                      <div className="flex items-center gap-2 mt-1">
-                        <Badge variant="secondary" size="small" style="outline">{profile.provider}</Badge>
-                        <Badge
-                          variant={
-                            normalizeModelType(profile.modelType) === 'embedding'
-                              ? 'warning'
-                              : normalizeModelType(profile.modelType) === 'both'
-                                ? 'info'
-                                : 'neutral'
-                          }
-                          size="small"
-                        >
-                          {normalizeModelType(profile.modelType)}
-                        </Badge>
-                        {renderLibraryCheck(profile.provider)}
-                        {profile.key === defaultChatbotProfile && (
-                          <Badge variant="primary" size="small">Default Chatbot</Badge>
-                        )}
-                        {profile.key === webuiIntelligenceProvider && (
-                          <Badge variant="warning" size="small">WebUI AI</Badge>
-                        )}
-                        {profile.key === defaultEmbeddingProvider && (
-                          <Badge variant="secondary" size="small">Default Embedding</Badge>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                  <div className="flex gap-2" onClick={(e) => e.stopPropagation()}>
-                    <Button size="sm" variant="outline" onClick={() => handleEditProfile(profile)}>
-                      <EditIcon className="w-4 h-4" />
-                    </Button>
-                    <Button size="sm" variant="outline" className="text-error hover:bg-error/10" onClick={() => handleDeleteProfile(profile.key)}>
-                      <DeleteIcon className="w-4 h-4" />
-                    </Button>
-                    <Button size="sm" variant="ghost" onClick={() => toggleExpand(profile.key)}>
-                      {expandedProfile === profile.key ? <CollapseIcon className="w-4 h-4" /> : <ExpandIcon className="w-4 h-4" />}
-                    </Button>
-                  </div>
-                </div>
-
-                {expandedProfile === profile.key && (
-                  <div className="px-4 pb-4 pt-0">
-                    <div className="bg-base-200/50 rounded-xl p-4 border border-base-200">
-                      <h4 className="text-xs font-bold uppercase opacity-50 mb-3 flex items-center gap-2">
-                        <ConfigIcon className="w-3 h-3" /> Configuration
-                      </h4>
-                      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-                        {Object.entries(profile.config || {}).map(([k, v]) => (
-                          <div key={k} className="bg-base-100 p-2 rounded border border-base-200/50 flex flex-col">
-                            <span className="font-mono text-[10px] opacity-50 uppercase tracking-wider mb-1">{k}</span>
-                            <span className="font-medium text-sm truncate" title={String(v)}>
-                              {String(k).toLowerCase().includes('key') || String(k).toLowerCase().includes('token') || String(k).toLowerCase().includes('password')
-                                ? '••••••••'
-                                : String(v)}
-                            </span>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-                )}
-              </div>
-            </Card>
-          ))}
-        </div>
-      )}
 
       <ProviderConfigModal
         modalState={{ ...modalState, providerType: 'llm' }}

--- a/src/client/src/pages/MarketplacePage.tsx
+++ b/src/client/src/pages/MarketplacePage.tsx
@@ -1,71 +1,23 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { apiService } from '../services/api';
-import Card from '../components/DaisyUI/Card';
 import Button from '../components/DaisyUI/Button';
-import Badge from '../components/DaisyUI/Badge';
 import {
   Store as StoreIcon,
-  Download as DownloadIcon,
-  RefreshCw as UpdateIcon,
-  Trash2 as UninstallIcon,
-  Plus as PlusIcon,
   Search as SearchIcon,
-  Brain as LLMIcon,
-  MessageCircle as MessageIcon,
-  Database as MemoryIcon,
-  Wrench as ToolIcon,
   Github as GitHubIcon,
   AlertCircle as AlertIcon,
   AlertTriangle as WarningIcon,
   CheckCircle as CheckIcon,
   X as CloseIcon,
-  Star as StarIcon,
-  ExternalLink as ExternalLinkIcon,
 } from 'lucide-react';
+import { MarketplaceCard } from '../components/Marketplace';
+import type { MarketplacePackage } from '../components/Marketplace';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-interface MarketplacePackage {
-  name: string;
-  displayName: string;
-  description: string;
-  type: 'llm' | 'message' | 'memory' | 'tool';
-  version: string;
-  status: 'built-in' | 'installed' | 'available';
-  repoUrl?: string;
-  feedbackUrl?: string;
-  rating?: number;
-  installedAt?: string;
-  updatedAt?: string;
-}
-
 type FilterType = 'all' | 'llm' | 'message' | 'memory' | 'tool';
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const TYPE_ICONS = {
-  llm: LLMIcon,
-  message: MessageIcon,
-  memory: MemoryIcon,
-  tool: ToolIcon,
-} as const;
-
-const TYPE_COLORS = {
-  llm: 'secondary',
-  message: 'primary',
-  memory: 'accent',
-  tool: 'info',
-} as const;
-
-const STATUS_BADGES = {
-  'built-in': { label: 'Built-in', color: 'neutral' as const },
-  'installed': { label: 'Installed', color: 'success' as const },
-  'available': { label: 'Available', color: 'info' as const },
-} as const;
 
 // ---------------------------------------------------------------------------
 // Component
@@ -103,6 +55,7 @@ const MarketplacePage: React.FC = () => {
     setLoading(true);
     setError(null);
     try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const data: any = await apiService.get('/api/marketplace/packages');
       setPackages(data?.data || data || []);
     } catch (err: unknown) {
@@ -132,6 +85,7 @@ const MarketplacePage: React.FC = () => {
     setActionMessage(null);
 
     try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result: any = await apiService.post('/api/marketplace/install', { repoUrl: githubUrl.trim() });
       const data = result?.data || result;
       setActionMessage({ type: 'success', text: `Installed ${data?.package?.displayName || 'package'} successfully!` });
@@ -145,12 +99,19 @@ const MarketplacePage: React.FC = () => {
     }
   };
 
+  // Install a specific package (from card button)
+  const handleInstall = (pkg: MarketplacePackage) => {
+    setGithubUrl(pkg.repoUrl || '');
+    setInstallModalOpen(true);
+  };
+
   // Update package
   const handleUpdate = async (name: string) => {
     setActionInProgress(`update-${name}`);
     setActionMessage(null);
 
     try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result: any = await apiService.post(`/api/marketplace/update/${name}`, {});
       const data = result?.data || result;
       setActionMessage({ type: 'success', text: `Updated ${data?.package?.displayName || name} successfully!` });
@@ -266,141 +227,22 @@ const MarketplacePage: React.FC = () => {
       {!loading && filteredPackages.length > 0 && (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {filteredPackages.map((pkg) => {
-            const Icon = TYPE_ICONS[pkg.type];
-            const color = TYPE_COLORS[pkg.type];
-            const statusBadge = STATUS_BADGES[pkg.status];
             const isBusy = actionInProgress?.startsWith(pkg.name) ||
                           actionInProgress === `update-${pkg.name}` ||
                           actionInProgress === `uninstall-${pkg.name}`;
 
             return (
-              <Card key={pkg.name} className="bg-base-200 hover:bg-base-300 transition-colors">
-                <Card.Body className="p-4">
-                  <div className="flex items-start justify-between mb-2">
-                    <div className="flex items-center gap-2">
-                      <div className={`p-2 rounded-lg bg-${color}/10`}>
-                        <Icon className={`w-5 h-5 text-${color}`} />
-                      </div>
-                      <div>
-                        <h3 className="font-semibold">{pkg.displayName}</h3>
-                        <p className="text-xs text-base-content/50 font-mono">{pkg.name}</p>
-                      </div>
-                    </div>
-                    <Badge variant={statusBadge.color} size="sm">
-                      {statusBadge.label}
-                    </Badge>
-                  </div>
-
-                  <p className="text-sm text-base-content/70 mb-3 line-clamp-2">
-                    {pkg.description}
-                  </p>
-
-                  <div className="flex items-center justify-between text-xs text-base-content/50 mb-3">
-                    <span>v{pkg.version}</span>
-                    <span className="uppercase badge badge-sm badge-outline">{pkg.type}</span>
-                  </div>
-
-                  {/* Star Rating & Feedback */}
-                  <div className="flex items-center justify-between mb-3">
-                    <div className="flex items-center gap-1" data-testid={`star-rating-${pkg.name}`}>
-                      {[1, 2, 3, 4, 5].map((star) => (
-                        <Button
-                          key={star}
-                          variant="ghost"
-                          size="xs"
-                          className="p-0"
-                          data-testid={`star-${star}`}
-                          onClick={() => handleRating(pkg.name, star)}
-                          aria-label={`Rate ${star} star${star > 1 ? 's' : ''}`}
-                        >
-                          <StarIcon
-                            className={`w-4 h-4 ${
-                              (ratings[pkg.name] ?? pkg.rating ?? 0) >= star
-                                ? 'fill-warning text-warning'
-                                : 'text-base-content/30'
-                            }`}
-                          />
-                        </Button>
-                      ))}
-                    </div>
-                    {pkg.feedbackUrl ? (
-                      <a
-                        href={pkg.feedbackUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="link link-primary text-xs flex items-center gap-1"
-                        data-testid={`feedback-link-${pkg.name}`}
-                      >
-                        Feedback <ExternalLinkIcon className="w-3 h-3" />
-                      </a>
-                    ) : pkg.repoUrl ? (
-                      <a
-                        href={`${pkg.repoUrl}/issues`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="link link-primary text-xs flex items-center gap-1"
-                        data-testid={`feedback-link-${pkg.name}`}
-                      >
-                        Feedback <ExternalLinkIcon className="w-3 h-3" />
-                      </a>
-                    ) : null}
-                  </div>
-
-                  {/* Actions */}
-                  <div className="flex gap-2">
-                    {pkg.status === 'installed' && (
-                      <>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className="flex-1"
-                          onClick={() => handleUpdate(pkg.name)}
-                          disabled={isBusy}
-                        >
-                          {actionInProgress === `update-${pkg.name}` ? (
-                            <span className="loading loading-spinner loading-xs" aria-hidden="true"></span>
-                          ) : (
-                            <UpdateIcon className="w-4 h-4" />
-                          )}
-                          Update
-                        </Button>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => handleUninstall(pkg.name)}
-                          disabled={isBusy}
-                        >
-                          {actionInProgress === `uninstall-${pkg.name}` ? (
-                            <span className="loading loading-spinner loading-xs" aria-hidden="true"></span>
-                          ) : (
-                            <UninstallIcon className="w-4 h-4 text-error" />
-                          )}
-                        </Button>
-                      </>
-                    )}
-                    {pkg.status === 'available' && (
-                      <Button
-                        variant="primary"
-                        size="sm"
-                        className="flex-1"
-                        onClick={() => {
-                          setGithubUrl(pkg.repoUrl || '');
-                          setInstallModalOpen(true);
-                        }}
-                        disabled={isBusy}
-                      >
-                        <DownloadIcon className="w-4 h-4 mr-1" />
-                        Install
-                      </Button>
-                    )}
-                    {pkg.status === 'built-in' && (
-                      <span className="text-xs text-base-content/50 italic w-full text-center">
-                        Included with open-hivemind
-                      </span>
-                    )}
-                  </div>
-                </Card.Body>
-              </Card>
+              <MarketplaceCard
+                key={pkg.name}
+                pkg={pkg}
+                isBusy={!!isBusy}
+                actionInProgress={actionInProgress}
+                userRating={ratings[pkg.name]}
+                onRate={handleRating}
+                onInstall={handleInstall}
+                onUpdate={handleUpdate}
+                onUninstall={handleUninstall}
+              />
             );
           })}
         </div>
@@ -468,8 +310,5 @@ const MarketplacePage: React.FC = () => {
     </div>
   );
 };
-
-// Missing imports
-const RefreshCw = UpdateIcon;
 
 export default MarketplacePage;


### PR DESCRIPTION
## Summary
- Refactors the LLM Providers page into a tabbed layout with three tabs: **Profiles**, **Settings**, and **Community**
- Extracts reusable `MarketplaceCard` and `MarketplaceGrid` components from MarketplacePage into `src/client/src/components/Marketplace/`
- Settings tab embeds LLM configuration with an Advanced toggle that reveals WebUI intelligence, system default, and per-use-case task assignments
- Community tab renders `MarketplaceGrid` filtered to LLM packages
- Tab state is persisted via URL search params (`?tab=profiles`)
- MarketplacePage updated to use shared `MarketplaceCard` component

## Test plan
- [ ] Navigate to LLM Providers page and verify three tabs render (Profiles, Settings, Community)
- [ ] Verify Profiles tab shows existing profile cards, search, and stats
- [ ] Verify Settings tab shows basic settings (default chatbot, embedding provider) and Advanced toggle reveals additional fields
- [ ] Verify Community tab shows LLM-filtered marketplace packages
- [ ] Verify tab state persists in URL (`?tab=settings`)
- [ ] Verify Marketplace page still renders correctly with shared card component
- [ ] Verify `npx tsc --noEmit` passes cleanly