### PR TITLE
feat(ui): tabbed layout for Bots page

### DIFF
--- a/src/client/src/pages/BotsPage/BotSettingsTab.tsx
+++ b/src/client/src/pages/BotsPage/BotSettingsTab.tsx
@@ -1,0 +1,118 @@
+import { Info } from 'lucide-react';
+import React, { useState } from 'react';
+import { Alert } from '../../components/DaisyUI/Alert';
+import Card from '../../components/DaisyUI/Card';
+import Select from '../../components/DaisyUI/Select';
+import Toggle from '../../components/DaisyUI/Toggle';
+
+const BotSettingsTab: React.FC = () => {
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  return (
+    <div className="space-y-6">
+      <Alert status="info" icon={<Info className="w-5 h-5" />}>
+        <span>Bot settings API coming soon — these controls are placeholders.</span>
+      </Alert>
+
+      {/* Basic Settings */}
+      <Card title="Basic Settings">
+        <div className="space-y-4">
+          <Toggle
+            label="Auto-start on creation"
+            disabled
+            checked={false}
+            onChange={() => {}}
+          />
+          <div className="form-control w-full max-w-xs">
+            <label className="label">
+              <span className="label-text">Default LLM Profile</span>
+            </label>
+            <Select disabled className="select-bordered" size="sm">
+              <option>Select LLM profile...</option>
+            </Select>
+          </div>
+          <div className="form-control w-full max-w-xs">
+            <label className="label">
+              <span className="label-text">Default Persona</span>
+            </label>
+            <Select disabled className="select-bordered" size="sm">
+              <option>Select persona...</option>
+            </Select>
+          </div>
+        </div>
+      </Card>
+
+      {/* Advanced Toggle */}
+      <div className="flex items-center gap-2">
+        <Toggle
+          label="Advanced"
+          checked={showAdvanced}
+          onChange={() => setShowAdvanced((v) => !v)}
+        />
+      </div>
+
+      {/* Advanced Settings */}
+      {showAdvanced && (
+        <div className="space-y-4">
+          <Card title="Startup Greeting">
+            <p className="text-base-content/60 text-sm">
+              Configure the default greeting message sent when a bot starts up.
+            </p>
+            <textarea
+              className="textarea textarea-bordered w-full mt-2"
+              placeholder="Hello! I'm ready to help."
+              disabled
+              rows={3}
+            />
+          </Card>
+
+          <Card title="Reconnection Settings">
+            <div className="space-y-3">
+              <Toggle
+                label="Auto-reconnect on disconnect"
+                disabled
+                checked={false}
+                onChange={() => {}}
+              />
+              <div className="form-control w-full max-w-xs">
+                <label className="label">
+                  <span className="label-text">Max retry attempts</span>
+                </label>
+                <input
+                  type="number"
+                  className="input input-bordered input-sm w-full max-w-xs"
+                  placeholder="3"
+                  disabled
+                />
+              </div>
+            </div>
+          </Card>
+
+          <Card title="Duplicate Response Suppression">
+            <div className="space-y-3">
+              <Toggle
+                label="Suppress duplicate responses"
+                disabled
+                checked={false}
+                onChange={() => {}}
+              />
+              <div className="form-control w-full max-w-xs">
+                <label className="label">
+                  <span className="label-text">Dedup window (seconds)</span>
+                </label>
+                <input
+                  type="number"
+                  className="input input-bordered input-sm w-full max-w-xs"
+                  placeholder="5"
+                  disabled
+                />
+              </div>
+            </div>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default BotSettingsTab;

--- a/src/client/src/pages/BotsPage/index.tsx
+++ b/src/client/src/pages/BotsPage/index.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Bot as BotIcon, Download, LayoutGrid, List, RefreshCw, Trash2, Upload as UploadIcon } from 'lucide-react';
+import { Bot as BotIcon, Download, LayoutGrid, List, RefreshCw, Settings, Trash2, Upload as UploadIcon } from 'lucide-react';
 import React, { useEffect, useMemo, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import Tabs from '../../components/DaisyUI/Tabs';
+import BotSettingsTab from './BotSettingsTab';
 import { CreateBotWizard } from '../../components/BotManagement/CreateBotWizard';
 import ImportBotsModal from '../../components/BotManagement/ImportBotsModal';
 import { BotSettingsModal } from '../../components/BotSettingsModal';
@@ -155,15 +157,23 @@ const BotsPage: React.FC = () => {
     onReorder: handleReorder,
   });
 
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = searchParams.get('tab') || 'instances';
+  const handleTabChange = (tabId: string) => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.set('tab', tabId);
+      return next;
+    });
+  };
+
   if (loading && bots.length === 0 && !error) {
     return <SkeletonPage variant="cards" statsCount={4} showFilters />;
   }
 
-  return (
-    <div className="space-y-6">
-      {/* Bot List — full width, no sidebar column */}
-      <div className="space-y-4">
-        <SearchFilterBar
+  const instancesContent = (
+    <div className="space-y-4">
+      <SearchFilterBar
           searchValue={searchQuery}
           onSearchChange={setSearchQuery}
           searchPlaceholder="Search agents by name or purpose..."
@@ -306,6 +316,29 @@ const BotsPage: React.FC = () => {
           )
         )}
       </div>
+  );
+
+  return (
+    <div className="space-y-6">
+      <Tabs
+        variant="lifted"
+        activeTab={activeTab}
+        onChange={handleTabChange}
+        tabs={[
+          {
+            id: 'instances',
+            label: 'Instances',
+            icon: <BotIcon className="w-4 h-4" />,
+            content: instancesContent,
+          },
+          {
+            id: 'settings',
+            label: 'Settings',
+            icon: <Settings className="w-4 h-4" />,
+            content: <BotSettingsTab />,
+          },
+        ]}
+      />
 
       {/* Bot Detail Drawer — slides in from right when a bot is selected */}
       <DetailDrawer


### PR DESCRIPTION
## Summary
- Adds Instances | Settings tabs to the Bots page using the DaisyUI lifted Tabs component
- Tab state persisted via `?tab=instances|settings` search params
- Settings tab includes Basic Settings (auto-start toggle, default LLM/persona dropdowns) and an Advanced toggle revealing Startup Greeting, Reconnection Settings, and Duplicate Response Suppression cards
- All settings controls are placeholder/disabled with an info alert

## Test plan
- [ ] Navigate to Bots page — Instances tab shown by default with all existing content
- [ ] Click Settings tab — placeholder settings UI renders
- [ ] Toggle Advanced — advanced cards appear/disappear
- [ ] Refresh page with `?tab=settings` — Settings tab is active on load
- [ ] Verify no TypeScript errors in changed files