### PR TITLE
fix: resolve TypeScript errors and ESLint crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -327,7 +327,6 @@
       "brace-expansion": "^5.0.5",
       "smol-toml": "^1.6.1",
       "diff": "^8.0.3",
-      "ajv": "^8.18.0",
       "@tootallnate/once": "^3.0.1"
     },
     "auditConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,6 @@ overrides:
   brace-expansion: ^5.0.5
   smol-toml: ^1.6.1
   diff: ^8.0.3
-  ajv: ^8.18.0
   '@tootallnate/once': ^3.0.1
 
 importers:
@@ -4244,13 +4243,19 @@ packages:
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
-      ajv: ^8.18.0
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
 
+  ajv@6.14.0:
+    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  ajv@8.6.3:
+    resolution: {integrity: sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -6559,6 +6564,9 @@ packages:
   json-schema-to-ts@1.6.4:
     resolution: {integrity: sha512-pR4yQ9DHz6itqswtHCm26mw45FSNfQ9rEQjosaZErhn5J3J2sIViQiz8rDaezjKAhFGpmsoczYVBgGHzFw/stA==}
 
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -8826,6 +8834,9 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
@@ -10842,7 +10853,7 @@ snapshots:
 
   '@eslint/eslintrc@3.3.5':
     dependencies:
-      ajv: 8.18.0
+      ajv: 6.14.0
       debug: 4.4.3(supports-color@8.1.1)
       espree: 10.4.0
       globals: 14.0.0
@@ -12462,7 +12473,7 @@ snapshots:
 
   '@vercel/static-config@3.2.0':
     dependencies:
-      ajv: 8.18.0
+      ajv: 8.6.3
       json-schema-to-ts: 1.6.4
       ts-morph: 12.0.0
 
@@ -12612,12 +12623,26 @@ snapshots:
     optionalDependencies:
       ajv: 8.18.0
 
+  ajv@6.14.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  ajv@8.6.3:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js: 4.4.1
 
   ansi-colors@4.1.3: {}
 
@@ -13989,7 +14014,7 @@ snapshots:
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
-      ajv: 8.18.0
+      ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3(supports-color@8.1.1)
@@ -15484,6 +15509,8 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
       ts-toolbelt: 6.15.5
+
+  json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
 
@@ -18174,6 +18201,10 @@ snapshots:
       browserslist: 4.28.1
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   url-parse@1.5.10:
     dependencies:

--- a/src/admin/adminRoutes.ts
+++ b/src/admin/adminRoutes.ts
@@ -198,9 +198,7 @@ adminRouter.get(
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
       debug(`Failed to get schema for provider ${providerId}`, e);
-      return res
-        .status(500)
-        .json({ success: false, error: message });
+      return res.status(500).json({ success: false, error: message });
     }
   }
 );
@@ -219,13 +217,14 @@ adminRouter.post(
         .json({ success: false, error: `Message provider '${providerId}' not found` });
     }
 
+    const body = req.body as { name?: string; token?: string; llm?: string };
     try {
       await (provider as IMessageProvider).addBot(req.body);
 
       logAdminAction(
         req,
         `CREATE_${providerId.toUpperCase()}_BOT`,
-        `${providerId}-bots/${req.body?.name || 'unknown'}`,
+        `${providerId}-bots/${body.name || 'unknown'}`,
         'success',
         `Created ${provider.label} bot`
       );
@@ -235,7 +234,7 @@ adminRouter.post(
       logAdminAction(
         req,
         `CREATE_${providerId.toUpperCase()}_BOT`,
-        `${providerId}-bots/${req.body?.name || 'unknown'}`,
+        `${providerId}-bots/${body.name || 'unknown'}`,
         'failure',
         `Failed to create ${provider.label} bot: ${message}`
       );
@@ -305,12 +304,13 @@ adminRouter.post(
 adminRouter.post('/slack-bots', requireAdmin, async (req: AuditedRequest, res: Response) => {
   const provider = providerRegistry.get('slack') as IMessageProvider;
   if (!provider) return res.status(404).json({ success: false, error: 'Slack provider not found' });
+  const body = req.body as { name?: string; token?: string };
   try {
     await provider.addBot(req.body);
     logAdminAction(
       req,
       'CREATE_SLACK_BOT',
-      `slack-bots/${req.body?.name}`,
+      `slack-bots/${body.name}`,
       'success',
       'Created Slack bot'
     );
@@ -320,7 +320,7 @@ adminRouter.post('/slack-bots', requireAdmin, async (req: AuditedRequest, res: R
     logAdminAction(
       req,
       'CREATE_SLACK_BOT',
-      `slack-bots/${req.body?.name || 'unknown'}`,
+      `slack-bots/${body.name || 'unknown'}`,
       'failure',
       `Failed to create Slack bot: ${message}`
     );
@@ -333,7 +333,11 @@ adminRouter.post('/discord-bots', requireAdmin, async (req: AuditedRequest, res:
   if (!provider)
     return res.status(404).json({ success: false, error: 'Discord provider not found' });
   try {
-    const { name, token, llm } = req.body || {};
+    const { name, token, llm } = (req.body || {}) as {
+      name?: string;
+      token?: string;
+      llm?: string;
+    };
     if (!token) {
       logAdminAction(
         req,
@@ -396,17 +400,18 @@ adminRouter.post('/discord-bots', requireAdmin, async (req: AuditedRequest, res:
     logAdminAction(
       req,
       'CREATE_DISCORD_BOT',
-      `discord-bots/${req.body?.name}`,
+      `discord-bots/${name || 'unnamed'}`,
       'success',
       'Created Discord bot'
     );
     return res.json({ success: true, note: 'Saved. Restart app to initialize Discord bot.' });
   } catch (e) {
     const message = (e as Error)?.message || String(e);
+    const discordBody = req.body as { name?: string };
     logAdminAction(
       req,
       'CREATE_DISCORD_BOT',
-      `discord-bots/${req.body?.name || 'unnamed'}`,
+      `discord-bots/${discordBody.name || 'unnamed'}`,
       'failure',
       `Failed to create Discord bot: ${message}`
     );

--- a/src/auth/middleware.ts
+++ b/src/auth/middleware.ts
@@ -55,7 +55,7 @@ export class AuthMiddleware {
           origin === 'https://127.0.0.1' ||
           origin.startsWith('https://127.0.0.1:'));
 
-      return isLocalhostIp || isLocalhostHost || isLocalhostOrigin;
+      return !!(isLocalhostIp || isLocalhostHost || isLocalhostOrigin);
     };
 
     const allowLocalBypass = process.env.ALLOW_LOCALHOST_ADMIN === 'true';

--- a/src/config/UserConfigStore.ts
+++ b/src/config/UserConfigStore.ts
@@ -121,7 +121,7 @@ export class UserConfigStore {
 
     const override = this.botMap.get(botName);
     if (override) {
-      override.disabled = disabled;
+      (override as BotConfiguration & { disabled?: boolean }).disabled = disabled;
     }
 
     await this.saveConfig();
@@ -186,7 +186,7 @@ export class UserConfigStore {
    * @returns A Map of botName to BotOverride.
    */
   public getAllBotOverrides(): Map<string, BotOverride> {
-    return new Map(this.botMap);
+    return new Map(this.botMap) as unknown as Map<string, BotOverride>;
   }
 
   /**

--- a/src/server/services/ConfigurationImportExportService.ts
+++ b/src/server/services/ConfigurationImportExportService.ts
@@ -3,8 +3,8 @@ import * as path from 'path';
 import Debug from 'debug';
 import { SecureConfigManager } from '../../config/SecureConfigManager';
 import { DatabaseManager } from '../../database/DatabaseManager';
+import { type BotConfigurationVersion } from '../../database/types';
 import { ErrorUtils } from '../../types/errors';
-import { BotConfigurationVersion } from '../../database/types';
 import {
   BackupManager,
   calculateChecksum,
@@ -129,9 +129,7 @@ export class ConfigurationImportExportService {
       // Include versions if requested
       if (options.includeVersions) {
         // ⚡ Bolt Optimization: Replace N DB queries with batched bulk queries
-        const configIds = configs
-          .filter((c) => c.id != null)
-          .map((c) => c.id as number);
+        const configIds = configs.filter((c) => c.id != null).map((c) => c.id as number);
 
         const versions: BotConfigurationVersion[] = [];
         const BATCH_SIZE = 50;

--- a/src/server/services/config/ConfigExporter.ts
+++ b/src/server/services/config/ConfigExporter.ts
@@ -17,7 +17,7 @@ import { SecureConfigManager } from '../../../config/SecureConfigManager';
 import { ErrorUtils } from '../../../types/errors';
 import { ConfigurationTemplateService } from '../ConfigurationTemplateService';
 import { ConfigurationVersionService } from '../ConfigurationVersionService';
-import { BotConfigurationVersion } from '../../../database/types';
+import { type BotConfigurationVersion } from '../../../database/types';
 import {
   encryptData,
   compressData,


### PR DESCRIPTION
## Summary
- Fix 12 TypeScript errors: add type assertions for `req.body` in `adminRoutes.ts` (9 errors), coerce boolean return in `middleware.ts` (1 error), fix `disabled` property access and `Map` type mismatch in `UserConfigStore.ts` (2 errors)
- Fix ESLint crash caused by `ajv` v8 override in pnpm overrides — `@eslint/eslintrc` requires ajv v6, so the override is removed
- Auto-fix pre-existing prettier formatting issues in two other files

## Test plan
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] `pnpm lint` runs without crash (warnings only, 0 errors)