### PR TITLE
fix(ui): add missing Alert import to ProviderConfigModal

### DIFF
--- a/src/client/src/components/ProviderConfiguration/ProviderConfigModal.tsx
+++ b/src/client/src/components/ProviderConfiguration/ProviderConfigModal.tsx
@@ -25,6 +25,7 @@ import { apiService } from '../../services/api';
 import { useConfigDiff } from '../../hooks/useConfigDiff';
 import { ConfigDiffConfirmDialog } from '../ConfigDiffViewer';
 import Select from '../DaisyUI/Select';
+import { Alert } from '../DaisyUI/Alert';
 import { useAvailableProviderTypes } from '../../hooks/useAvailableProviderTypes';
 import type { ProviderSchema as ApiProviderSchema } from '../../hooks/useAvailableProviderTypes';
 import { DynamicSchemaForm } from '../DynamicSchemaForm';


### PR DESCRIPTION
## Summary
- `Alert` was used in `ProviderConfigModal.tsx` but never imported, which would cause a React render error ("Element type is invalid") when the Alert path is hit

## Test plan
- [ ] Open a provider config modal (LLM or message)
- [ ] Confirm no "Element type is invalid" console errors