### PR TITLE
feat: add self-hosted Letta container support

### DIFF
--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -104,10 +104,34 @@ services:
       - "127.0.0.1:8474:7474"
       - "127.0.0.1:8687:7687"
 
+  # ---------------------------------------------------------------------------
+  # Letta — self-hosted stateful agent server (REST API on port 8283)
+  # Docs: https://docs.letta.com/guides/docker/
+  # ---------------------------------------------------------------------------
+  letta:
+    image: letta/letta:latest
+    ports:
+      - "127.0.0.1:8283:8283"
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - OPENAI_API_BASE=${OPENAI_API_BASE:-}
+      - SECURE=true
+      - LETTA_SERVER_PASSWORD=${LETTA_SERVER_PASSWORD}
+    volumes:
+      - letta_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8283/v1/health/"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
 volumes:
   mem0_postgres_data:
   mem0_neo4j_data:
   mem0_history:
+  letta_pgdata:
 
 networks:
   mem0_network:

--- a/packages/llm-letta/src/lettaProvider.ts
+++ b/packages/llm-letta/src/lettaProvider.ts
@@ -21,8 +21,10 @@ export class LettaProvider implements ILlmProvider {
 
   private constructor(config?: LettaProviderConfig) {
     this.config = config || {};
-    // SDK auto-reads LETTA_API_KEY and LETTA_BASE_URL from env
-    this.client = new Letta();
+    // Uses LETTA_SERVER_PASSWORD for both cloud and self-hosted auth
+    this.client = new Letta({
+      apiKey: process.env.LETTA_SERVER_PASSWORD,
+    });
   }
 
   static getInstance(config?: LettaProviderConfig): LettaProvider {


### PR DESCRIPTION
- Add letta service to docker-compose.override.example.yml
- Use LETTA_SERVER_PASSWORD for auth (works with both cloud and self-hosted)
- Pass OPENAI_API_KEY and OPENAI_BASE_URL to Letta container
- Includes healthcheck, persistent pgdata volume, SECURE=true by default

Tested end-to-end: agent create → message → response → delete via local Letta container.