### PR TITLE
fix(ui): remove legacy Integrations tab and placeholder tool entries

### DIFF
--- a/src/client/src/pages/SystemSettings.tsx
+++ b/src/client/src/pages/SystemSettings.tsx
@@ -5,7 +5,6 @@ import SettingsGeneral from '../components/Settings/SettingsGeneral';
 import SettingsSecurity from '../components/Settings/SettingsSecurity';
 import SettingsMessaging from '../components/Settings/SettingsMessaging';
 import SettingsLLM from '../components/Settings/SettingsLLM';
-import SettingsIntegrations from '../components/Settings/SettingsIntegrations';
 import Button from '../components/DaisyUI/Button';
 import PageHeader from '../components/DaisyUI/PageHeader';
 import Tabs from '../components/DaisyUI/Tabs';
@@ -33,8 +32,7 @@ const SystemSettings: React.FC = () => {
     { id: 'general', label: 'General', component: <SettingsGeneral /> },
     { id: 'messaging', label: 'Messaging', component: <SettingsMessaging /> },
     { id: 'llm', label: 'LLM', component: <SettingsLLM /> },
-    { id: 'integrations', label: 'Integrations', component: <SettingsIntegrations /> },
-    { id: 'security', label: 'Security', component: <HiddenFeatureToggle fallback="hide"><SettingsSecurity /></HiddenFeatureToggle> },
+{ id: 'security', label: 'Security', component: <HiddenFeatureToggle fallback="hide"><SettingsSecurity /></HiddenFeatureToggle> },
   ];
 
   // Determine active tab index, default to 0 (General) if not found or not specified

--- a/src/server/data/community-packages.json
+++ b/src/server/data/community-packages.json
@@ -45,21 +45,6 @@
     }
   },
   {
-    "name": "github-tools",
-    "displayName": "GitHub Tools",
-    "description": "Comprehensive GitHub integration tools. Create issues, pull requests, manage repositories, search code, and automate workflows.",
-    "type": "tool",
-    "version": "1.5.0",
-    "status": "available",
-    "repoUrl": "https://github.com/open-hivemind/github-tools",
-    "downloadUrl": "https://github.com/open-hivemind/github-tools/archive/refs/heads/main.zip",
-    "author": "OpenHivemind Community",
-    "tags": ["github", "tools", "automation", "ci-cd"],
-    "requirements": {
-      "node": ">=18.0.0"
-    }
-  },
-  {
     "name": "telegram-provider",
     "displayName": "Telegram",
     "description": "Connect agents to Telegram with full bot API support. Handle messages, commands, inline queries, and callbacks.",
@@ -105,21 +90,6 @@
     }
   },
   {
-    "name": "jira-tools",
-    "displayName": "Jira Tools",
-    "description": "Comprehensive Jira integration. Create and manage issues, projects, sprints, and boards. Automate workflows and track progress.",
-    "type": "tool",
-    "version": "2.1.0",
-    "status": "available",
-    "repoUrl": "https://github.com/open-hivemind/jira-tools",
-    "downloadUrl": "https://github.com/open-hivemind/jira-tools/archive/refs/heads/main.zip",
-    "author": "OpenHivemind Community",
-    "tags": ["jira", "tools", "project-management", "atlassian"],
-    "requirements": {
-      "node": ">=18.0.0"
-    }
-  },
-  {
     "name": "weaviate-memory",
     "displayName": "Weaviate Memory",
     "description": "Vector memory provider using Weaviate. GraphQL API, auto-schema, and built-in vectorization options.",
@@ -135,21 +105,6 @@
     }
   },
   {
-    "name": "web-scraper-tools",
-    "displayName": "Web Scraper Tools",
-    "description": "Advanced web scraping capabilities. Extract content, handle dynamic pages, bypass bot detection, and parse structured data.",
-    "type": "tool",
-    "version": "1.4.0",
-    "status": "available",
-    "repoUrl": "https://github.com/open-hivemind/web-scraper-tools",
-    "downloadUrl": "https://github.com/open-hivemind/web-scraper-tools/archive/refs/heads/main.zip",
-    "author": "OpenHivemind Community",
-    "tags": ["web-scraping", "tools", "automation", "data-extraction"],
-    "requirements": {
-      "node": ">=18.0.0"
-    }
-  },
-  {
     "name": "cohere-provider",
     "displayName": "Cohere",
     "description": "Cohere LLM provider with Command models. Includes embeddings, reranking, and classification capabilities.",
@@ -160,21 +115,6 @@
     "downloadUrl": "https://github.com/open-hivemind/cohere-provider/archive/refs/heads/main.zip",
     "author": "OpenHivemind Community",
     "tags": ["cohere", "llm", "embeddings", "reranking"],
-    "requirements": {
-      "node": ">=18.0.0"
-    }
-  },
-  {
-    "name": "notion-tools",
-    "displayName": "Notion Tools",
-    "description": "Full Notion integration. Create and update pages, databases, and blocks. Query and sync workspace content.",
-    "type": "tool",
-    "version": "1.3.0",
-    "status": "available",
-    "repoUrl": "https://github.com/open-hivemind/notion-tools",
-    "downloadUrl": "https://github.com/open-hivemind/notion-tools/archive/refs/heads/main.zip",
-    "author": "OpenHivemind Community",
-    "tags": ["notion", "tools", "productivity", "knowledge-base"],
     "requirements": {
       "node": ">=18.0.0"
     }

--- a/src/server/routes/marketplace.ts
+++ b/src/server/routes/marketplace.ts
@@ -283,6 +283,9 @@ async function getPackages(): Promise<MarketplacePackage[]> {
     packageMap.set(pkg.name, pkg);
   }
 
+  // TODO: Replace with a real community tool example once the first
+  // community-contributed MCP tool plugin is published. The weather tool
+  // below is a placeholder to demonstrate the community tool listing UI.
   // Add example community package if no community packages exist
   if (!packageMap.has('hivemind-plugin-weather')) {
     packageMap.set('hivemind-plugin-weather', {


### PR DESCRIPTION
## Summary

- Removes the legacy **Integrations** tab from SystemSettings — the project now uses the Providers page (per-instance provider packages) instead. The `SettingsIntegrations` component itself is left in place; it is simply no longer rendered.
- Removes four placeholder `"type": "tool"` entries from `community-packages.json` (`github-tools`, `jira-tools`, `web-scraper-tools`, `notion-tools`) that do not correspond to real published packages.
- Adds a `TODO` comment above the `hivemind-plugin-weather` placeholder block in `marketplace.ts` to make clear it is a demo entry pending a real community tool.

## Test plan

- [ ] Open System Settings and confirm the Integrations tab is no longer visible; General, Messaging, LLM, and Security tabs still work.
- [ ] Open the Marketplace page and confirm no tool-type entries appear (only the weather placeholder from `marketplace.ts` should show under tools).
- [ ] Verify `community-packages.json` contains no entries with `"type": "tool"`.
- [ ] Confirm `SettingsIntegrations.tsx` still exists on disk (not deleted).