### PR TITLE
docs: fix persona ID/system_instruction descriptions and unsolicited response levels

### DIFF
--- a/docs/architecture/layered-overview.md
+++ b/docs/architecture/layered-overview.md
@@ -59,12 +59,16 @@ Mattermost.
   Discord, Slack, or Mattermost conversations.
 
 ## Persona & System Instructions
-- Persona templates live in `config/personas/` and can be assigned per agent from
-  the WebUI or via `BOTS_{NAME}_PERSONA` variables.
-- Custom system prompts override persona defaults when present, enabling
-  targeted behaviour for specific channels or tenants.
-- The PersonaEngine merges persona, system instructions, channel hints, and
-  recent history into a single prompt payload before calling the LLM provider.
+- Personas live in `config/personas/` and are assigned per agent from the WebUI or
+  via `BOTS_{NAME}_PERSONA`. A persona is a full object — not just a name — containing
+  a `systemPrompt` template, `traits`, `responseBehavior` fields, and other metadata.
+  The same persona can be shared across multiple bots.
+- `BOTS_{NAME}_SYSTEM_INSTRUCTION` provides an independent system instruction that
+  overrides the persona's built-in `systemPrompt` when set, enabling targeted
+  behaviour for specific bots without replacing the persona itself.
+- The PersonaEngine merges the resolved persona, any system instruction override,
+  channel hints, and recent history into a single prompt payload before calling the
+  LLM provider.
 
 ## Model Context Protocol Integration
 - Open-Hivemind can connect to one or more MCP servers using the WebUI or JSON

--- a/docs/configuration/multi-bot-setup.md
+++ b/docs/configuration/multi-bot-setup.md
@@ -115,9 +115,30 @@ BOTS_ALPHA_DISCORD_BOT_TOKEN=your-discord-token-here
 BOTS_ALPHA_DISCORD_CLIENT_ID=your-client-id
 BOTS_ALPHA_DISCORD_GUILD_ID=your-guild-id
 
-# Identity
+# Identity — Persona ID string (resolved by PersonaManager to a full Persona object)
 BOTS_ALPHA_PERSONA=helpful-assistant
+# Optional: override the persona's built-in systemPrompt with a standalone instruction
+# BOTS_ALPHA_SYSTEM_INSTRUCTION=You are a helpful assistant focused on internal tooling.
 ```
+
+---
+
+## Persona and system instruction
+
+### `BOTS_{n}_PERSONA`
+
+Stores a **Persona ID string**. At runtime, PersonaManager resolves this ID to a full Persona object containing:
+
+- `id`, `name`, `description`, `category`, `traits`
+- `systemPrompt` — the full prompt template for this bot's voice and character
+- `responseBehavior` — optional embedded response-behaviour settings (baseChance, mentionBonus, penalties, onlyWhenSpokenTo, etc.)
+- `avatarStyle`, `isBuiltIn`
+
+Personas are reusable templates — the same persona can be assigned to multiple bots. They are managed in the Web UI under **Personas** or defined in `config/personas/`.
+
+### `BOTS_{n}_SYSTEM_INSTRUCTION`
+
+An **independent system instruction** that can override or supplement the persona's `systemPrompt`. When both a persona and a system instruction are set, the system instruction takes precedence over the persona's built-in `systemPrompt`. Use this when you need to give a specific bot a custom prompt without creating an entirely new persona.
 
 ---
 
@@ -171,9 +192,19 @@ Configures the bot's memory/context backend.
 
 ### Response Profile (`RESPONSE_PROFILE`)
 
-Overrides message-behaviour settings (typing delays, response length, etc.).
+Overrides per-bot `MESSAGE_*` settings (unsolicited response chance, typing delays, response length, etc.). This is **not** the same as a persona — response profiles contain only messaging-behaviour overrides, not character or prompt data.
 
 **Variable:** `BOTS_{n}_RESPONSE_PROFILE`
+
+Built-in profiles: `eager` (higher response chance, shorter delays) and `cautious` (lower chance, longer delays). Custom profiles can be defined in `config/response-profiles.json`.
+
+**Unsolicited response configuration operates at three levels** (highest priority wins):
+
+| Level | Mechanism | Where defined |
+|---|---|---|
+| Per-persona | `Persona.responseBehavior` fields (baseChance, mentionBonus, onlyWhenSpokenTo, etc.) | Embedded in the Persona object; editable via Web UI → Personas |
+| Per-bot | `BOTS_{n}_RESPONSE_PROFILE` → response profile key | `config/response-profiles.json` or built-ins |
+| Global | `MESSAGE_UNSOLICITED_BASE_CHANCE`, `MESSAGE_UNSOLICITED_ADDRESSED`, etc. | Environment variables / `.env` |
 
 > **Note:** `RESPONSE_PROFILE` is not fully materialised yet. The variable is recognised but the apply step is incomplete. This is a known TODO.
 
@@ -245,7 +276,7 @@ BOTS_SLACK_SUPPORT_SLACK_JOIN_CHANNELS=C01234567,C09876543
 | MCP Guard | `BOTS_{n}_MCP_GUARD_PROFILE` | `config/guardrail-profiles.json` | `applyGuardrailProfile()` | Fully applied |
 | MCP Server | `BOTS_{n}_MCP_SERVER_PROFILE` | `config/mcp-server-profiles.json` | `applyMcpServerProfile()` | Fully applied |
 | Memory | `BOTS_{n}_MEMORY_PROFILE` | `config/memory-profiles.json` | `applyMemoryProfile()` | TODO: not applied at runtime |
-| Response | `BOTS_{n}_RESPONSE_PROFILE` | _(pending)_ | _(pending)_ | TODO: not fully materialised |
+| Response | `BOTS_{n}_RESPONSE_PROFILE` | `config/response-profiles.json` | _(pending)_ | TODO: not fully materialised; built-ins: `eager`, `cautious` |
 
 ---
 

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -14,8 +14,9 @@ the WebUI.
    `config/user/bot-overrides.json`.
 3. **Static configuration files** – defaults under `config/` (e.g.
    `config/default.json`, `config/bots/*.json`).
-4. **Personas and templates** – JSON/YAML content in `config/personas/` that can
-   be referenced by name.
+4. **Personas** – full persona objects in `config/personas/` referenced by Persona ID
+   (e.g. via `BOTS_{NAME}_PERSONA`); each carries a `systemPrompt`, `traits`,
+   `responseBehavior`, and other metadata resolved at runtime by PersonaManager.
 
 Convict provides schema validation and sensible defaults at each layer.
 
@@ -54,14 +55,17 @@ MCP_TOOL_GUARD_ALLOWLIST=1234567890,9876543210
 ```
 
 ## Personas & System Instructions
-- Personas are stored in `config/personas/`. Each file exposes a `key`,
-  `displayName`, and prompt content.
-- Assign a persona globally with `MESSAGE_PERSONA_KEY=<key>` or per agent via
-  `BOTS_{NAME}_PERSONA_KEY`.
-- Provide ad-hoc system instructions using `MESSAGE_SYSTEM_INSTRUCTIONS` or
-  `BOTS_{NAME}_SYSTEM_INSTRUCTIONS`.
-- When both are supplied, the persona template loads first and system
-  instructions append additional guidance.
+- Personas are managed in `config/personas/` and via the Web UI. Each persona is a
+  full object containing an `id`, `name`, `systemPrompt` (the prompt template for
+  that bot's voice), optional `responseBehavior` fields, `traits`, `category`, and
+  `avatarStyle`. Personas are reusable — the same persona can be assigned to
+  multiple bots.
+- Assign a persona to a bot via `BOTS_{NAME}_PERSONA=<persona-id>`. The ID is
+  resolved at runtime by PersonaManager to the full Persona object.
+- Provide an independent system instruction per bot using
+  `BOTS_{NAME}_SYSTEM_INSTRUCTION`. When both a persona and a system instruction
+  are set, the system instruction takes precedence over the persona's built-in
+  `systemPrompt`.
 
 ## WebUI Overrides & Guardrails
 - The WebUI shows which fields are locked by environment variables. Locked


### PR DESCRIPTION
## Summary

- **Persona ID vs key**: Replace all "persona key" / `PERSONA_KEY` usages with the correct term — `BOTS_{n}_PERSONA` stores a **Persona ID string** resolved at runtime by PersonaManager to a full Persona object (id, name, systemPrompt, responseBehavior, traits, avatarStyle, isBuiltIn).
- **SYSTEM_INSTRUCTION semantics**: Clarify `BOTS_{n}_SYSTEM_INSTRUCTION` as an **independent system instruction** that overrides the persona's built-in `systemPrompt` when set — not merely a "per-bot prompt override". Also fix wrong env var names in `overview.md` (`PERSONA_KEY` → `PERSONA`, `SYSTEM_INSTRUCTIONS` → `SYSTEM_INSTRUCTION`).
- **Unsolicited response levels**: Document the three-tier priority for unsolicited response config — per-persona (`Persona.responseBehavior` embedded fields), per-bot (`BOTS_{n}_RESPONSE_PROFILE`), and global (`MESSAGE_UNSOLICITED_*` env vars). Add a table in `multi-bot-setup.md` under the RESPONSE_PROFILE section.
- **RESPONSE_PROFILE description**: Correct the description — response profiles are per-bot `MESSAGE_*` overrides (built-ins: `eager`, `cautious`; custom via `config/response-profiles.json`), not the same as personas.

## Files changed

- `docs/configuration/multi-bot-setup.md` — added Persona/SYSTEM_INSTRUCTION section, fixed RESPONSE_PROFILE description, added unsolicited-response level table
- `docs/configuration/overview.md` — fixed env var names, rewrote Personas & System Instructions section, updated Sources & Precedence entry
- `docs/architecture/layered-overview.md` — updated Persona & System Instructions section to describe personas as full objects and SYSTEM_INSTRUCTION as the override mechanism

## Test plan

- [ ] Read each changed file and verify terminology matches the ground-truth facts in the task
- [ ] Confirm no invented design — all descriptions match current code behaviour