### PR TITLE
fix: improve doc strings for persona, system_instruction, and unsolicited response config

### DIFF
--- a/src/config/botSchema.ts
+++ b/src/config/botSchema.ts
@@ -33,14 +33,14 @@ export const botSchema = {
 
   // Persona configuration
   PERSONA: {
-    doc: 'Bot persona key',
+    doc: 'Persona ID (UUID) to use for this bot. The ID is resolved at runtime by PersonaManager to a full Persona object containing a system-prompt template, response-behaviour settings, traits, and category.',
     format: String,
     default: 'default',
     env: 'BOTS_{name}_PERSONA',
   },
 
   SYSTEM_INSTRUCTION: {
-    doc: 'Bot system instruction/prompt',
+    doc: 'Optional system instruction that overrides the system-prompt template supplied by the selected Persona. When set this value replaces Persona.systemPrompt entirely, so the bot still inherits all other Persona fields (responseBehavior, traits, etc.).',
     format: String,
     default: '',
     env: 'BOTS_{name}_SYSTEM_INSTRUCTION',

--- a/src/config/messageConfig.ts
+++ b/src/config/messageConfig.ts
@@ -417,7 +417,7 @@ const messageConfig = convict({
     env: 'MESSAGE_DELAY_MULTIPLIER',
   },
   MESSAGE_RESPONSE_PROFILES: {
-    doc: 'Named response profiles for per-bot engagement tuning. JSON map of profileName -> {MESSAGE_* overrides}.',
+    doc: 'Named response profiles for per-bot engagement tuning. JSON map of profileName → {MESSAGE_* overrides}. Built-in profiles: "default" (baseline), "eager" (low delay, higher unsolicited chance, responds unprompted), "cautious" (high delay, very low unsolicited chance, only responds when spoken to). Additional custom profiles can be added here and referenced via BOTS_{name}_RESPONSE_PROFILE.',
     format: 'response-profiles',
     default: {
       default: {},
@@ -531,13 +531,13 @@ const messageConfig = convict({
     env: 'MESSAGE_INTERACTIVE_FOLLOWUPS',
   },
   MESSAGE_UNSOLICITED_ADDRESSED: {
-    doc: 'Allow unsolicited addressed messages',
+    doc: 'Allow the bot to send unsolicited replies to messages that were explicitly directed at it (e.g. mentions, DMs) but where the bot chose not to respond immediately. When false the bot only replies when actively triggered.',
     format: Boolean,
     default: false,
     env: 'MESSAGE_UNSOLICITED_ADDRESSED',
   },
   MESSAGE_UNSOLICITED_UNADDRESSED: {
-    doc: 'Allow unsolicited unaddressed messages',
+    doc: 'Allow the bot to send unsolicited replies to messages that were NOT directed at it. Probability is governed by MESSAGE_UNSOLICITED_BASE_CHANCE and related factor vars. Has no effect when MESSAGE_ONLY_WHEN_SPOKEN_TO=true.',
     format: Boolean,
     default: false,
     env: 'MESSAGE_UNSOLICITED_UNADDRESSED',


### PR DESCRIPTION
## Summary

- **`botSchema.ts` — `PERSONA`**: was `'Bot persona key'` — now accurately states it stores a UUID that PersonaManager resolves to a full Persona object (system-prompt template, responseBehavior, traits, category)
- **`botSchema.ts` — `SYSTEM_INSTRUCTION`**: was `'Bot system instruction/prompt'` — now explains it *overrides* `Persona.systemPrompt` while the bot still inherits all other Persona fields
- **`messageConfig.ts` — `MESSAGE_RESPONSE_PROFILES`**: was a terse one-liner — now documents the three built-ins (`default`/`eager`/`cautious`) and how custom profiles are referenced via `BOTS_{name}_RESPONSE_PROFILE`
- **`messageConfig.ts` — `MESSAGE_UNSOLICITED_ADDRESSED`**: was `'Allow unsolicited addressed messages'` — now describes exact trigger condition and the `false` behaviour
- **`messageConfig.ts` — `MESSAGE_UNSOLICITED_UNADDRESSED`**: was `'Allow unsolicited unaddressed messages'` — now explains probability mechanics and the `MESSAGE_ONLY_WHEN_SPOKEN_TO` interaction

## Test plan
- [ ] Confirm TypeScript compiles without errors (`timeout 30 npm run dev`)
- [ ] Visually verify config descriptions surface correctly in any admin tooling that reads convict `doc` fields