### PR TITLE
fix: add-widget popup needs solid bg, border and shadow

### DIFF
--- a/src/client/src/components/DaisyUI/DashboardWidgetSystem.tsx
+++ b/src/client/src/components/DaisyUI/DashboardWidgetSystem.tsx
@@ -457,7 +457,7 @@ const DashboardWidgetSystem: React.FC<DashboardWidgetSystemProps> = ({
 
       {/* Widget Palette */}
       {showWidgetPalette && (
-        <Card className="fixed top-20 right-4 z-40 w-80" title="Add Widget">
+        <Card className="fixed top-20 right-4 z-40 w-80 bg-base-100 shadow-xl border border-base-300" title="Add Widget">
           <div className="grid grid-cols-1 gap-2">
             {widgetTypes.map(type => (
               <button


### PR DESCRIPTION
## Problem
The \"Add Widget\" palette is a `fixed` floating overlay but had no shadow or explicit border, so it could visually blend into whatever content was behind it.

## Change
`DashboardWidgetSystem.tsx` — added `bg-base-100 shadow-xl border border-base-300` to the palette `<Card>`:
- `bg-base-100` — ensures opaque background regardless of theme (Card already sets this but being explicit guarantees it isn't overridden)
- `shadow-xl` — elevates the popup visually above the dashboard grid
- `border border-base-300` — crisp edge so the bounds are obvious

## Test plan
- [ ] Open dashboard in edit mode, click \"Add Widget\" — popup appears with solid background and visible shadow/border
- [ ] Check in both light and dark themes