### PR TITLE
fix: redact Slack secrets (signingSecret, botToken, appToken) in config API

### DIFF
--- a/src/server/utils/sanitizeConfig.ts
+++ b/src/server/utils/sanitizeConfig.ts
@@ -21,6 +21,12 @@ const SENSITIVE_KEYS = new Set([
   'private_key',
   'webhookSecret',
   'webhook_secret',
+  'signingSecret',
+  'signing_secret',
+  'botToken',
+  'bot_token',
+  'appToken',
+  'app_token',
 ]);
 
 export function sanitizeConfig(config: Record<string, unknown>): Record<string, unknown> {

--- a/src/webui/routes/config.ts
+++ b/src/webui/routes/config.ts
@@ -29,6 +29,15 @@ router.get('/api/config', (_req, res) => {
         if (botClone.openswarm && botClone.openswarm.apiKey) {
           botClone.openswarm.apiKey = '***';
         }
+        if (botClone.slack && botClone.slack.botToken) {
+          botClone.slack.botToken = '***';
+        }
+        if (botClone.slack && botClone.slack.appToken) {
+          botClone.slack.appToken = '***';
+        }
+        if (botClone.slack && botClone.slack.signingSecret) {
+          botClone.slack.signingSecret = '***';
+        }
 
         // Compatibility fields for tests
         botClone.provider = botClone.messageProvider;

--- a/tests/api/webui-config-api.test.ts
+++ b/tests/api/webui-config-api.test.ts
@@ -42,9 +42,15 @@ describe('WebUI Configuration API - COMPLETE TDD SUITE', () => {
 
       const configString = JSON.stringify(response.body);
 
-      // Should not contain sensitive data
+      // Should not contain sensitive data values (key names containing these words are acceptable)
       expect(configString).not.toMatch(/password/i);
-      expect(configString).not.toMatch(/secret/i);
+      // Ensure signingSecret and similar fields have redacted values, not literal secrets
+      expect(configString).not.toMatch(/"signingSecret"\s*:\s*"(?!\*\*\*)[^"]+"/);
+      expect(configString).not.toMatch(/"botToken"\s*:\s*"(?!\*\*\*)[^"]+"/);
+      expect(configString).not.toMatch(/"appToken"\s*:\s*"(?!\*\*\*)[^"]+"/);
+      expect(configString).not.toMatch(/"clientSecret"\s*:\s*"(?!\*\*\*)[^"]+"/);
+      expect(configString).not.toMatch(/"webhookSecret"\s*:\s*"(?!\*\*\*)[^"]+"/);
+      expect(configString).not.toMatch(/"secret"\s*:\s*"(?!\*\*\*)[^"]+"/i);
       // If bots are present, tokens should be redacted
       // Note: In test environment with no bots configured, these patterns won't match
       // The test verifies the API doesn't leak sensitive data


### PR DESCRIPTION
## Summary

- Added `signingSecret`, `signing_secret`, `botToken`, `bot_token`, `appToken`, and `app_token` to `SENSITIVE_KEYS` in `src/server/utils/sanitizeConfig.ts`
- Added explicit redaction for `slack.botToken`, `slack.appToken`, and `slack.signingSecret` in the webui config route (`src/webui/routes/config.ts`)
- Fixed the overly-broad `/secret/i` test regex in `tests/api/webui-config-api.test.ts` — it was matching key names like `signingSecret` even when values were properly redacted; replaced with targeted per-field regexes that only fail when the field VALUE is not `***`

## Test plan

- [x] `NODE_CONFIG_DIR=config/test/ NODE_ENV=test node -r dotenv/config ./node_modules/jest/bin/jest.js --runInBand --no-coverage --testPathPattern="webui-config-api"` — all 30 tests pass
- [x] `NODE_CONFIG_DIR=config/test/ NODE_ENV=test node -r dotenv/config ./node_modules/jest/bin/jest.js --runInBand --no-coverage --testPathPattern="sanitizeConfig"` — all 12 tests pass