### PR TITLE
test: add architectural guard preventing raw axios in packages

### DIFF
--- a/tests/unit/architecture/no-raw-axios-in-packages.test.ts
+++ b/tests/unit/architecture/no-raw-axios-in-packages.test.ts
@@ -1,0 +1,31 @@
+import { execSync } from 'child_process';
+import path from 'path';
+
+/**
+ * Architectural guard: packages must use the SSRF-safe `http` client from
+ * `@hivemind/shared-types` instead of importing `axios` directly.
+ *
+ * The shared httpClient.ts calls `isSafeUrl()` on every request, so routing
+ * all HTTP traffic through it guarantees SSRF protection without manual checks.
+ */
+describe('Architecture: no raw axios in packages', () => {
+  it('should not import axios in any package source file', () => {
+    const packagesDir = path.resolve(__dirname, '../../../packages');
+    let output = '';
+    try {
+      output = execSync(
+        `grep -rn "from 'axios'\\|from \\"axios\\"\\|require('axios')\\|require(\\"axios\\")" --include="*.ts" "${packagesDir}" 2>/dev/null || true`,
+        { encoding: 'utf-8' }
+      );
+    } catch {
+      return;
+    }
+
+    const violations = output
+      .split('\n')
+      .filter(Boolean)
+      .filter((line) => !line.includes('.test.') && !line.includes('.spec.') && !line.includes('.d.ts'));
+
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
Adds `tests/unit/architecture/no-raw-axios-in-packages.test.ts` — an architectural guard that ensures no package source file imports `axios` directly, forcing all HTTP traffic through the SSRF-safe `http` client from `@hivemind/shared-types`.

**Context**: During review of PR #1630 (SSRF fix), discovered the entire codebase has already been migrated from raw axios to the shared http client which calls `isSafeUrl()` on every request. This test prevents regressions.

**What it checks**: Scans all `packages/` `.ts` files (excluding tests/declarations) for direct axios imports. Fails if any are found.