### PR TITLE
🧹 Janitor: Remove deprecated AutoBreadcrumbs alias

### DIFF
--- a/src/client/src/components/DaisyUI/Breadcrumbs.tsx
+++ b/src/client/src/components/DaisyUI/Breadcrumbs.tsx
@@ -214,8 +214,3 @@ const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ items }) => {
 };
 
 export default Breadcrumbs;
-
-/**
- * @deprecated Use Breadcrumbs (the default export) with no props for auto mode.
- */
-export const AutoBreadcrumbs = Breadcrumbs;

--- a/src/client/src/components/DaisyUI/__tests__/Breadcrumbs.test.tsx
+++ b/src/client/src/components/DaisyUI/__tests__/Breadcrumbs.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
-import Breadcrumbs, { AutoBreadcrumbs } from '../Breadcrumbs';
+import Breadcrumbs from '../Breadcrumbs';
 
 describe('Breadcrumbs', () => {
   describe('manual mode (items prop)', () => {
@@ -119,12 +119,6 @@ describe('Breadcrumbs', () => {
       const bots = screen.getByText('Bots');
       const span = bots.closest('span');
       expect(span).toHaveAttribute('aria-current', 'page');
-    });
-  });
-
-  describe('backward compatibility', () => {
-    it('exports AutoBreadcrumbs as an alias', () => {
-      expect(AutoBreadcrumbs).toBe(Breadcrumbs);
     });
   });
 });

--- a/src/client/src/components/DaisyUI/index.ts
+++ b/src/client/src/components/DaisyUI/index.ts
@@ -3,7 +3,7 @@ export { default as Accordion } from './Accordion';
 export { Alert } from './Alert';
 export { default as Avatar } from './Avatar';
 export { default as Badge } from './Badge';
-export { default as Breadcrumbs, AutoBreadcrumbs } from './Breadcrumbs';
+export { default as Breadcrumbs } from './Breadcrumbs';
 export type { BreadcrumbItem, BreadcrumbsProps } from './Breadcrumbs';
 export { default as Hero } from './Hero';
 export { default as Button } from './Button';


### PR DESCRIPTION
🎯 **What:** Removed the deprecated `AutoBreadcrumbs` component alias from `Breadcrumbs.tsx`, `index.ts`, and the associated test file.
💡 **Why:** This code health improvement removes dead/deprecated code to improve maintainability and readability, as requested by the task. The deprecated alias was a straightforward search-and-replace, and its removal reduces clutter.
✅ **Verification:** Verified the fix locally by running the frontend tests for the Breadcrumbs component using `vitest` to ensure no functionality is broken.
✨ **Result:** Cleaned up the `Breadcrumbs` component and tests without changing any active functionality.

---
*PR created automatically by Jules for task [9291242084187239517](https://jules.google.com/task/9291242084187239517) started by @matthewhand*