### PR TITLE
fix(docs): correct broken image path for Message Platforms List

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -126,7 +126,7 @@ Manage connections to Large Language Model providers.
 ### [Message Platforms](/admin/providers/message)
 Connect your bots to messaging services.
 
-![Message Platforms List](screenshots/message-add-provider-modal.png)
+![Message Platforms List](screenshots/message-providers-list.png)
 ![Add Message Provider](screenshots/message-add-provider-modal.png)
 
 *   **Discord**: Add your Discord Bot Token and configure server settings.


### PR DESCRIPTION
## Summary
- Fix broken image reference in USER_GUIDE.md for Message Platforms section

Extracted from `docs/user-guide-expansion` branch during cleanup.

👾 Generated with [Letta Code](https://letta.com)