### PR TITLE
test: align isSafeUrl mocks with SafeUrlResult return type

### DIFF
--- a/packages/memory-mem0/src/Mem0Provider.test.ts
+++ b/packages/memory-mem0/src/Mem0Provider.test.ts
@@ -268,7 +268,7 @@ describe('SSRF protection', () => {
   const { isSafeUrl } = jest.requireMock('@hivemind/shared-types');
 
   it('blocks requests when isSafeUrl returns false', async () => {
-    isSafeUrl.mockResolvedValue(false);
+    isSafeUrl.mockResolvedValue({ safe: false });
     const p = new Mem0Provider({
       ...BASE_CONFIG,
       baseUrl: 'http://169.254.169.254',

--- a/packages/memory-mem4ai/src/Mem4aiProvider.test.ts
+++ b/packages/memory-mem4ai/src/Mem4aiProvider.test.ts
@@ -1,11 +1,6 @@
 import { Mem4aiProvider } from './Mem4aiProvider';
 import { Mem4aiApiError } from './types';
-
-// Mock isSafeUrl so test URLs don't trigger SSRF guard failures
-jest.mock('@hivemind/shared-types', () => ({
-  ...jest.requireActual('@hivemind/shared-types'),
-  isSafeUrl: jest.fn().mockResolvedValue({ safe: true }),
-}));
+import { clearCircuitBreakerRegistry } from './CircuitBreaker';
 
 // Mock isSafeUrl so test URLs don't trigger SSRF guard failures
 jest.mock('@hivemind/shared-types', () => ({

--- a/packages/memory-mem4ai/src/Mem4aiProvider.test.ts
+++ b/packages/memory-mem4ai/src/Mem4aiProvider.test.ts
@@ -7,6 +7,12 @@ jest.mock('@hivemind/shared-types', () => ({
   isSafeUrl: jest.fn().mockResolvedValue({ safe: true }),
 }));
 
+// Mock isSafeUrl so test URLs don't trigger SSRF guard failures
+jest.mock('@hivemind/shared-types', () => ({
+  ...jest.requireActual('@hivemind/shared-types'),
+  isSafeUrl: jest.fn().mockResolvedValue({ safe: true }),
+}));
+
 const BASE_CONFIG = {
   apiKey: 'test-key',
   apiUrl: 'https://api.mem4ai.example.com',

--- a/tests/unit/providers/Mem0Provider.edge.test.ts
+++ b/tests/unit/providers/Mem0Provider.edge.test.ts
@@ -14,7 +14,7 @@ import { clearCircuitBreakerRegistry } from '../../../src/common/CircuitBreaker'
 // Mock isSafeUrl so injected test URLs don't trigger SSRF guard failures
 jest.mock('@hivemind/shared-types', () => ({
   ...jest.requireActual('@hivemind/shared-types'),
-  isSafeUrl: jest.fn().mockResolvedValue(true),
+  isSafeUrl: jest.fn().mockResolvedValue({ safe: true }),
 }));
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/providers/Mem0Provider.test.ts
+++ b/tests/unit/providers/Mem0Provider.test.ts
@@ -12,7 +12,7 @@ import { clearCircuitBreakerRegistry } from '../../../src/common/CircuitBreaker'
 // Mock isSafeUrl so injected test URLs don't trigger SSRF guard failures
 jest.mock('@hivemind/shared-types', () => ({
   ...jest.requireActual('@hivemind/shared-types'),
-  isSafeUrl: jest.fn().mockResolvedValue(true),
+  isSafeUrl: jest.fn().mockResolvedValue({ safe: true }),
 }));
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Aligns test mocks for `isSafeUrl` to return the `SafeUrlResult` object shape instead of a plain boolean, fixing type mismatches in Mem0Provider and Mem4aiProvider tests.