### PR TITLE
🎨 Palette: [UX improvement] Add aria-label to system announcements button

### DIFF
--- a/src/client/src/components/SystemAnnouncements.tsx
+++ b/src/client/src/components/SystemAnnouncements.tsx
@@ -142,6 +142,7 @@ const SystemAnnouncements: React.FC<SystemAnnouncementsProps> = ({
               className="btn btn-ghost btn-sm btn-circle"
               onClick={() => setIsLive(!isLive)}
               title={isLive ? 'Pause live updates' : 'Resume live updates'}
+              aria-label={isLive ? 'Pause live updates' : 'Resume live updates'}
             >
               {isLive ? '⏸️' : '▶️'}
             </button>

--- a/src/server/services/websocket/index.ts
+++ b/src/server/services/websocket/index.ts
@@ -90,7 +90,9 @@ export class WebSocketService {
 
         const demoMode = container.isRegistered(DemoModeService)
           ? container.resolve(DemoModeService)
-          : (DemoModeService as any).getInstance ? (DemoModeService as any).getInstance() : new DemoModeService();
+          : (DemoModeService as any).getInstance
+            ? (DemoModeService as any).getInstance()
+            : new DemoModeService();
 
         const broadcastService = container.isRegistered(BroadcastService)
           ? container.resolve(BroadcastService)


### PR DESCRIPTION
**💡 What**
Added an `aria-label` to the "Pause / Resume" icon-only button in the `<SystemAnnouncements>` component.

**🎯 Why**
The button only contained an emoji (`⏸️` or `▶️`) and a `title` attribute. Screen readers need a clear, reliable accessible name, especially for real-time controls whose state toggles dynamically. Providing an `aria-label` ensures the button's action is announced correctly to assistive technologies.

**📸 Before/After**
*Before:* `<button title="Pause live updates">⏸️</button>`
*After:* `<button title="Pause live updates" aria-label="Pause live updates">⏸️</button>`

**♿ Accessibility**
Improves screen reader support for the System Announcements component by exposing an accessible name for the toggle button.

---
*PR created automatically by Jules for task [14600330066954628424](https://jules.google.com/task/14600330066954628424) started by @matthewhand*