### PR TITLE
⚡ Bolt: [performance improvement] Prevent O(N) re-renders in Provider Config lists

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -22,3 +22,7 @@
 ## 2024-05-22 - Dashboard Bot Status Lookups
 **Learning:** `Dashboard.tsx` was rendering a list of bots and calling `status?.bots?.find()` for every bot in the `.map()` loop, making the rendering loop $O(N \times M)$ complexity.
 **Action:** When rendering lists in React components that require correlated data, never use `.find()` inside the `.map()`. Pre-compute a lookup Map using `useMemo` to achieve O(1) lookups and bring the rendering complexity down to $O(N + M)$.
+
+## 2024-05-23 - Complete Memoization of Context-Derived Lists
+**Learning:** Adding `React.memo` to a list item (like `SortableProviderCard`) isn't enough if the parent component passes down unmemoized callbacks or if derived arrays used for context (like `providers.map(p => p.id)` for `SortableContext`) are recreated on every render. This forces unnecessary re-renders of $O(N)$ list items on any unrelated parent state update.
+**Action:** Always ensure that `React.memo` list items receive stable props by wrapping parent handlers in `useCallback` and derived arrays or data structures passed down to contexts/lists in `useMemo`.

--- a/src/client/src/components/ProviderManagement/BaseProvidersConfig.tsx
+++ b/src/client/src/components/ProviderManagement/BaseProvidersConfig.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   closestCenter,
   DndContext,
@@ -66,7 +66,8 @@ interface SortableProviderCardProps {
   onToggleActive: (id: string, isActive: boolean) => void;
 }
 
-const SortableProviderCard: React.FC<SortableProviderCardProps> = ({
+// ⚡ Bolt Optimization: Added React.memo() to prevent unnecessary re-renders of list items when parent state changes.
+const SortableProviderCard: React.FC<SortableProviderCardProps> = React.memo(({
   provider,
   onEdit,
   onDelete,
@@ -149,7 +150,7 @@ const SortableProviderCard: React.FC<SortableProviderCardProps> = ({
       </Card>
     </div>
   );
-};
+});
 
 const BaseProvidersConfig: React.FC<BaseProvidersConfigProps> = ({
   apiEndpoint,
@@ -188,7 +189,8 @@ const BaseProvidersConfig: React.FC<BaseProvidersConfigProps> = ({
     })
   );
 
-  const fetchProviders = async () => {
+  // ⚡ Bolt Optimization: Memoized parent callbacks and arrays so SortableProviderCard gets stable props.
+  const fetchProviders = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
@@ -199,11 +201,11 @@ const BaseProvidersConfig: React.FC<BaseProvidersConfigProps> = ({
     } finally {
       setLoading(false);
     }
-  };
+  }, [apiEndpoint, title]);
 
   useEffect(() => {
     fetchProviders();
-  }, [apiEndpoint]);
+  }, [fetchProviders]);
 
   const handleDragEnd = async (event: DragEndEvent) => {
     const { active, over } = event;
@@ -228,17 +230,17 @@ const BaseProvidersConfig: React.FC<BaseProvidersConfigProps> = ({
     }
   };
 
-  const handleOpenDialog = (provider?: ProviderItem) => {
+  const handleOpenDialog = useCallback((provider?: ProviderItem) => {
     setEditingProvider(provider || null);
     setFormData(provider?.config || {});
     setOpenDialog(true);
-  };
+  }, []);
 
-  const handleCloseDialog = () => {
+  const handleCloseDialog = useCallback(() => {
     setOpenDialog(false);
     setEditingProvider(null);
     setFormData({});
-  };
+  }, []);
 
   const handleSaveProvider = async () => {
     try {
@@ -274,7 +276,7 @@ const BaseProvidersConfig: React.FC<BaseProvidersConfigProps> = ({
     }
   };
 
-  const handleDeleteProvider = async (providerId: string) => {
+  const handleDeleteProvider = useCallback(async (providerId: string) => {
     setConfirmModal({
       isOpen: true,
       title: 'Delete Provider',
@@ -299,9 +301,9 @@ const BaseProvidersConfig: React.FC<BaseProvidersConfigProps> = ({
         }
       },
     });
-  };
+  }, [apiEndpoint, fetchProviders]);
 
-  const handleToggleActive = async (providerId: string, isActive: boolean) => {
+  const handleToggleActive = useCallback(async (providerId: string, isActive: boolean) => {
     try {
       await apiService.post(`${apiEndpoint}/${providerId}/toggle`, { isActive });
 
@@ -313,12 +315,15 @@ const BaseProvidersConfig: React.FC<BaseProvidersConfigProps> = ({
         type: 'error',
       });
     }
-  };
+  }, [apiEndpoint, fetchProviders]);
 
-  const activeProviderDocs = React.useMemo(() => {
+  const activeProviderDocs = useMemo(() => {
     const currentType = formData.type || editingProvider?.type;
     return providerTypeOptions.find((o) => o.value === currentType)?.docsUrl;
   }, [formData.type, editingProvider?.type, providerTypeOptions]);
+
+  // ⚡ Bolt Optimization: Memoize the derived array to prevent SortableContext from remounting or causing re-renders
+  const providerIds = useMemo(() => providers.map((p) => p.id), [providers]);
 
   if (loading) {
     return (
@@ -366,7 +371,7 @@ const BaseProvidersConfig: React.FC<BaseProvidersConfigProps> = ({
       ) : (
         <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
           <SortableContext
-            items={providers.map((p) => p.id)}
+            items={providerIds}
             strategy={verticalListSortingStrategy}
           >
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/src/server/services/websocket/index.ts
+++ b/src/server/services/websocket/index.ts
@@ -90,7 +90,9 @@ export class WebSocketService {
 
         const demoMode = container.isRegistered(DemoModeService)
           ? container.resolve(DemoModeService)
-          : (DemoModeService as any).getInstance ? (DemoModeService as any).getInstance() : new DemoModeService();
+          : (DemoModeService as any).getInstance
+            ? (DemoModeService as any).getInstance()
+            : new DemoModeService();
 
         const broadcastService = container.isRegistered(BroadcastService)
           ? container.resolve(BroadcastService)


### PR DESCRIPTION
💡 What: Wrapped `SortableProviderCard` in `React.memo` and strictly memoized its dependencies (parent callbacks and array context data) using `useCallback` and `useMemo` in `BaseProvidersConfig`.
🎯 Why: `SortableProviderCard` components rendered inside a complex mapped loop were needlessly re-rendering every time any unrelated parent state (like the dialog box or toast overlay form inputs) updated. This caused visible sluggishness as the list of providers grew.
📊 Impact: Effectively changes rendering complexity of interacting with the modal configurations from $O(N)$ (where N is the number of installed providers) to $O(1)$. Re-renders of list items are now prevented.
🧪 Measurement: You can verify the improvement by placing a `console.log` inside `SortableProviderCard` and triggering a toast or opening a modal; logs will no longer spam the console for every existing provider card. Types and test suites pass locally.

---
*PR created automatically by Jules for task [8365291858140530652](https://jules.google.com/task/8365291858140530652) started by @matthewhand*