### PR TITLE
🎨 Palette: Add descriptive aria-labels to Getting Started action buttons

### DIFF
--- a/src/client/src/components/GettingStarted.tsx
+++ b/src/client/src/components/GettingStarted.tsx
@@ -152,6 +152,7 @@ const GettingStarted: React.FC<GettingStartedProps> = ({ onDismiss }) => {
                 <button
                   className="btn btn-sm btn-ghost border border-base-300 flex-shrink-0"
                   onClick={() => navigate(task.actionLink)}
+                  aria-label={`${task.actionLabel} ${task.title.toLowerCase()}`}
                 >
                   {task.actionLabel}
                 </button>


### PR DESCRIPTION
💡 What: Added a dynamic `aria-label` to the action buttons in the `GettingStarted` dashboard panel tasks list.
🎯 Why: The buttons all share the text "Start", which is confusing for screen reader users when tabbing through them.
♿ Accessibility: The new `aria-label` combines the action text ("Start") with the specific task title (e.g., "Start connect an LLM provider"), giving users clear context on what action they are about to take.

---
*PR created automatically by Jules for task [11865723056438273194](https://jules.google.com/task/11865723056438273194) started by @matthewhand*