### PR TITLE
fix: remove no-explicit-any from top 3 offender files

### DIFF
--- a/src/message/helpers/processing/shouldReplyToMessage.ts
+++ b/src/message/helpers/processing/shouldReplyToMessage.ts
@@ -14,6 +14,29 @@ import { isOnTopic } from './SemanticRelevanceChecker';
 
 const debug = Debug('app:shouldReplyToMessage');
 
+interface MessageLike {
+  getChannelId(): string;
+  getMessageId(): string;
+  getText?(): string;
+  getAuthorId?(): string;
+  isFromBot?(): boolean;
+  isDirectMessage?(): boolean;
+  getUserMentions?(): string[];
+  mentionsUsers?(id: string): boolean;
+  isMentioning?(id: string): boolean;
+  isReplyToBot?(): boolean;
+  metadata?: { replyTo?: { userId?: string } };
+}
+
+interface HistoryMessageLike {
+  getAuthorId?(): string;
+  getText?(): string;
+  isFromBot?(): boolean;
+  authorId?: string;
+  timestamp?: number | Date;
+  createdAt?: number | Date;
+}
+
 /**
  * Resolve the persona's responseBehavior from botConfig.persona (an ID string).
  * Returns undefined when no persona is configured or the persona has no overrides.
@@ -42,12 +65,11 @@ export interface ReplyDecision {
 }
 
 export async function shouldReplyToMessage(
-  message: any,
+  message: MessageLike,
   botId: string,
   platform: 'discord' | 'generic',
   botNameOrNames?: string | string[],
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- heterogeneous history messages
-  historyMessages?: any[],
+  historyMessages?: HistoryMessageLike[],
   defaultChannelId?: string,
   botConfig?: Record<string, unknown>
 ): Promise<ReplyDecision> {
@@ -103,12 +125,11 @@ export async function shouldReplyToMessage(
 }
 
 async function evaluateReplyDecision(
-  message: any,
+  message: MessageLike,
   botId: string,
   platform: 'discord' | 'generic',
   botNameOrNames?: string | string[],
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- heterogeneous history messages
-  historyMessages?: any[],
+  historyMessages?: HistoryMessageLike[],
   defaultChannelId?: string,
   botConfig?: Record<string, unknown>
 ): Promise<ReplyDecision> {
@@ -260,11 +281,7 @@ async function evaluateReplyDecision(
   let density: IncomingMessageDensity | null = null;
   try {
     density = IncomingMessageDensity.getInstance();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- runtime duck-typing check
-    if (typeof (density as any).recordMessage === 'function') {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (density as any).recordMessage(channelId, authorId, isFromBot);
-    }
+    density.recordMessage(channelId, authorId, isFromBot);
   } catch (error) {
     debug('Error recording incoming message density:', error);
   }
@@ -345,12 +362,10 @@ async function evaluateReplyDecision(
     for (let i = historyMessages.length - 1; i >= 0; i--) {
       const m = historyMessages[i];
       if (m.authorId === botId) {
-        const timestamp = (m as any).timestamp || (m as any).createdAt || 0;
+        const tsRaw = m.timestamp || m.createdAt || 0;
+        const timestamp = tsRaw instanceof Date ? tsRaw.getTime() : Number(tsRaw);
         if (timestamp > 0) {
-          lastPostTime = Math.max(
-            lastPostTime,
-            timestamp instanceof Date ? timestamp.getTime() : timestamp
-          );
+          lastPostTime = Math.max(lastPostTime, timestamp);
           break;
         }
       }
@@ -391,8 +406,8 @@ async function evaluateReplyDecision(
     const windowMs = typeof windowRaw === 'number' ? windowRaw : Number(windowRaw) || 5 * 60 * 1000;
     let participants = 1;
     try {
-      if (density && typeof (density as any).getUniqueParticipantCount === 'function') {
-        participants = (density as any).getUniqueParticipantCount(channelId, windowMs);
+      if (density) {
+        participants = density.getUniqueParticipantCount(channelId, windowMs);
       }
     } catch (error) {
       debug('Error getting unique participant count:', error);
@@ -431,7 +446,7 @@ async function evaluateReplyDecision(
     try {
       const recentContext = historyMessages
         .slice(-5)
-        .map((m: any) => `${m.getAuthorId?.() || 'unknown'}: ${m.getText?.() || ''}`)
+        .map((m: HistoryMessageLike) => `${m.getAuthorId?.() || 'unknown'}: ${m.getText?.() || ''}`)
         .join('\n');
       const newMessage = message.getText?.() || '';
       if (await isOnTopic(recentContext, newMessage)) {
@@ -499,8 +514,8 @@ async function evaluateReplyDecision(
 
     if (historyMessages && historyMessages.length > 0 && lastPostTime > 0) {
       for (const msg of historyMessages) {
-        const ts = (msg as any).timestamp || (msg as any).createdAt || 0;
-        const msgTime = ts instanceof Date ? ts.getTime() : ts;
+        const tsRaw = msg.timestamp || msg.createdAt || 0;
+        const msgTime = tsRaw instanceof Date ? tsRaw.getTime() : Number(tsRaw);
         const aid = msg.getAuthorId?.() || '';
         const isBot = msg.isFromBot?.() || false;
 
@@ -539,9 +554,9 @@ async function evaluateReplyDecision(
     }
 
     // Quiet Channel Bonus (5 min window) - still global as it's about channel activity
-    if (density && typeof (density as any).getDensity === 'function') {
+    if (density) {
       const quietWindow = 300000;
-      const { total: total5m } = (density as any).getDensity(channelId, quietWindow);
+      const { total: total5m } = density.getDensity(channelId, quietWindow);
       const quietBonus = 0.2 * Math.max(0, 1 - total5m / 5);
       if (quietBonus > 0) {
         chance += quietBonus;
@@ -840,14 +855,14 @@ function escapeRegExp(string: string) {
 }
 
 function applyModifiers(
-  message: any,
+  message: MessageLike,
   botId: string,
   platform: 'discord' | 'generic',
   chance: number,
   isDirectlyAddressed = false,
   isLeadingAddress = false,
   isReplyToBot = false,
-  botConfig?: Record<string, any>,
+  botConfig?: Record<string, unknown>,
   personaBehavior?: PersonaResponseBehavior
 ): { chance: number; modifiers: string } {
   const text = (message.getText?.() || '').toLowerCase();
@@ -890,7 +905,7 @@ function applyModifiers(
   }
 
   const channelBonuses: Record<string, number> =
-    (messageConfig.get as any)('CHANNEL_BONUSES') || {};
+    (messageConfig.get('CHANNEL_BONUSES') as Record<string, number>) || {};
   const channelBonus =
     typeof channelBonuses?.[message.getChannelId()] === 'number'
       ? channelBonuses[message.getChannelId()]

--- a/src/message/management/getMessengerProvider.ts
+++ b/src/message/management/getMessengerProvider.ts
@@ -1,8 +1,19 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { instantiateMessageService, loadPlugin } from '@src/plugins/PluginLoader';
+import type { IMessengerService } from '../interfaces/IMessengerService';
 
 const gmpDebug = require('debug')('app:getMessengerProvider');
+
+interface MessengersConfig {
+  MESSAGE_PROVIDER?: string | string[];
+  providers?: { type: string }[];
+}
+
+type MessengerServiceInstance = IMessengerService & {
+  provider?: string;
+  sendTypingIndicator(...args: unknown[]): Promise<void>;
+};
 
 /**
  * Get Messenger Providers
@@ -17,11 +28,11 @@ const gmpDebug = require('debug')('app:getMessengerProvider');
  * @returns Array of initialized message provider instances.
  */
 // Ensure CommonJS require compatibility for tests using jest.mock()
-function __require(modulePath: string): any {
+function __require(modulePath: string): unknown {
   return require(modulePath);
 }
 
-let cachedMessengersConfig: any = null;
+let cachedMessengersConfig: MessengersConfig | null = null;
 
 export function resetMessengerProviderCache(): void {
   cachedMessengersConfig = null;
@@ -30,14 +41,16 @@ export function resetMessengerProviderCache(): void {
 export async function getMessengerProvider() {
   const messengersConfigPath = path.join(__dirname, '../../../config/providers/messengers.json');
 
-  let messengersConfig: any = {};
+  let messengersConfig: MessengersConfig = {};
 
   if (cachedMessengersConfig) {
     messengersConfig = cachedMessengersConfig;
   } else {
     try {
       const messengersConfigRaw = await fs.promises.readFile(messengersConfigPath, 'utf-8');
-      messengersConfig = messengersConfigRaw ? JSON.parse(messengersConfigRaw) : {};
+      messengersConfig = messengersConfigRaw
+        ? (JSON.parse(messengersConfigRaw) as MessengersConfig)
+        : {};
     } catch {
       // If file doesn't exist or JSON is invalid, use empty config
       messengersConfig = {};
@@ -45,7 +58,7 @@ export async function getMessengerProvider() {
     cachedMessengersConfig = messengersConfig;
   }
 
-  const messengerServices: any[] = [];
+  const messengerServices: MessengerServiceInstance[] = [];
 
   // Derive MESSAGE_PROVIDER filter similar to src/index.ts bootstrap
   // Supports string or array-like values via environment (primary) or config fallback
@@ -57,7 +70,7 @@ export async function getMessengerProvider() {
           .map((v: string) => v.trim().toLowerCase())
           .filter(Boolean)
       : Array.isArray(rawProviders)
-        ? rawProviders.map((v: any) => String(v).trim().toLowerCase()).filter(Boolean)
+        ? rawProviders.map((v: unknown) => String(v).trim().toLowerCase()).filter(Boolean)
         : [];
 
   const wantProvider = (name: string) => {
@@ -65,8 +78,8 @@ export async function getMessengerProvider() {
   };
 
   // In tests we exclusively support the { providers: [{ type: string }] } shape
-  const providersArray: { type: string }[] = Array.isArray((messengersConfig as any).providers)
-    ? (messengersConfig as any).providers
+  const providersArray: { type: string }[] = Array.isArray(messengersConfig.providers)
+    ? messengersConfig.providers
     : [];
 
   const hasType = (type: string) =>
@@ -94,10 +107,11 @@ export async function getMessengerProvider() {
       const mod = await loadPlugin(`message-${name}`);
       const svc = instantiateMessageService(mod, undefined, dependencies);
       if (svc) {
-        if (typeof (svc as any).provider === 'undefined') {
-          (svc as any).provider = name;
+        const instance = svc as MessengerServiceInstance;
+        if (typeof instance.provider === 'undefined') {
+          instance.provider = name;
         }
-        messengerServices.push(svc);
+        messengerServices.push(instance);
         gmpDebug('Initialized %s provider via plugin loader', name);
       }
     } catch (e: unknown) {
@@ -122,10 +136,11 @@ export async function getMessengerProvider() {
         const mod = await loadPlugin('message-slack');
         const svc = instantiateMessageService(mod, undefined, dependencies);
         if (svc) {
-          if (typeof (svc as any).provider === 'undefined') {
-            (svc as any).provider = 'slack';
+          const instance = svc as MessengerServiceInstance;
+          if (typeof instance.provider === 'undefined') {
+            instance.provider = 'slack';
           }
-          messengerServices.push(svc);
+          messengerServices.push(instance);
         }
       } catch {
         // As a last resort in tests, return a recognizable Slack sentinel
@@ -133,13 +148,13 @@ export async function getMessengerProvider() {
           provider: 'slack',
           sendMessageToChannel: () => {},
           getClientId: () => 'SLACK_CLIENT_ID',
-        });
+        } as unknown as MessengerServiceInstance);
       }
     }
   }
 
   gmpDebug(
-    `Returning ${messengerServices.length} provider(s): ${messengerServices.map((p: any) => p?.provider).join(',')}`
+    `Returning ${messengerServices.length} provider(s): ${messengerServices.map((p) => p?.provider).join(',')}`
   );
   return messengerServices;
 }

--- a/src/services/ServiceDependenciesProvider.ts
+++ b/src/services/ServiceDependenciesProvider.ts
@@ -1,4 +1,12 @@
-import { type IErrorTypes, type IServiceDependencies } from '@hivemind/shared-types';
+import {
+  type IBotConfig,
+  type IConfigAccessor,
+  type IErrorTypes,
+  type IMetricsCollector,
+  type IServiceDependencies,
+  type IStartupGreetingService,
+  type IWebSocketService,
+} from '@hivemind/shared-types';
 import Logger from '../common/logger';
 import { BotConfigurationManager } from '../config/BotConfigurationManager';
 import * as discordConfig from '../config/discordConfig';
@@ -23,24 +31,27 @@ export class ServiceDependenciesProvider {
     const botConfigManager = BotConfigurationManager.getInstance();
 
     const errorTypes: IErrorTypes = {
-      HivemindError: errorClasses.BaseHivemindError as any,
-      ConfigError: errorClasses.ConfigurationError as any,
-      NetworkError: errorClasses.NetworkError as any,
-      ValidationError: errorClasses.ValidationError as any,
-      AuthenticationError: errorClasses.AuthenticationError as any,
+      HivemindError: errorClasses.BaseHivemindError as unknown as IErrorTypes['HivemindError'],
+      ConfigError: errorClasses.ConfigurationError as unknown as IErrorTypes['ConfigError'],
+      NetworkError: errorClasses.NetworkError as unknown as IErrorTypes['NetworkError'],
+      ValidationError: errorClasses.ValidationError as unknown as IErrorTypes['ValidationError'],
+      AuthenticationError:
+        errorClasses.AuthenticationError as unknown as IErrorTypes['AuthenticationError'],
     };
 
     return {
       logger: Logger.withContext('Adapter'),
       errorTypes,
-      discordConfig: (discordConfig.default || discordConfig) as any,
-      slackConfig: (slackConfig.default || slackConfig) as any,
-      messageConfig: (messageConfig.default || messageConfig) as any,
-      webSocketService: WebSocketService.getInstance() as any,
-      metricsCollector: MetricsCollector.getInstance() as any,
-      startupGreetingService: container.resolve(StartupGreetingService) as any,
-      getBotConfig: (name: string) => botConfigManager.getBot(name) as any,
-      getAllBotConfigs: () => botConfigManager.getAllBots() as any,
+      discordConfig: (discordConfig.default || discordConfig) as unknown as IConfigAccessor,
+      slackConfig: (slackConfig.default || slackConfig) as unknown as IConfigAccessor,
+      messageConfig: (messageConfig.default || messageConfig) as unknown as IConfigAccessor,
+      webSocketService: WebSocketService.getInstance() as unknown as IWebSocketService,
+      metricsCollector: MetricsCollector.getInstance() as unknown as IMetricsCollector,
+      startupGreetingService: container.resolve(
+        StartupGreetingService
+      ) as unknown as IStartupGreetingService,
+      getBotConfig: (name: string) => botConfigManager.getBot(name) as unknown as IBotConfig | null,
+      getAllBotConfigs: () => botConfigManager.getAllBots() as unknown as IBotConfig[],
       isBotDisabled: (name: string) => !botConfigManager.getBot(name)?.enabled,
     };
   }


### PR DESCRIPTION
## Summary

Remove all `@typescript-eslint/no-explicit-any` warnings from the 3 highest-offender files:

- **shouldReplyToMessage.ts** (14→0): Added `MessageLike`/`HistoryMessageLike` interfaces, removed `density as any` casts (methods are public), typed timestamp access
- **ServiceDependenciesProvider.ts** (13→0): Replaced `as any` with `as unknown as T` using proper `IServiceDependencies` field types  
- **getMessengerProvider.ts** (12→0): Added `MessengersConfig` interface, used `IMessengerService`-based types

**Net: −39 `no-explicit-any` warnings** (510→471 remaining across codebase)

tsc: clean. Tests: no regressions.