### PR TITLE
refactor: extract shared TabbedProviderPage component

### DIFF
--- a/src/client/src/components/TabbedProviderPage.tsx
+++ b/src/client/src/components/TabbedProviderPage.tsx
@@ -1,0 +1,49 @@
+/**
+ * Shared layout wrapper for provider configuration pages.
+ * Provides consistent header, error alert, and tabbed navigation.
+ */
+import React from 'react';
+import type { TabItem } from './DaisyUI/Tabs';
+import Tabs from './DaisyUI/Tabs';
+import { Alert } from './DaisyUI/Alert';
+import { XCircle as XIcon } from 'lucide-react';
+
+interface TabbedProviderPageProps {
+  title: string;
+  description: string;
+  error: string | null;
+  onClearError: () => void;
+  tabs: TabItem[];
+  activeTab: string;
+  onTabChange: (tabId: string) => void;
+  children?: React.ReactNode;
+}
+
+const TabbedProviderPage: React.FC<TabbedProviderPageProps> = ({
+  title,
+  description,
+  error,
+  onClearError,
+  tabs,
+  activeTab,
+  onTabChange,
+  children,
+}) => (
+  <div>
+    <div className="px-6 pt-6 pb-2">
+      <h1 className="text-2xl font-bold">{title}</h1>
+      <p className="text-base-content/60 text-sm mt-1">{description}</p>
+    </div>
+    <div className="px-6 pb-6">
+      {error && (
+        <div className="mb-6">
+          <Alert status="error" icon={<XIcon />} message={error} onClose={onClearError} />
+        </div>
+      )}
+      <Tabs variant="lifted" activeTab={activeTab} onChange={onTabChange} tabs={tabs} />
+      {children}
+    </div>
+  </div>
+);
+
+export default TabbedProviderPage;

--- a/src/client/src/pages/LLMProvidersPage.tsx
+++ b/src/client/src/pages/LLMProvidersPage.tsx
@@ -5,9 +5,9 @@ import { useModal } from '../hooks/useModal';
 import Card from '../components/DaisyUI/Card';
 import Button from '../components/DaisyUI/Button';
 import Badge from '../components/DaisyUI/Badge';
-import Tabs from '../components/DaisyUI/Tabs';
+import TabbedProviderPage from '../components/TabbedProviderPage';
 import Toggle from '../components/DaisyUI/Toggle';
-import { Alert } from '../components/DaisyUI/Alert';
+
 import StatsCards from '../components/DaisyUI/StatsCards';
 import EmptyState from '../components/DaisyUI/EmptyState';
 import ConfigKeyValueCard from '../components/DaisyUI/ConfigKeyValueCard';
@@ -917,25 +917,15 @@ const LLMProvidersPage: React.FC = () => {
   ];
 
   return (
-    <div>
-      <div className="px-6 pt-6 pb-2">
-        <h1 className="text-2xl font-bold">LLM Providers</h1>
-        <p className="text-base-content/60 text-sm mt-1">Manage language model provider profiles and settings</p>
-      </div>
-      <div className="px-6 pb-6">
-        {error && (
-          <div className="mb-6">
-            <Alert status="error" icon={<XIcon />} message={error} onClose={() => setError(null)} />
-          </div>
-        )}
-        <Tabs
-          tabs={tabs}
-          variant="lifted"
-          activeTab={activeTab}
-          onChange={handleTabChange}
-        />
-      </div>
-
+    <TabbedProviderPage
+      title="LLM Providers"
+      description="Manage language model provider profiles and settings"
+      error={error}
+      onClearError={() => setError(null)}
+      tabs={tabs}
+      activeTab={activeTab}
+      onTabChange={handleTabChange}
+    >
       <ProviderConfigModal
         modalState={modalState}
         onClose={closeModal}
@@ -953,7 +943,7 @@ const LLMProvidersPage: React.FC = () => {
           }}
         />
       )}
-    </div>
+    </TabbedProviderPage>
   );
 };
 

--- a/src/client/src/pages/MemoryProvidersPage.tsx
+++ b/src/client/src/pages/MemoryProvidersPage.tsx
@@ -3,8 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import Card from '../components/DaisyUI/Card';
 import Button from '../components/DaisyUI/Button';
 import Badge from '../components/DaisyUI/Badge';
-import Tabs from '../components/DaisyUI/Tabs';
-import { Alert } from '../components/DaisyUI/Alert';
+import TabbedProviderPage from '../components/TabbedProviderPage';
 import StatsCards from '../components/DaisyUI/StatsCards';
 import EmptyState from '../components/DaisyUI/EmptyState';
 import ConfigKeyValueCard from '../components/DaisyUI/ConfigKeyValueCard';
@@ -17,7 +16,7 @@ import {
   Database as MemoryIcon,
   Plus as AddIcon,
   Settings as ConfigIcon,
-  XCircle as XIcon,
+
   Trash2 as DeleteIcon,
   Edit as EditIcon,
   ChevronDown as ExpandIcon,
@@ -466,25 +465,15 @@ const MemoryProvidersPage: React.FC = () => {
   ], [profilesContent]);
 
   return (
-    <div>
-      <div className="px-6 pt-6 pb-2">
-        <h1 className="text-2xl font-bold">Memory Providers</h1>
-        <p className="text-base-content/60 text-sm mt-1">Configure vector stores and memory backends for your bots</p>
-      </div>
-      <div className="px-6 pb-6">
-        {error && (
-          <div className="mb-6">
-            <Alert status="error" icon={<XIcon />} message={error} onClose={() => setError(null)} />
-          </div>
-        )}
-        <Tabs
-          variant="lifted"
-          activeTab={activeTab}
-          onChange={handleTabChange}
-          tabs={memoryTabs}
-        />
-      </div>
-    </div>
+    <TabbedProviderPage
+      title="Memory Providers"
+      description="Configure vector stores and memory backends for your bots"
+      error={error}
+      onClearError={() => setError(null)}
+      tabs={memoryTabs}
+      activeTab={activeTab}
+      onTabChange={handleTabChange}
+    />
   );
 };
 

--- a/src/client/src/pages/MessageProvidersPage.tsx
+++ b/src/client/src/pages/MessageProvidersPage.tsx
@@ -3,21 +3,21 @@ import { useModal } from '../hooks/useModal';
 import Card from '../components/DaisyUI/Card';
 import Button from '../components/DaisyUI/Button';
 import Badge from '../components/DaisyUI/Badge';
-import { Alert } from '../components/DaisyUI/Alert';
+import TabbedProviderPage from '../components/TabbedProviderPage';
 import StatsCards from '../components/DaisyUI/StatsCards';
 import EmptyState from '../components/DaisyUI/EmptyState';
 import ConfigKeyValueCard from '../components/DaisyUI/ConfigKeyValueCard';
 import { SkeletonTableLayout } from '../components/DaisyUI/Skeleton';
 import SearchFilterBar from '../components/SearchFilterBar';
 import { ConfirmModal } from '../components/DaisyUI/Modal';
-import Tabs from '../components/DaisyUI/Tabs';
+
 import Toggle from '../components/DaisyUI/Toggle';
 import { useErrorToast } from '../components/DaisyUI/ToastNotification';
 import {
   MessageSquare as MessageIcon,
   Plus as AddIcon,
   Settings as ConfigIcon,
-  XCircle as XIcon,
+
   Trash2 as DeleteIcon,
   Edit as EditIcon,
   ChevronDown as ExpandIcon,
@@ -549,43 +549,33 @@ const MessageProvidersPage: React.FC = () => {
   ];
 
   return (
-    <div>
-      <div className="px-6 pt-6 pb-2">
-        <h1 className="text-2xl font-bold">Message Providers</h1>
-        <p className="text-base-content/60 text-sm mt-1">Manage messaging platform connections and profiles</p>
-      </div>
-      <div className="px-6 pb-6">
-        {error && (
-          <div className="mb-6">
-            <Alert status="error" icon={<XIcon />} message={error} onClose={() => setError(null)} />
-          </div>
-        )}
-        <Tabs
-          tabs={tabs}
-          variant="lifted"
-          activeTab={activeTab}
-          onChange={setActiveTab}
-        />
+    <TabbedProviderPage
+      title="Message Providers"
+      description="Manage messaging platform connections and profiles"
+      error={error}
+      onClearError={() => setError(null)}
+      tabs={tabs}
+      activeTab={activeTab}
+      onTabChange={setActiveTab}
+    >
+      <ProviderConfigModal
+        modalState={{ ...modalState, providerType: 'message' }}
+        existingProviders={profiles}
+        onClose={closeModal}
+        onSubmit={handleProviderSubmit}
+      />
 
-        <ProviderConfigModal
-          modalState={{ ...modalState, providerType: 'message' }}
-          existingProviders={profiles}
-          onClose={closeModal}
-          onSubmit={handleProviderSubmit}
-        />
-
-        <ConfirmModal
-          isOpen={confirmModal.isOpen}
-          onClose={() => setConfirmModal(prev => ({ ...prev, isOpen: false }))}
-          title={confirmModal.title}
-          message={confirmModal.message}
-          onConfirm={confirmModal.onConfirm}
-          confirmVariant="error"
-          confirmText="Delete"
-          cancelText="Cancel"
-        />
-      </div>
-    </div>
+      <ConfirmModal
+        isOpen={confirmModal.isOpen}
+        onClose={() => setConfirmModal(prev => ({ ...prev, isOpen: false }))}
+        title={confirmModal.title}
+        message={confirmModal.message}
+        onConfirm={confirmModal.onConfirm}
+        confirmVariant="error"
+        confirmText="Delete"
+        cancelText="Cancel"
+      />
+    </TabbedProviderPage>
   );
 };
 

--- a/src/client/src/pages/ToolProvidersPage.tsx
+++ b/src/client/src/pages/ToolProvidersPage.tsx
@@ -3,8 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import Card from '../components/DaisyUI/Card';
 import Button from '../components/DaisyUI/Button';
 import Badge from '../components/DaisyUI/Badge';
-import Tabs from '../components/DaisyUI/Tabs';
-import { Alert } from '../components/DaisyUI/Alert';
+import TabbedProviderPage from '../components/TabbedProviderPage';
 import StatsCards from '../components/DaisyUI/StatsCards';
 import EmptyState from '../components/DaisyUI/EmptyState';
 import ConfigKeyValueCard from '../components/DaisyUI/ConfigKeyValueCard';
@@ -17,7 +16,7 @@ import {
   Wrench as ToolIcon,
   Plus as AddIcon,
   Settings as ConfigIcon,
-  XCircle as XIcon,
+
   Trash2 as DeleteIcon,
   Edit as EditIcon,
   ChevronDown as ExpandIcon,
@@ -281,25 +280,15 @@ const ToolProvidersPage: React.FC = () => {
   ], [profilesContent]);
 
   return (
-    <div>
-      <div className="px-6 pt-6 pb-2">
-        <h1 className="text-2xl font-bold">Tool Providers</h1>
-        <p className="text-base-content/60 text-sm mt-1">Connect tool providers and external integrations</p>
-      </div>
-      <div className="px-6 pb-6">
-        {error && (
-          <div className="mb-6">
-            <Alert status="error" icon={<XIcon />} message={error} onClose={() => setError(null)} />
-          </div>
-        )}
-        <Tabs
-          variant="lifted"
-          activeTab={activeTab}
-          onChange={handleTabChange}
-          tabs={toolTabs}
-        />
-      </div>
-    </div>
+    <TabbedProviderPage
+      title="Tool Providers"
+      description="Connect tool providers and external integrations"
+      error={error}
+      onClearError={() => setError(null)}
+      tabs={toolTabs}
+      activeTab={activeTab}
+      onTabChange={handleTabChange}
+    />
   );
 };
 


### PR DESCRIPTION
## Summary

Extracts the duplicated header + error alert + tabbed navigation layout into a shared `TabbedProviderPage` component, used by all 4 provider config pages.

### Changes
- **New**: `src/client/src/components/TabbedProviderPage.tsx` — shared layout wrapper
- **Refactored**: LLM, Message, Memory, Tool provider pages to use it
- Pages with extra content (modals) pass them via `children` prop

### Before/After
Each page had ~15 lines of identical layout boilerplate. Now it's a single `<TabbedProviderPage ...>` call.

tsc: clean.