### PR TITLE
⚡ Bolt: [performance improvement] Optimize bot status lookup in MonitoringDashboard

### DIFF
--- a/src/client/src/components/Monitoring/MonitoringDashboard.tsx
+++ b/src/client/src/components/Monitoring/MonitoringDashboard.tsx
@@ -187,8 +187,16 @@ const MonitoringDashboard: React.FC<MonitoringDashboardProps> = ({
 
   // Derive bots with status combining config and system data independently
   useEffect(() => {
+    // Pre-compute a lookup Map for O(1) status lookup instead of O(N*M) with .find()
+    const statusBotMap = new Map<string, any>();
+    if (systemMetrics?.bots) {
+      for (const b of systemMetrics.bots) {
+        statusBotMap.set(b.name, b);
+      }
+    }
+
     const botsWithStatus = configBots.map((bot: Bot) => {
-      const statusBot = systemMetrics?.bots?.find((b: any) => b.name === bot.name);
+      const statusBot = statusBotMap.get(bot.name);
       return {
         ...bot,
         id: bot.name,

--- a/src/server/services/websocket/index.ts
+++ b/src/server/services/websocket/index.ts
@@ -90,7 +90,9 @@ export class WebSocketService {
 
         const demoMode = container.isRegistered(DemoModeService)
           ? container.resolve(DemoModeService)
-          : (DemoModeService as any).getInstance ? (DemoModeService as any).getInstance() : new DemoModeService();
+          : (DemoModeService as any).getInstance
+            ? (DemoModeService as any).getInstance()
+            : new DemoModeService();
 
         const broadcastService = container.isRegistered(BroadcastService)
           ? container.resolve(BroadcastService)

--- a/src/server/services/websocket/index.ts
+++ b/src/server/services/websocket/index.ts
@@ -90,9 +90,7 @@ export class WebSocketService {
 
         const demoMode = container.isRegistered(DemoModeService)
           ? container.resolve(DemoModeService)
-          : (DemoModeService as any).getInstance
-            ? (DemoModeService as any).getInstance()
-            : new DemoModeService();
+          : (DemoModeService as any).getInstance ? (DemoModeService as any).getInstance() : new DemoModeService();
 
         const broadcastService = container.isRegistered(BroadcastService)
           ? container.resolve(BroadcastService)


### PR DESCRIPTION
💡 **What:** Optimized the bot status merging logic in `MonitoringDashboard.tsx` by pre-computing a lookup `Map` of status bots keyed by `name` before mapping over `configBots`.

🎯 **Why:** The previous implementation used an `Array.find()` inside a `.map()`, resulting in an $O(N \times M)$ complexity rendering loop. By switching to a Map, we reduce this to an $O(N + M)$ lookup. This is specifically outlined as a critical pattern to avoid in lists rendering in `.jules/bolt.md`.

📊 **Impact:** Reduces time complexity of the rendering loop from $O(N \times M)$ to $O(N + M)$, avoiding a potential bottleneck on the UI thread when many bots are monitored. 

🔬 **Measurement:** The code logic remains identical but leverages a Map. Tests pass successfully in the `src/client` workspace.

---
*PR created automatically by Jules for task [5488845614384334655](https://jules.google.com/task/5488845614384334655) started by @matthewhand*