### PR TITLE
fix: Remove unused import, fix regex bug, normalize indentation

### DIFF
--- a/src/client/src/utils/jsonHighlighter.ts
+++ b/src/client/src/utils/jsonHighlighter.ts
@@ -60,9 +60,9 @@ function tokenizeJson(jsonString: string): Token[] {
     const char = jsonString[i];
 
     // Handle whitespace
-    if (\t\n\r\s/.test(char)) {
+    if (/[\t\n\r\s]/.test(char)) {
       let whitespace = '';
-      while (i < len && \t\n\r\s/.test(jsonString[i])) {
+      while (i < len && /[\t\n\r\s]/.test(jsonString[i])) {
         whitespace += jsonString[i++];
       }
       tokens.push({ type: 'whitespace', value: whitespace, escaped: escapeHtml(whitespace) });

--- a/src/config/ConfigurationManager.ts
+++ b/src/config/ConfigurationManager.ts
@@ -5,7 +5,7 @@ import Debug from 'debug';
 import { isValidUrl } from '../common/urlUtils';
 import { SecureConfigManager } from './SecureConfigManager';
 import { ValidationError } from '../types/errorClasses';
-import { validateUrl, validateString, validateEnum } from './validationUtils';
+import { validateUrl, validateEnum } from './validationUtils';
 import { type IConfigurationManager } from '../di/interfaces';
 const debug = Debug('app:ConfigurationManager');
 

--- a/src/database/DatabaseManager.ts
+++ b/src/database/DatabaseManager.ts
@@ -151,7 +151,7 @@ export class DatabaseManager {
         this.db = new Database(dbPath);
         debug('DATABASE_MANAGER: this.db initialized, type:', typeof this.db);
         if (this.db && (this.db as any).exec) {
-           debug('DATABASE_MANAGER: this.db.exec exists');
+          debug('DATABASE_MANAGER: this.db.exec exists');
         }
 
         await this.createTables();


### PR DESCRIPTION
## Summary
Small code cleanup fixes:
- Remove unused `validateString` import from ConfigurationManager
- Fix regex bug in jsonHighlighter: `\t\n\r\s` → `/[\t\n\r\s]` (was matching literal characters, not whitespace class)
- Normalize inconsistent indentation in DatabaseManager

## Files changed
- src/config/ConfigurationManager.ts
- src/client/src/utils/jsonHighlighter.ts
- src/database/DatabaseManager.ts