### PR TITLE
sec: Fix path traversal in plugin name validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -33,3 +33,8 @@
 **Vulnerability:** The custom `isLocalhostRequest` implementation in `src/auth/middleware.ts` used a logical OR (`||`) to check if the request came from localhost by examining the IP address, Host header, or Origin header. When `ALLOW_LOCALHOST_ADMIN=true` was enabled, an external attacker could completely bypass authentication by simply adding `Host: localhost` or `Origin: http://localhost` to their HTTP request headers.
 **Learning:** Security checks that rely on client-provided headers (like `Host` or `Origin`) MUST NOT be used in an OR condition alongside stronger identity factors like source IP address for establishing trust. The intention was to check all properties to protect against DNS rebinding and CSRF, but the OR implementation actually expanded the trust domain to any request containing the spoofed headers.
 **Prevention:** Always use strict AND conditions when layering defense-in-depth header checks on top of a foundational trust signal like source IP. Verify that the IP address itself is correct FIRST, and then only reject (not authorize) the request if the provided headers do not match expectations.
+
+## 2026-04-17 - Path Traversal in Plugin Name
+**Vulnerability:** Malicious plugin repository could define_relative path sequence in `package.json` "name" field (e.g., `../../../tmp/pwned`), causing arbitrary file write during plugin directory rename.
+**Learning:** Always validate extracted strings from external configuration files before filesystem operations. The `package.json` name field is user-controlled and should never be trusted.
+**Prevention:** Reject plugin names containing `..`, `/`, or `\` path separators. Throw `PluginValidationError` if detected.

--- a/src/plugins/PluginManager.ts
+++ b/src/plugins/PluginManager.ts
@@ -167,13 +167,20 @@ async function readPackageVersion(pluginPath: string): Promise<string> {
 }
 
 async function deriveNameFromPath(pluginPath: string): Promise<string> {
+  let name = path.basename(pluginPath);
   try {
     const content = await fs.promises.readFile(path.join(pluginPath, 'package.json'), 'utf-8');
     const pkg = JSON.parse(content);
-    return pkg.name?.replace(/^@[^/]+\//, '') ?? path.basename(pluginPath);
-  } catch {
-    return path.basename(pluginPath);
+    if (pkg.name && typeof pkg.name === 'string') {
+      name = pkg.name.replace(/^@[^/]+\//, '');
+    }
+  } catch {}
+
+  if (name.includes('..') || name.includes('/') || name.includes('\\')) {
+    throw new PluginValidationError(`Invalid plugin name: ${name}`);
   }
+
+  return name;
 }
 
 function exec(cmd: string, args: string[], cwd: string): void {


### PR DESCRIPTION
## Summary
Fix critical path traversal vulnerability in plugin installation.

## Vulnerability
Malicious plugin repository could define relative path sequence in `package.json` "name" field (e.g., `../../../tmp/pwned`), causing arbitrary file write during plugin directory rename.

## Fix
Reject plugin names containing path separators (`..`, `/`, `\`) in `deriveNameFromPath()` function. Throw `PluginValidationError` if detected.

## Files changed
- `src/plugins/PluginManager.ts` - add validation
- `.jules/sentinel.md` - document learning