### PR TITLE
fix: Letta integration tests - accept new key format

### DIFF
--- a/tests/integration/letta/LettaIntegration.test.ts
+++ b/tests/integration/letta/LettaIntegration.test.ts
@@ -35,7 +35,8 @@ createIntegrationSuite(lettaConfig.name, lettaConfig.requiredEnvVars, () => {
     it('should have valid API key set', () => {
       const key = process.env.LETTA_API_KEY!;
       expect(key.length).toBeGreaterThan(0);
-      expect(key.startsWith('sk-let-')).toBe(true);
+      // Letta API keys can start with 'sk-let-' or 'at-let-' (newer format)
+      expect(key.startsWith('sk-let-') || key.startsWith('at-let')).toBe(true);
     });
   });
 

--- a/tests/integration/letta/PluginLoaderLetta.test.ts
+++ b/tests/integration/letta/PluginLoaderLetta.test.ts
@@ -319,11 +319,22 @@ describe('PluginLoader → LettaProvider integration', () => {
   // ---- Error Handling ----
 
   it('should throw when no agent ID is provided', async () => {
-    const provider = instantiateLlmProvider(llmLettaModule, { agentId: undefined as any });
+    // Temporarily clear LETTA_AGENT_ID to test the validation error
+    const originalAgentId = process.env.LETTA_AGENT_ID;
+    delete process.env.LETTA_AGENT_ID;
 
-    await expect(
-      provider.generateChatCompletion('hello', [], {})
-    ).rejects.toThrow('No agent ID provided');
+    try {
+      const provider = instantiateLlmProvider(llmLettaModule, { agentId: undefined as any });
+
+      await expect(
+        provider.generateChatCompletion('hello', [], {})
+      ).rejects.toThrow('No agent ID provided');
+    } finally {
+      // Restore the env var
+      if (originalAgentId !== undefined) {
+        process.env.LETTA_AGENT_ID = originalAgentId;
+      }
+    }
   });
 
   it('should handle SDK errors gracefully and fall back to default conversation', async () => {


### PR DESCRIPTION
## Summary
- Accept both `sk-let-` and `at-let` key prefixes (Letta API changed format)
- Clear `LETTA_AGENT_ID` env var in test that validates missing agent ID

## Test plan
- [ ] Run Letta integration tests
- [ ] Verify tests pass with both key formats

👾 Generated with [Letta Code](https://letta.com)