### PR TITLE
fix: as-any cleanup — top 3 offenders + auto-fix formatting

### DIFF
--- a/packages/llm-letta/src/agentBrowser.test.ts
+++ b/packages/llm-letta/src/agentBrowser.test.ts
@@ -1,8 +1,8 @@
+import { getAgent, listAgents } from './agentBrowser';
+
 jest.mock('dns', () => ({
   promises: { lookup: jest.fn().mockResolvedValue({ address: '1.2.3.4', family: 4 }) },
 }));
-
-import { listAgents, getAgent } from './agentBrowser';
 
 jest.mock('@hivemind/shared-types', () => {
   const actual = jest.requireActual('@hivemind/shared-types');
@@ -20,7 +20,13 @@ jest.mock('@letta-ai/letta-client', () =>
 
 beforeEach(() => jest.clearAllMocks());
 
-const AGENT = { id: 'a1', name: 'TestAgent', description: 'desc', created_at: '2024-01-01', updated_at: '2024-01-02' };
+const AGENT = {
+  id: 'a1',
+  name: 'TestAgent',
+  description: 'desc',
+  created_at: '2024-01-01',
+  updated_at: '2024-01-02',
+};
 
 describe('listAgents', () => {
   it('returns array of agent summaries', async () => {
@@ -40,7 +46,9 @@ describe('listAgents', () => {
     mockAgentsList.mockResolvedValue([AGENT]);
     const Letta = require('@letta-ai/letta-client');
     await listAgents('api-key', 'https://custom.letta.com/v1');
-    expect(Letta).toHaveBeenCalledWith(expect.objectContaining({ baseURL: 'https://custom.letta.com/v1' }));
+    expect(Letta).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: 'https://custom.letta.com/v1' })
+    );
   });
 
   it('throws on SSRF unsafe URL', async () => {

--- a/packages/llm-openswarm/src/OpenSwarmProvider.test.ts
+++ b/packages/llm-openswarm/src/OpenSwarmProvider.test.ts
@@ -21,7 +21,10 @@ afterEach(() => jest.restoreAllMocks());
 
 function mockFetch(body: unknown, status = 200) {
   jest.spyOn(global, 'fetch').mockResolvedValue(
-    new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
   );
 }
 

--- a/packages/llm-openwebui/src/directClient.test.ts
+++ b/packages/llm-openwebui/src/directClient.test.ts
@@ -18,7 +18,10 @@ afterEach(() => jest.restoreAllMocks());
 
 function mockFetch(body: unknown, status = 200) {
   jest.spyOn(global, 'fetch').mockResolvedValue(
-    new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
   );
 }
 

--- a/packages/llm-openwebui/src/openWebUIProvider.test.ts
+++ b/packages/llm-openwebui/src/openWebUIProvider.test.ts
@@ -1,3 +1,6 @@
+import { manifest } from './index';
+import { openWebUIProvider } from './openWebUIProvider';
+
 // Mock DNS so isSafeUrl always resolves to a public IP in tests
 jest.mock('dns', () => ({
   promises: { lookup: jest.fn().mockResolvedValue({ address: '1.2.3.4', family: 4 }) },
@@ -14,7 +17,14 @@ jest.mock('convict', () => {
     }),
     set: jest.fn(),
     validate: jest.fn(),
-    getProperties: jest.fn(() => ({ apiUrl: 'https://openwebui.example.com', model: 'test-model', username: 'u', password: 'p', authMethod: 'apiKey', apiKey: 'fake-key' })),
+    getProperties: jest.fn(() => ({
+      apiUrl: 'https://openwebui.example.com',
+      model: 'test-model',
+      username: 'u',
+      password: 'p',
+      authMethod: 'apiKey',
+      apiKey: 'fake-key',
+    })),
   }));
 });
 
@@ -23,12 +33,12 @@ jest.mock('@hivemind/shared-types', () => {
   return { ...actual, isSafeUrl: jest.fn().mockResolvedValue(true) };
 });
 
-import { manifest } from './index';
-import { openWebUIProvider } from './openWebUIProvider';
-
 function mockFetch(body: unknown, status = 200) {
   jest.spyOn(global, 'fetch').mockResolvedValue(
-    new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
   );
 }
 
@@ -60,7 +70,9 @@ describe('openWebUIProvider', () => {
 
   it('generateChatCompletion throws on HTTP error', async () => {
     mockFetch({ error: 'fail' }, 500);
-    await expect(openWebUIProvider.generateChatCompletion('hello', [])).rejects.toThrow('Chat completion failed');
+    await expect(openWebUIProvider.generateChatCompletion('hello', [])).rejects.toThrow(
+      'Chat completion failed'
+    );
   });
 
   it('generateCompletion returns text string', async () => {
@@ -70,6 +82,8 @@ describe('openWebUIProvider', () => {
 
   it('generateCompletion throws on HTTP error', async () => {
     mockFetch({ error: 'fail' }, 500);
-    await expect(openWebUIProvider.generateCompletion('prompt')).rejects.toThrow('Non-chat completion failed');
+    await expect(openWebUIProvider.generateCompletion('prompt')).rejects.toThrow(
+      'Non-chat completion failed'
+    );
   });
 });

--- a/packages/llm-openwebui/src/sessionManager.test.ts
+++ b/packages/llm-openwebui/src/sessionManager.test.ts
@@ -34,7 +34,10 @@ jest.mock('@hivemind/shared-types', () => {
 
 function mockFetch(body: unknown, status = 200) {
   jest.spyOn(global, 'fetch').mockResolvedValue(
-    new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
   );
 }
 

--- a/packages/memory-mem0/src/Mem0Provider.test.ts
+++ b/packages/memory-mem0/src/Mem0Provider.test.ts
@@ -14,10 +14,10 @@ afterEach(() => jest.restoreAllMocks());
 
 function mockFetch(status: number, body: unknown) {
   return jest.spyOn(global, 'fetch').mockResolvedValue(
-    new Response(
-      status === 204 ? null : JSON.stringify(body),
-      { status, headers: { 'content-type': 'application/json' } }
-    )
+    new Response(status === 204 ? null : JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
   );
 }
 
@@ -39,8 +39,9 @@ afterEach(() => jest.restoreAllMocks());
 
 describe('Mem0Provider constructor', () => {
   it('throws if apiKey is missing', () => {
-    expect(() => new Mem0Provider({ apiKey: '', baseUrl: 'https://api.mem0.ai/v1' }))
-      .toThrow('apiKey is required');
+    expect(() => new Mem0Provider({ apiKey: '', baseUrl: 'https://api.mem0.ai/v1' })).toThrow(
+      'apiKey is required'
+    );
   });
 
   it('uses default baseUrl when not provided', () => {
@@ -204,10 +205,7 @@ describe('retry behaviour', () => {
   });
 
   it('throws after exhausting retries', async () => {
-    mockFetchSequence(
-      { status: 500, body: 'err' },
-      { status: 500, body: 'err' }
-    );
+    mockFetchSequence({ status: 500, body: 'err' }, { status: 500, body: 'err' });
     const p = new Mem0Provider({ ...BASE_CONFIG, maxRetries: 1 });
     await expect(p.getMemories()).rejects.toBeInstanceOf(Mem0ApiError);
   });
@@ -244,7 +242,10 @@ describe('legacy convenience methods', () => {
 
   it('get() returns null on 404', async () => {
     jest.spyOn(global, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({}), { status: 404, headers: { 'content-type': 'application/json' } })
+      new Response(JSON.stringify({}), {
+        status: 404,
+        headers: { 'content-type': 'application/json' },
+      })
     );
     const p = new Mem0Provider(BASE_CONFIG);
     expect(await p.get('missing')).toBeNull();

--- a/packages/memory-mem4ai/src/CircuitBreaker.test.ts
+++ b/packages/memory-mem4ai/src/CircuitBreaker.test.ts
@@ -1,9 +1,9 @@
 import {
   CircuitBreaker,
-  CircuitBreakerState,
   CircuitBreakerError,
-  getCircuitBreaker,
+  CircuitBreakerState,
   clearCircuitBreakerRegistry,
+  getCircuitBreaker,
   resetAllCircuitBreakers,
 } from './CircuitBreaker';
 
@@ -48,7 +48,9 @@ describe('CircuitBreaker — OPEN state', () => {
   it('rejects immediately when OPEN', async () => {
     const cb = new CircuitBreaker({ name: 'test', failureThreshold: 1, resetTimeoutMs: 60000 });
     await expect(cb.execute(() => Promise.reject(new Error('e')))).rejects.toThrow();
-    await expect(cb.execute(() => Promise.resolve('ok'))).rejects.toBeInstanceOf(CircuitBreakerError);
+    await expect(cb.execute(() => Promise.resolve('ok'))).rejects.toBeInstanceOf(
+      CircuitBreakerError
+    );
   });
 
   it('transitions to HALF_OPEN after resetTimeoutMs', async () => {
@@ -66,7 +68,12 @@ describe('CircuitBreaker — HALF_OPEN state', () => {
   }
 
   it('closes after halfOpenMaxAttempts successes', async () => {
-    const cb = new CircuitBreaker({ name: 'test', failureThreshold: 1, resetTimeoutMs: 1, halfOpenMaxAttempts: 2 });
+    const cb = new CircuitBreaker({
+      name: 'test',
+      failureThreshold: 1,
+      resetTimeoutMs: 1,
+      halfOpenMaxAttempts: 2,
+    });
     await openAndWait(cb);
     await cb.execute(() => Promise.resolve('ok'));
     await cb.execute(() => Promise.resolve('ok'));
@@ -74,15 +81,20 @@ describe('CircuitBreaker — HALF_OPEN state', () => {
   });
 
   it('re-opens on failure in HALF_OPEN', async () => {
-    const cb = new CircuitBreaker({ name: 'test', failureThreshold: 1, resetTimeoutMs: 1000, halfOpenMaxAttempts: 3 });
+    const cb = new CircuitBreaker({
+      name: 'test',
+      failureThreshold: 1,
+      resetTimeoutMs: 1000,
+      halfOpenMaxAttempts: 3,
+    });
     // Manually force into OPEN then HALF_OPEN
     await expect(cb.execute(() => Promise.reject(new Error('e')))).rejects.toThrow();
     // Simulate time passing to get to HALF_OPEN
     (cb as any).lastFailureTime = Date.now() - 2000;
-    
+
     // Now it should be HALF_OPEN on next call or getState
     expect(cb.getState()).toBe(CircuitBreakerState.HALF_OPEN);
-    
+
     // This failure should return it to OPEN
     await expect(cb.execute(() => Promise.reject(new Error('e')))).rejects.toThrow();
     expect(cb.getState()).toBe(CircuitBreakerState.OPEN);
@@ -91,11 +103,16 @@ describe('CircuitBreaker — HALF_OPEN state', () => {
   it('rejects after halfOpenMaxAttempts probe limit reached before success', async () => {
     // With halfOpenMaxAttempts=2: first probe allowed, second probe allowed,
     // third probe rejected because limit reached
-    const cb = new CircuitBreaker({ name: 'test', failureThreshold: 1, resetTimeoutMs: 1000, halfOpenMaxAttempts: 2 });
-    
+    const cb = new CircuitBreaker({
+      name: 'test',
+      failureThreshold: 1,
+      resetTimeoutMs: 1000,
+      halfOpenMaxAttempts: 2,
+    });
+
     // Open the circuit
     await expect(cb.execute(() => Promise.reject(new Error('e')))).rejects.toThrow();
-    
+
     // Wait for HALF_OPEN
     (cb as any).lastFailureTime = Date.now() - 2000;
     expect(cb.getState()).toBe(CircuitBreakerState.HALF_OPEN);
@@ -103,7 +120,7 @@ describe('CircuitBreaker — HALF_OPEN state', () => {
     // First probe — allowed but fails, re-opens
     await expect(cb.execute(() => Promise.reject(new Error('e')))).rejects.toThrow();
     expect(cb.getState()).toBe(CircuitBreakerState.OPEN);
-    
+
     // Wait again for HALF_OPEN
     (cb as any).lastFailureTime = Date.now() - 2000;
     expect(cb.getState()).toBe(CircuitBreakerState.HALF_OPEN);

--- a/packages/memory-mem4ai/src/Mem4aiProvider.test.ts
+++ b/packages/memory-mem4ai/src/Mem4aiProvider.test.ts
@@ -1,6 +1,6 @@
+import { clearCircuitBreakerRegistry } from './CircuitBreaker';
 import { Mem4aiProvider } from './Mem4aiProvider';
 import { Mem4aiApiError } from './types';
-import { clearCircuitBreakerRegistry } from './CircuitBreaker';
 
 // Mock isSafeUrl so test URLs don't trigger SSRF guard failures
 jest.mock('@hivemind/shared-types', () => ({
@@ -43,13 +43,13 @@ afterEach(() => jest.restoreAllMocks());
 
 describe('Mem4aiProvider constructor', () => {
   it('throws if apiKey is missing', () => {
-    expect(() => new Mem4aiProvider({ apiKey: '', apiUrl: 'https://api.mem4ai.example.com' }))
-      .toThrow('apiKey is required');
+    expect(
+      () => new Mem4aiProvider({ apiKey: '', apiUrl: 'https://api.mem4ai.example.com' })
+    ).toThrow('apiKey is required');
   });
 
   it('throws if apiUrl is missing', () => {
-    expect(() => new Mem4aiProvider({ apiKey: 'key', apiUrl: '' }))
-      .toThrow('apiUrl is required');
+    expect(() => new Mem4aiProvider({ apiKey: 'key', apiUrl: '' })).toThrow('apiUrl is required');
   });
 
   it('strips trailing slash from apiUrl', () => {
@@ -117,7 +117,10 @@ describe('getMemories', () => {
 describe('getMemory', () => {
   it('returns null on 404', async () => {
     jest.spyOn(global, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({}), { status: 404, headers: { 'content-type': 'application/json' } })
+      new Response(JSON.stringify({}), {
+        status: 404,
+        headers: { 'content-type': 'application/json' },
+      })
     );
     const p = new Mem4aiProvider(BASE_CONFIG);
     expect(await p.getMemory('missing')).toBeNull();
@@ -197,10 +200,7 @@ describe('retry behaviour', () => {
   });
 
   it('throws after exhausting retries', async () => {
-    mockFetchSequence(
-      { status: 500, body: 'err' },
-      { status: 500, body: 'err' }
-    );
+    mockFetchSequence({ status: 500, body: 'err' }, { status: 500, body: 'err' });
     const p = new Mem4aiProvider({ ...BASE_CONFIG, maxRetries: 1 });
     await expect(p.getMemories()).rejects.toBeInstanceOf(Mem4aiApiError);
   });
@@ -216,7 +216,11 @@ describe('retry behaviour', () => {
 describe('circuit breaker', () => {
   it('opens after failureThreshold consecutive failures', async () => {
     jest.spyOn(global, 'fetch').mockRejectedValue(new Error('network'));
-    const p = new Mem4aiProvider({ ...BASE_CONFIG, maxRetries: 0, circuitBreaker: { failureThreshold: 2, resetTimeoutMs: 60000, name: 'mem4ai-cb-test' } as any });
+    const p = new Mem4aiProvider({
+      ...BASE_CONFIG,
+      maxRetries: 0,
+      circuitBreaker: { failureThreshold: 2, resetTimeoutMs: 60000, name: 'mem4ai-cb-test' } as any,
+    });
     await expect(p.getMemories()).rejects.toThrow();
     await expect(p.getMemories()).rejects.toThrow();
     await expect(p.getMemories()).rejects.toThrow(/Circuit breaker/);
@@ -247,7 +251,10 @@ describe('legacy convenience methods', () => {
 
   it('get() returns null on 404', async () => {
     jest.spyOn(global, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({}), { status: 404, headers: { 'content-type': 'application/json' } })
+      new Response(JSON.stringify({}), {
+        status: 404,
+        headers: { 'content-type': 'application/json' },
+      })
     );
     const p = new Mem4aiProvider(BASE_CONFIG);
     expect(await p.get('missing')).toBeNull();

--- a/src/admin/adminRoutes.ts
+++ b/src/admin/adminRoutes.ts
@@ -106,7 +106,7 @@ adminRouter.post(
 
     const body = req.body as { name?: string; token?: string; llm?: string };
     try {
-      await (provider as IMessageProvider).addBot(req.body);
+      await (provider as IMessageProvider).addBot(req.body as Record<string, unknown>);
 
       logAdminAction(
         req,
@@ -158,7 +158,7 @@ adminRouter.post('/slack-bots', requireAdmin, async (req: AuditedRequest, res: R
   if (!provider) return res.status(404).json({ success: false, error: 'Slack provider not found' });
   const body = req.body as { name?: string; token?: string };
   try {
-    await provider.addBot(req.body);
+    await provider.addBot(req.body as Record<string, unknown>);
     logAdminAction(
       req,
       'CREATE_SLACK_BOT',

--- a/src/cli/handlers/BotCommandHandler.ts
+++ b/src/cli/handlers/BotCommandHandler.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import chalk from 'chalk';
 import { type Command } from 'commander';
 import inquirer from 'inquirer';

--- a/src/cli/handlers/ConfigCommandHandler.ts
+++ b/src/cli/handlers/ConfigCommandHandler.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { promises as fs } from 'fs';
 import chalk from 'chalk';
 import { type Command } from 'commander';

--- a/src/cli/handlers/ServerCommandHandler.ts
+++ b/src/cli/handlers/ServerCommandHandler.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import chalk from 'chalk';
 import { type Command } from 'commander';
 import { type CommandHandler } from './CommandHandler';

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { redactSensitiveInfo } from './redactSensitiveInfo';
 
 type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error';

--- a/src/database/DatabaseManager.ts
+++ b/src/database/DatabaseManager.ts
@@ -199,19 +199,16 @@ export class DatabaseManager {
   // ---------------------------------------------------------------------------
 
   private initRepositories(): void {
-    const getDb = (): Database => {
-      if (!this.db) throw new Error('Database not initialized');
-      return this.db;
-    };
+    const getDb = (): Database | null => this.db ?? null;
     const isConn = (): boolean => this.connected;
     const ensure = (): void => this.ensureConnected();
 
-    this.messageRepo = new MessageRepository(getDb as any, isConn, ensure as any);
-    this.botConfigRepo = new BotConfigRepository(getDb as any, ensure as any);
-    this.anomalyRepo = new AnomalyRepository(getDb as any, isConn);
-    this.approvalRepo = new ApprovalRepository(getDb as any, ensure as any);
-    this.aiFeedbackRepo = new AIFeedbackRepository(getDb as any, ensure as any);
-    this.decisionRepo = new DecisionRepository(getDb as any, isConn);
+    this.messageRepo = new MessageRepository(getDb, isConn, ensure);
+    this.botConfigRepo = new BotConfigRepository(getDb, ensure);
+    this.anomalyRepo = new AnomalyRepository(getDb, isConn);
+    this.approvalRepo = new ApprovalRepository(getDb, ensure);
+    this.aiFeedbackRepo = new AIFeedbackRepository(getDb, ensure);
+    this.decisionRepo = new DecisionRepository(getDb, isConn);
   }
 
   // ---------------------------------------------------------------------------
@@ -823,7 +820,7 @@ export class DatabaseManager {
     return this.decisionRepo.saveDecision(decision);
   }
 
-  async getRecentDecisions(limit = 100): Promise<any[]> {
+  async getRecentDecisions(limit = 100): Promise<DecisionRecord[]> {
     return this.decisionRepo.getRecentDecisions(limit);
   }
 }

--- a/src/database/DecisionRepository.ts
+++ b/src/database/DecisionRepository.ts
@@ -59,7 +59,7 @@ export class DecisionRepository {
   /**
    * Retrieve recent decisions.
    */
-  async getRecentDecisions(limit = 100): Promise<any[]> {
+  async getRecentDecisions(limit = 100): Promise<DecisionRecord[]> {
     const db = this.getDb();
     if (!db || !this.isConnected()) {
       return [];
@@ -68,14 +68,14 @@ export class DecisionRepository {
     try {
       const rows = await db.all(`SELECT * FROM decisions ORDER BY timestamp DESC LIMIT ?`, [limit]);
 
-      return rows.map((row: any) => ({
-        id: row.id,
-        botName: row.botName,
+      return rows.map((row: Record<string, unknown>) => ({
+        id: row.id as number,
+        botName: row.botName as string,
         shouldReply: Boolean(row.shouldReply),
-        reason: row.reason,
-        probabilityRoll: row.probabilityRoll,
-        threshold: row.threshold,
-        timestamp: row.timestamp ? new Date(row.timestamp) : undefined,
+        reason: row.reason as string,
+        probabilityRoll: row.probabilityRoll as number,
+        threshold: row.threshold as number,
+        timestamp: row.timestamp ? new Date(row.timestamp as string) : undefined,
       }));
     } catch (error) {
       debug('Error retrieving recent decisions:', error);

--- a/src/providers/DiscordProvider.ts
+++ b/src/providers/DiscordProvider.ts
@@ -23,11 +23,11 @@ export class DiscordProvider implements IMessageProvider<DiscordConfig> {
     this.discordService = discordService || (Discord as any).DiscordService.getInstance();
   }
 
-  getSchema(): any {
+  getSchema(): Record<string, unknown> {
     return discordConfig.getSchema();
   }
 
-  getConfig(): any {
+  getConfig(): Record<string, unknown> {
     return discordConfig;
   }
 
@@ -68,13 +68,15 @@ export class DiscordProvider implements IMessageProvider<DiscordConfig> {
     return [];
   }
 
-  async getBots(): Promise<any[]> {
+  async getBots(): Promise<Record<string, unknown>[]> {
     const status = await this.getStatus();
     return status.bots;
   }
 
-  async addBot(config: any): Promise<void> {
-    const { name, token, llm } = config;
+  async addBot(config: Record<string, unknown>): Promise<void> {
+    const name = String(config.name ?? '');
+    const token = config.token as string | undefined;
+    const llm = config.llm;
     if (!token) {
       throw new Error('token is required');
     }

--- a/src/providers/FlowiseProvider.ts
+++ b/src/providers/FlowiseProvider.ts
@@ -8,12 +8,12 @@ export class FlowiseProvider implements ILLMProvider {
   docsUrl = 'https://docs.flowiseai.com/installation/overview';
   helpText = 'Use the Flowise REST endpoint and API key configured in your Flowise instance.';
 
-  getSchema() {
-    return flowiseConfig.getSchema();
+  getSchema(): Record<string, unknown> {
+    return flowiseConfig.getSchema() as unknown as Record<string, unknown>;
   }
 
-  getConfig() {
-    return flowiseConfig;
+  getConfig(): Record<string, unknown> {
+    return flowiseConfig as unknown as Record<string, unknown>;
   }
 
   getSensitiveKeys() {

--- a/src/providers/MattermostProvider.ts
+++ b/src/providers/MattermostProvider.ts
@@ -17,11 +17,11 @@ export class MattermostProvider implements IMessageProvider<MattermostConfig> {
     this.mattermostService = mattermostService || MattermostService.getInstance();
   }
 
-  getSchema(): any {
+  getSchema(): Record<string, unknown> {
     return mattermostConfig.getSchema();
   }
 
-  getConfig(): any {
+  getConfig(): Record<string, unknown> {
     return mattermostConfig;
   }
 
@@ -34,7 +34,7 @@ export class MattermostProvider implements IMessageProvider<MattermostConfig> {
    * Note: This currently simulates connection status and should be updated
    * to perform a real API check in the future.
    */
-  async getStatus(): Promise<{ ok: boolean; bots: any[]; count: number }> {
+  async getStatus(): Promise<Record<string, unknown>> {
     const mattermost = this.mattermostService;
     const botNames = mattermost.getBotNames();
     const bots = botNames.map((name: string) => {
@@ -63,13 +63,13 @@ export class MattermostProvider implements IMessageProvider<MattermostConfig> {
   /**
    * Retrieves the current list of bots.
    */
-  async getBots(): Promise<any[]> {
+  async getBots(): Promise<Record<string, unknown>[]> {
     const status = await this.getStatus();
-    return status.bots;
+    return (status.bots as Record<string, unknown>[]) ?? [];
   }
 
-  async addBot(config: any): Promise<void> {
-    const { name } = config;
+  async addBot(config: Record<string, unknown>): Promise<void> {
+    const name = String(config.name ?? '');
 
     // Since MattermostProvider does not fully implement addBot yet, we
     // set up the foundation for the ReconnectionManager integration here.
@@ -115,7 +115,7 @@ export class MattermostProvider implements IMessageProvider<MattermostConfig> {
    * @param limit - Optional maximum number of messages to retrieve
    * @returns A promise that resolves to an array of messages
    */
-  async getMessages(channelId: string, limit?: number): Promise<any[]> {
+  async getMessages(channelId: string, limit?: number): Promise<unknown[]> {
     return await this.mattermostService.getMessagesFromChannel(channelId, limit);
   }
 

--- a/src/providers/OpenAIProvider.ts
+++ b/src/providers/OpenAIProvider.ts
@@ -8,12 +8,12 @@ export class OpenAIProvider implements ILLMProvider<OpenAIConfig> {
   docsUrl = 'https://platform.openai.com/account/api-keys';
   helpText = 'Create an OpenAI API key from the developer dashboard and paste it here.';
 
-  getSchema() {
-    return openaiConfig.getSchema();
+  getSchema(): Record<string, unknown> {
+    return openaiConfig.getSchema() as unknown as Record<string, unknown>;
   }
 
-  getConfig() {
-    return openaiConfig;
+  getConfig(): Record<string, unknown> {
+    return openaiConfig as unknown as Record<string, unknown>;
   }
 
   getSensitiveKeys() {

--- a/src/providers/OpenWebUIProvider.ts
+++ b/src/providers/OpenWebUIProvider.ts
@@ -8,12 +8,12 @@ export class OpenWebUIProvider implements ILLMProvider {
   docsUrl = 'https://docs.openwebui.com/';
   helpText = 'Enable API access in OpenWebUI and copy the token from the administration panel.';
 
-  getSchema() {
-    return openWebUIConfig.getSchema();
+  getSchema(): Record<string, unknown> {
+    return openWebUIConfig.getSchema() as unknown as Record<string, unknown>;
   }
 
-  getConfig() {
-    return openWebUIConfig;
+  getConfig(): Record<string, unknown> {
+    return openWebUIConfig as unknown as Record<string, unknown>;
   }
 
   getSensitiveKeys() {

--- a/src/providers/SlackProvider.ts
+++ b/src/providers/SlackProvider.ts
@@ -22,11 +22,11 @@ export class SlackProvider implements IMessageProvider<SlackConfig> {
     this.slackService = slackService || SlackService.getInstance();
   }
 
-  getSchema(): any {
+  getSchema(): Record<string, unknown> {
     return slackConfig.getSchema();
   }
 
-  getConfig(): any {
+  getConfig(): Record<string, unknown> {
     return slackConfig;
   }
 
@@ -34,7 +34,7 @@ export class SlackProvider implements IMessageProvider<SlackConfig> {
     return ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN', 'SLACK_SIGNING_SECRET'];
   }
 
-  async getStatus(): Promise<{ ok: boolean; bots: any[]; count: number }> {
+  async getStatus(): Promise<Record<string, unknown>> {
     const slack = this.slackService;
     const botNames = slack.getBotNames();
     const bots = botNames.map((name: string) => {
@@ -61,14 +61,20 @@ export class SlackProvider implements IMessageProvider<SlackConfig> {
     return this.slackService.getBotNames();
   }
 
-  async getBots(): Promise<any[]> {
+  async getBots(): Promise<Record<string, unknown>[]> {
     const status = await this.getStatus();
-    return status.bots;
+    return (status.bots as Record<string, unknown>[]) ?? [];
   }
 
-  async addBot(config: any): Promise<void> {
-    const { name, botToken, signingSecret, appToken, defaultChannelId, joinChannels, mode, llm } =
-      config;
+  async addBot(config: Record<string, unknown>): Promise<void> {
+    const name = String(config.name ?? '');
+    const botToken = config.botToken as string | undefined;
+    const signingSecret = config.signingSecret as string | undefined;
+    const appToken = config.appToken as string | undefined;
+    const defaultChannelId = config.defaultChannelId as string | undefined;
+    const joinChannels = config.joinChannels;
+    const mode = config.mode as string | undefined;
+    const llm = config.llm;
 
     if (!name || !botToken || !signingSecret) {
       throw new Error('name, botToken, and signingSecret are required');

--- a/src/providers/TelegramProvider.ts
+++ b/src/providers/TelegramProvider.ts
@@ -49,8 +49,8 @@ export class TelegramProvider implements IMessageProvider<TelegramConfig> {
     return telegramConfig.getSchema() as unknown as Record<string, unknown>;
   }
 
-  getConfig(): typeof telegramConfig {
-    return telegramConfig;
+  getConfig(): Record<string, unknown> {
+    return telegramConfig as unknown as Record<string, unknown>;
   }
 
   getSensitiveKeys(): string[] {

--- a/src/services/StartupLegendService.ts
+++ b/src/services/StartupLegendService.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import Logger from '@common/logger';
 
 const appLogger = Logger.withContext('app:startup');

--- a/src/types/IProvider.ts
+++ b/src/types/IProvider.ts
@@ -1,4 +1,4 @@
-export interface IProvider<TConfig = any> {
+export interface IProvider<TConfig = unknown> {
   /**
    * Unique identifier for the provider (e.g., 'slack', 'discord', 'openai').
    */
@@ -17,12 +17,12 @@ export interface IProvider<TConfig = any> {
   /**
    * Returns the configuration schema object for this provider.
    */
-  getSchema(): any;
+  getSchema(): Record<string, unknown>;
 
   /**
    * Returns the configuration instance or properties.
    */
-  getConfig(): any;
+  getConfig(): TConfig | Record<string, unknown>;
 
   /**
    * Returns a list of sensitive configuration keys (e.g., tokens, secrets) that should be redacted.
@@ -40,13 +40,13 @@ export interface IProvider<TConfig = any> {
   helpText?: string;
 }
 
-export interface IMessageProvider<TConfig = any> extends IProvider<TConfig> {
+export interface IMessageProvider<TConfig = unknown> extends IProvider<TConfig> {
   type: 'messenger';
 
   /**
    * Returns the status of the provider (e.g., connected bots).
    */
-  getStatus(): Promise<any>;
+  getStatus(): Promise<Record<string, unknown>>;
 
   /**
    * Returns a list of configured bot names.
@@ -56,17 +56,17 @@ export interface IMessageProvider<TConfig = any> extends IProvider<TConfig> {
   /**
    * Returns detailed bot information.
    */
-  getBots(): Promise<any[]>;
+  getBots(): Promise<Record<string, unknown>[]>;
 
   /**
    * Adds a new bot configuration.
    */
-  addBot(config: any): Promise<void>;
+  addBot(config: Record<string, unknown>): Promise<void>;
 
   /**
    * Reloads the provider configuration.
    */
-  reload?(): Promise<any>;
+  reload?(): Promise<unknown>;
 
   /**
    * Sends a message to a specific channel.
@@ -83,7 +83,7 @@ export interface IMessageProvider<TConfig = any> extends IProvider<TConfig> {
    * @param limit - Optional maximum number of messages to retrieve
    * @returns A promise that resolves to an array of messages
    */
-  getMessages(channelId: string, limit?: number): Promise<any[]>;
+  getMessages(channelId: string, limit?: number): Promise<unknown[]>;
 
   /**
    * Sends a message to a channel with an optional agent name.
@@ -112,7 +112,7 @@ export interface IMessageProvider<TConfig = any> extends IProvider<TConfig> {
   getForumOwner(forumId: string): Promise<string>;
 }
 
-export interface ILLMProvider<TConfig = any> extends IProvider<TConfig> {
+export interface ILLMProvider<TConfig = unknown> extends IProvider<TConfig> {
   type: 'llm';
 }
 

--- a/src/types/discord.ts
+++ b/src/types/discord.ts
@@ -9,14 +9,14 @@
 // Base Discord API Response Types
 export interface DiscordAPIResponse {
   ok: boolean;
-  data?: any;
+  data?: unknown;
   error?: DiscordAPIError;
 }
 
 export interface DiscordAPIError {
   code: number;
   message: string;
-  errors?: Record<string, any>;
+  errors?: Record<string, unknown>;
 }
 
 // Discord Message Types
@@ -515,7 +515,7 @@ export interface DiscordInteractionData {
 export interface DiscordInteractionDataOption {
   name: string;
   type: number;
-  value?: any;
+  value?: string | number | boolean;
   options?: DiscordInteractionDataOption[];
   focused?: boolean;
 }
@@ -543,7 +543,7 @@ export interface DiscordEntitlement {
 
 // Discord Client and Bot Types
 export interface DiscordBot {
-  client: any; // Discord.js Client
+  client: unknown; // Discord.js Client
   botUserId: string;
   botUserName: string;
   config: DiscordBotConfig;
@@ -556,7 +556,7 @@ export interface DiscordBotConfig {
     token: string;
   };
   llmProvider?: string;
-  llm?: any;
+  llm?: Record<string, unknown>;
 }
 
 // Discord Message Provider Types
@@ -566,33 +566,39 @@ export interface DiscordMessageProvider {
 }
 
 // Type Guards for Runtime Type Checking
-export function isDiscordMessage(obj: any): obj is DiscordMessage {
+export function isDiscordMessage(obj: unknown): obj is DiscordMessage {
+  const o = obj as Record<string, unknown>;
   return (
-    obj &&
-    typeof obj.id === 'string' &&
-    typeof obj.channel_id === 'string' &&
-    typeof obj.content === 'string' &&
-    obj.author &&
-    typeof obj.author.id === 'string'
+    !!o &&
+    typeof o.id === 'string' &&
+    typeof o.channel_id === 'string' &&
+    typeof o.content === 'string' &&
+    !!o.author &&
+    typeof (o.author as Record<string, unknown>).id === 'string'
   );
 }
 
-export function isDiscordUser(obj: any): obj is DiscordUser {
-  return obj && typeof obj.id === 'string' && typeof obj.username === 'string';
+export function isDiscordUser(obj: unknown): obj is DiscordUser {
+  const o = obj as Record<string, unknown>;
+  return !!o && typeof o.id === 'string' && typeof o.username === 'string';
 }
 
-export function isDiscordChannel(obj: any): obj is DiscordChannel {
-  return obj && typeof obj.id === 'string' && typeof obj.type === 'number';
+export function isDiscordChannel(obj: unknown): obj is DiscordChannel {
+  const o = obj as Record<string, unknown>;
+  return !!o && typeof o.id === 'string' && typeof o.type === 'number';
 }
 
-export function isDiscordGuild(obj: any): obj is DiscordGuild {
-  return obj && typeof obj.id === 'string' && typeof obj.name === 'string';
+export function isDiscordGuild(obj: unknown): obj is DiscordGuild {
+  const o = obj as Record<string, unknown>;
+  return !!o && typeof o.id === 'string' && typeof o.name === 'string';
 }
 
-export function isDiscordAPIResponse(obj: any): obj is DiscordAPIResponse {
-  return obj && typeof obj.ok === 'boolean';
+export function isDiscordAPIResponse(obj: unknown): obj is DiscordAPIResponse {
+  const o = obj as Record<string, unknown>;
+  return !!o && typeof o.ok === 'boolean';
 }
 
-export function isDiscordAPIError(obj: any): obj is DiscordAPIError {
-  return obj && typeof obj.code === 'number' && typeof obj.message === 'string';
+export function isDiscordAPIError(obj: unknown): obj is DiscordAPIError {
+  const o = obj as Record<string, unknown>;
+  return !!o && typeof o.code === 'number' && typeof o.message === 'string';
 }

--- a/tests/api/Agents.integration.test.ts
+++ b/tests/api/Agents.integration.test.ts
@@ -1,6 +1,6 @@
+import { promises as fs } from 'fs';
 import express from 'express';
 import request from 'supertest';
-import { promises as fs } from 'fs';
 import agentsRouter from '../../src/server/routes/agents';
 
 jest.mock('fs', () => ({
@@ -9,7 +9,7 @@ jest.mock('fs', () => ({
     writeFile: jest.fn(),
     mkdir: jest.fn().mockResolvedValue(undefined),
     access: jest.fn().mockResolvedValue(undefined),
-  }
+  },
 }));
 
 // Mock validation to avoid schema overhead in this test
@@ -34,15 +34,15 @@ describe('Agents API Integration', () => {
     llmProvider: 'openai',
     mcpServers: [],
     mcpGuard: { enabled: false, type: 'owner', allowedUserIds: [] },
-    isActive: true
+    isActive: true,
   };
 
   describe('GET /api/agents', () => {
     it('should return a list of agents', async () => {
       (fs.readFile as jest.Mock).mockResolvedValue(JSON.stringify([mockAgent]));
-      
+
       const response = await request(app).get('/api/agents');
-      
+
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
       expect(response.body.data.agents).toHaveLength(1);
@@ -51,9 +51,9 @@ describe('Agents API Integration', () => {
 
     it('should handle empty config file', async () => {
       (fs.readFile as jest.Mock).mockRejectedValue({ code: 'ENOENT' });
-      
+
       const response = await request(app).get('/api/agents');
-      
+
       expect(response.status).toBe(200);
       expect(response.body.data.agents).toEqual([]);
     });
@@ -63,17 +63,15 @@ describe('Agents API Integration', () => {
     it('should create a new agent', async () => {
       (fs.readFile as jest.Mock).mockResolvedValue('[]');
       (fs.writeFile as jest.Mock).mockResolvedValue(undefined);
-      
+
       const newAgentData = {
         name: 'New Bot',
         messageProvider: 'slack',
-        llmProvider: 'anthropic'
+        llmProvider: 'anthropic',
       };
-      
-      const response = await request(app)
-        .post('/api/agents')
-        .send(newAgentData);
-      
+
+      const response = await request(app).post('/api/agents').send(newAgentData);
+
       expect(response.status).toBe(200);
       expect(response.body.data.agent.name).toBe('New Bot');
       expect(fs.writeFile).toHaveBeenCalled();
@@ -81,11 +79,9 @@ describe('Agents API Integration', () => {
 
     it('should return existing agent if name matches (idempotency)', async () => {
       (fs.readFile as jest.Mock).mockResolvedValue(JSON.stringify([mockAgent]));
-      
-      const response = await request(app)
-        .post('/api/agents')
-        .send({ name: 'Test Agent' });
-      
+
+      const response = await request(app).post('/api/agents').send({ name: 'Test Agent' });
+
       expect(response.status).toBe(200);
       expect(response.body.agent.id).toBe('agent-1');
       expect(fs.writeFile).not.toHaveBeenCalled();
@@ -96,25 +92,21 @@ describe('Agents API Integration', () => {
     it('should update an existing agent', async () => {
       (fs.readFile as jest.Mock).mockResolvedValue(JSON.stringify([mockAgent]));
       (fs.writeFile as jest.Mock).mockResolvedValue(undefined);
-      
-      const response = await request(app)
-        .put('/api/agents/agent-1')
-        .send({ isActive: false });
-      
+
+      const response = await request(app).put('/api/agents/agent-1').send({ isActive: false });
+
       expect(response.status).toBe(200);
       expect(response.body.data.agent.isActive).toBe(false);
-      
+
       const savedData = JSON.parse((fs.writeFile as jest.Mock).mock.calls[0][1]);
       expect(savedData[0].isActive).toBe(false);
     });
 
     it('should return 404 for non-existent agent', async () => {
       (fs.readFile as jest.Mock).mockResolvedValue('[]');
-      
-      const response = await request(app)
-        .put('/api/agents/non-existent')
-        .send({ name: 'Updated' });
-      
+
+      const response = await request(app).put('/api/agents/non-existent').send({ name: 'Updated' });
+
       expect(response.status).toBe(404);
     });
   });

--- a/tests/api/admin-endpoints.test.ts
+++ b/tests/api/admin-endpoints.test.ts
@@ -308,7 +308,9 @@ describe('Admin API Endpoints - COMPLETE TDD SUITE', () => {
     it('should handle connection failures gracefully', async () => {
       // Set up mock to reject connection
       const mcpServiceInstance = MCPService.getInstance();
-      jest.spyOn(mcpServiceInstance, 'connectToServer').mockRejectedValueOnce(new Error('Connection failed'));
+      jest
+        .spyOn(mcpServiceInstance, 'connectToServer')
+        .mockRejectedValueOnce(new Error('Connection failed'));
 
       const failingConfig = {
         name: 'failing-server',

--- a/tests/api/agent-templates.integration.test.ts
+++ b/tests/api/agent-templates.integration.test.ts
@@ -1,7 +1,7 @@
-import request from 'supertest';
-import { WebUIServer } from '../../src/server/server';
 import express from 'express';
+import request from 'supertest';
 import { registerServices } from '../../src/di/registration';
+import { WebUIServer } from '../../src/server/server';
 
 describe('Agent and Template API Integration', () => {
   let app: express.Application;
@@ -16,7 +16,7 @@ describe('Agent and Template API Integration', () => {
     const res = await request(app)
       .get('/api/specs/templates')
       .set('Authorization', 'Bearer fake-token-for-admin');
-    
+
     // Protection check (401 if auth is not bypassed)
     if (res.status === 200) {
       expect(Array.isArray(res.body.data.templates)).toBe(true);
@@ -30,7 +30,7 @@ describe('Agent and Template API Integration', () => {
     const res = await request(app)
       .get('/api/agents')
       .set('Authorization', 'Bearer fake-token-for-admin');
-    
+
     expect([200, 401]).toContain(res.status);
     if (res.status === 200) {
       expect(res.body.success).toBe(true);

--- a/tests/api/api-response-consistency.test.ts
+++ b/tests/api/api-response-consistency.test.ts
@@ -1,8 +1,8 @@
 import express from 'express';
 import request from 'supertest';
+import configRouter from '../../src/server/routes/config';
 import healthRouter from '../../src/server/routes/health';
 import sitemapRouter from '../../src/server/routes/sitemap';
-import configRouter from '../../src/server/routes/config';
 
 describe('API Response Consistency', () => {
   let app: express.Application;
@@ -25,10 +25,10 @@ describe('API Response Consistency', () => {
   endpoints.forEach(({ path, expectedStatus }) => {
     it(`GET ${path} should return a consistent JSON response`, async () => {
       const res = await request(app).get(path);
-      
+
       expect(res.status).toBe(expectedStatus);
       expect(res.headers['content-type']).toMatch(/json/);
-      
+
       // All successful non-legacy endpoints should ideally have a success flag
       // or at least be valid JSON
       expect(typeof res.body).toBe('object');

--- a/tests/api/auth-validation.integration.test.ts
+++ b/tests/api/auth-validation.integration.test.ts
@@ -26,7 +26,7 @@ describe('Auth Validation Integration', () => {
       const res = await request(app).post('/auth/register').send({
         username: 'a', // Too short
         password: '123', // Too short
-        email: 'test@example.com'
+        email: 'test@example.com',
       });
       expect(res.status).toBe(400);
       expect(res.body.code).toBe('VALIDATION_ERROR');
@@ -37,7 +37,7 @@ describe('Auth Validation Integration', () => {
       const res = await request(app).post('/auth/register').send({
         username: 'validuser',
         password: 'ValidPassword123!',
-        email: 'not-an-email'
+        email: 'not-an-email',
       });
       expect(res.status).toBe(400);
       expect(res.body.code).toBe('VALIDATION_ERROR');

--- a/tests/api/comprehensive-integration.test.ts
+++ b/tests/api/comprehensive-integration.test.ts
@@ -1,9 +1,9 @@
 import express from 'express';
 import request from 'supertest';
+import { adminRouter } from '../../src/server/routes/admin';
+import configRouter from '../../src/server/routes/config';
 import healthRouter from '../../src/server/routes/health';
 import sitemapRouter from '../../src/server/routes/sitemap';
-import configRouter from '../../src/server/routes/config';
-import { adminRouter } from '../../src/server/routes/admin';
 
 describe('Comprehensive API Integration', () => {
   let app: express.Application;
@@ -11,7 +11,7 @@ describe('Comprehensive API Integration', () => {
   beforeAll(() => {
     app = express();
     app.use(express.json());
-    
+
     // Mount all major route groups
     app.use('/health', healthRouter);
     app.use('/sitemap', sitemapRouter);

--- a/tests/api/config-redaction.integration.test.ts
+++ b/tests/api/config-redaction.integration.test.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import request from 'supertest';
-import configRouter from '../../src/server/routes/config';
 import { BotConfigurationManager } from '../../src/config/BotConfigurationManager';
+import configRouter from '../../src/server/routes/config';
 
 describe('Config Redaction Integration', () => {
   let app: express.Application;
@@ -15,11 +15,11 @@ describe('Config Redaction Integration', () => {
   it('should return redacted bot configuration from real router', async () => {
     // Add a temporary bot with secret info via the manager
     const manager = BotConfigurationManager.getInstance();
-    
+
     // Check real API response
     const res = await request(app).get('/api/config');
     expect(res.status).toBe(200);
-    
+
     // Verify all bots in response have redacted tokens
     if (res.body.bots && res.body.bots.length > 0) {
       res.body.bots.forEach((bot: any) => {

--- a/tests/api/config-sources-async.test.ts
+++ b/tests/api/config-sources-async.test.ts
@@ -8,10 +8,10 @@
  * error coverage. The old file's name promised "Performance Optimization"
  * but contained no timing, throughput, or memory assertions.
  */
-import express from 'express';
-import request from 'supertest';
 import fs from 'fs';
 import path from 'path';
+import express from 'express';
+import request from 'supertest';
 import configRouter from '../../src/server/routes/config';
 
 // ---------------------------------------------------------------------------
@@ -165,7 +165,11 @@ describe('GET /api/config/sources', () => {
   it('should return empty envVars when no matching env vars exist', async () => {
     // Clear all matching env vars
     Object.keys(process.env).forEach((key) => {
-      if (/^(BOTS_|DISCORD_|SLACK_|OPENAI_|FLOWISE_|OPENWEBUI_|MATTERMOST_|MESSAGE_|WEBHOOK_)/.test(key)) {
+      if (
+        /^(BOTS_|DISCORD_|SLACK_|OPENAI_|FLOWISE_|OPENWEBUI_|MATTERMOST_|MESSAGE_|WEBHOOK_)/.test(
+          key
+        )
+      ) {
         delete process.env[key];
       }
     });

--- a/tests/api/dashboard.integration.test.ts
+++ b/tests/api/dashboard.integration.test.ts
@@ -1,7 +1,7 @@
-import request from 'supertest';
-import { WebUIServer } from '../../src/server/server';
 import express from 'express';
+import request from 'supertest';
 import { registerServices } from '../../src/di/registration';
+import { WebUIServer } from '../../src/server/server';
 
 describe('Dashboard API Integration', () => {
   let app: express.Application;

--- a/tests/api/hot-reload.integration.test.ts
+++ b/tests/api/hot-reload.integration.test.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import request from 'supertest';
-import hotReloadRouter from '../../src/server/routes/hotReload';
 import { HotReloadManager } from '../../src/config/HotReloadManager';
+import hotReloadRouter from '../../src/server/routes/hotReload';
 
 describe('Hot Reload API Integration', () => {
   let app: express.Application;
@@ -18,7 +18,7 @@ describe('Hot Reload API Integration', () => {
       .post('/api/hot-reload')
       .set('Origin', 'http://localhost:3000')
       .send({});
-    
+
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('Validation failed');
   });
@@ -30,9 +30,9 @@ describe('Hot Reload API Integration', () => {
       .send({
         type: 'update',
         botName: 'test-bot',
-        changes: {}
+        changes: {},
       });
-    
+
     expect(res.status).toBe(400);
     expect(JSON.stringify(res.body)).toContain('At least one change');
   });

--- a/tests/api/import-export.integration.test.ts
+++ b/tests/api/import-export.integration.test.ts
@@ -1,7 +1,7 @@
-import request from 'supertest';
-import { WebUIServer } from '../../src/server/server';
 import express from 'express';
+import request from 'supertest';
 import { registerServices } from '../../src/di/registration';
+import { WebUIServer } from '../../src/server/server';
 
 describe('Import-Export API Integration', () => {
   let app: express.Application;
@@ -14,7 +14,9 @@ describe('Import-Export API Integration', () => {
 
   it('should reject unauthenticated access to import/export endpoints', async () => {
     const resBackups = await request(app).get('/api/import-export/backups');
-    const resExport = await request(app).post('/api/import-export/export').send({ configIds: [1], format: 'json' });
+    const resExport = await request(app)
+      .post('/api/import-export/export')
+      .send({ configIds: [1], format: 'json' });
 
     // Assuming global auth mock doesn't bypass this, we should get 401
     expect([200, 401]).toContain(resBackups.status);

--- a/tests/api/llm-provider-lifecycle.integration.test.ts
+++ b/tests/api/llm-provider-lifecycle.integration.test.ts
@@ -18,7 +18,7 @@ describe('LLM Provider API Integration', () => {
       .set('Origin', 'http://localhost:3000');
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body.data)).toBe(true);
-    
+
     // We should have some default profiles
     if (res.body.data.length > 0) {
       expect(res.body.data[0]).toHaveProperty('key');

--- a/tests/api/mcp-tool-preferences.test.ts
+++ b/tests/api/mcp-tool-preferences.test.ts
@@ -89,12 +89,7 @@ describe('ToolPreferencesService', () => {
   });
 
   it('should set a tool to disabled', async () => {
-    const result = await service.setToolEnabled(
-      'server1-tool1',
-      'server1',
-      'tool1',
-      false
-    );
+    const result = await service.setToolEnabled('server1-tool1', 'server1', 'tool1', false);
 
     expect(result.toolId).toBe('server1-tool1');
     expect(result.enabled).toBe(false);

--- a/tests/api/persona-management.integration.test.ts
+++ b/tests/api/persona-management.integration.test.ts
@@ -1,6 +1,6 @@
 import request from 'supertest';
-import { WebUIServer } from '../../src/server/server';
 import { registerServices } from '../../src/di/registration';
+import { WebUIServer } from '../../src/server/server';
 
 describe('Persona Management Integration', () => {
   let app: any;
@@ -16,13 +16,13 @@ describe('Persona Management Integration', () => {
       .get('/api/personas')
       .set('Authorization', 'Bearer dummy-token')
       .set('Origin', 'http://localhost:3000');
-    
+
     expect([200, 401, 403]).toContain(res.status);
-    
+
     if (res.status === 200) {
       expect(Array.isArray(res.body)).toBe(true);
       expect(res.body.length).toBeGreaterThanOrEqual(1);
-      
+
       // Check that personas have required fields
       const persona = res.body[0];
       expect(persona).toHaveProperty('id');
@@ -36,7 +36,7 @@ describe('Persona Management Integration', () => {
       .get('/api/personas/non-existent-persona-12345')
       .set('Authorization', 'Bearer dummy-token')
       .set('Origin', 'http://localhost:3000');
-    
+
     expect([404, 401, 403]).toContain(res.status);
   });
 });

--- a/tests/api/system-status.integration.test.ts
+++ b/tests/api/system-status.integration.test.ts
@@ -1,8 +1,8 @@
 import express from 'express';
 import request from 'supertest';
+import configRouter from '../../src/server/routes/config';
 import healthRouter from '../../src/server/routes/health';
 import sitemapRouter from '../../src/server/routes/sitemap';
-import configRouter from '../../src/server/routes/config';
 
 describe('System Status API Integration', () => {
   let app: express.Application;

--- a/tests/api/usage-analytics.integration.test.ts
+++ b/tests/api/usage-analytics.integration.test.ts
@@ -1,7 +1,7 @@
-import request from 'supertest';
-import { WebUIServer } from '../../src/server/server';
 import express from 'express';
+import request from 'supertest';
 import { registerServices } from '../../src/di/registration';
+import { WebUIServer } from '../../src/server/server';
 import { UsageTrackerService } from '../../src/server/services/UsageTrackerService';
 
 describe('Usage Analytics API Integration', () => {
@@ -17,7 +17,7 @@ describe('Usage Analytics API Integration', () => {
     const res = await request(app)
       .get('/api/usage/stats')
       .set('Authorization', 'Bearer fake-admin-token');
-    
+
     expect([200, 401]).toContain(res.status);
     if (res.status === 200) {
       expect(res.body.success).toBe(true);
@@ -29,7 +29,7 @@ describe('Usage Analytics API Integration', () => {
     const res = await request(app)
       .get('/api/usage/tools')
       .set('Authorization', 'Bearer fake-admin-token');
-    
+
     expect([200, 401]).toContain(res.status);
   });
 });

--- a/tests/api/webui-config.integration.test.ts
+++ b/tests/api/webui-config.integration.test.ts
@@ -1,9 +1,9 @@
+import fs from 'fs';
+import path from 'path';
 import request from 'supertest';
+import { registerServices } from '../../src/di/registration';
 import { WebUIServer } from '../../src/server/server';
 import { webUIStorage } from '../../src/storage/webUIStorage';
-import { registerServices } from '../../src/di/registration';
-import path from 'path';
-import fs from 'fs';
 
 describe('WebUI Config API Integration', () => {
   let app: any;
@@ -11,7 +11,7 @@ describe('WebUI Config API Integration', () => {
 
   beforeAll(() => {
     registerServices();
-    
+
     // Override config directory for testing
     (webUIStorage as any).configDir = testConfigDir;
     (webUIStorage as any).configFile = path.join(testConfigDir, 'webui-config.json');
@@ -38,8 +38,8 @@ describe('WebUI Config API Integration', () => {
       mcpGuard: {
         enabled: false,
         type: 'owner',
-        allowedUserIds: []
-      }
+        allowedUserIds: [],
+      },
     };
 
     // 1. Create agent - use a token that our auth mock accepts or bypasses
@@ -48,11 +48,11 @@ describe('WebUI Config API Integration', () => {
       .set('Authorization', 'Bearer dummy-admin-token')
       .set('Origin', 'http://localhost:3000')
       .send(newAgent);
-    
-    // If auth is not mocked to pass, this will be 401. 
+
+    // If auth is not mocked to pass, this will be 401.
     // We want to test the logic, so we hope it's 200.
     expect([200, 401, 403]).toContain(createRes.status);
-    
+
     if (createRes.status === 200) {
       expect(createRes.body.data.agent.name).toBe(newAgent.name);
       const agentId = createRes.body.data.agent.id;

--- a/tests/common/CircuitBreaker.robust.test.ts
+++ b/tests/common/CircuitBreaker.robust.test.ts
@@ -1,7 +1,7 @@
-import { 
-  CircuitBreaker, 
-  CircuitBreakerState, 
-  CircuitBreakerError 
+import {
+  CircuitBreaker,
+  CircuitBreakerError,
+  CircuitBreakerState,
 } from '../../src/common/CircuitBreaker';
 
 describe('CircuitBreaker (Robust)', () => {
@@ -13,12 +13,12 @@ describe('CircuitBreaker (Robust)', () => {
     jest.useFakeTimers();
     // Set a fixed system time for consistent testing
     jest.setSystemTime(new Date('2024-01-01T00:00:00Z'));
-    
+
     breaker = new CircuitBreaker({
       name: 'test-breaker',
       failureThreshold: FAILURE_THRESHOLD,
       resetTimeoutMs: RESET_TIMEOUT,
-      halfOpenMaxAttempts: 2
+      halfOpenMaxAttempts: 2,
     });
   });
 
@@ -39,17 +39,29 @@ describe('CircuitBreaker (Robust)', () => {
 
     it('should transition to OPEN after reaching failure threshold', async () => {
       const error = new Error('service down');
-      
+
       // 1st failure
-      await expect(breaker.execute(async () => { throw error; })).rejects.toThrow(error);
+      await expect(
+        breaker.execute(async () => {
+          throw error;
+        })
+      ).rejects.toThrow(error);
       expect(breaker.getState()).toBe(CircuitBreakerState.CLOSED);
-      
+
       // 2nd failure
-      await expect(breaker.execute(async () => { throw error; })).rejects.toThrow(error);
+      await expect(
+        breaker.execute(async () => {
+          throw error;
+        })
+      ).rejects.toThrow(error);
       expect(breaker.getState()).toBe(CircuitBreakerState.CLOSED);
-      
+
       // 3rd failure (threshold reached)
-      await expect(breaker.execute(async () => { throw error; })).rejects.toThrow(error);
+      await expect(
+        breaker.execute(async () => {
+          throw error;
+        })
+      ).rejects.toThrow(error);
       expect(breaker.getState()).toBe(CircuitBreakerState.OPEN);
     });
   });
@@ -58,13 +70,19 @@ describe('CircuitBreaker (Robust)', () => {
     beforeEach(async () => {
       // Trip the breaker
       for (let i = 0; i < FAILURE_THRESHOLD; i++) {
-        await breaker.execute(async () => { throw new Error('fail'); }).catch(() => {});
+        await breaker
+          .execute(async () => {
+            throw new Error('fail');
+          })
+          .catch(() => {});
       }
       expect(breaker.getState()).toBe(CircuitBreakerState.OPEN);
     });
 
     it('should reject requests immediately with CircuitBreakerError', async () => {
-      await expect(breaker.execute(async () => 'should not run')).rejects.toThrow(CircuitBreakerError);
+      await expect(breaker.execute(async () => 'should not run')).rejects.toThrow(
+        CircuitBreakerError
+      );
     });
 
     it('should transition to HALF_OPEN after reset timeout', async () => {
@@ -75,7 +93,7 @@ describe('CircuitBreaker (Robust)', () => {
 
       // Advance past timeout
       jest.advanceTimersByTime(200);
-      
+
       // Next call should transition to HALF_OPEN and allow request
       const result = await breaker.execute(async () => 'recovered');
       expect(result).toBe('recovered');
@@ -87,7 +105,11 @@ describe('CircuitBreaker (Robust)', () => {
     beforeEach(async () => {
       // Trip and wait for reset
       for (let i = 0; i < FAILURE_THRESHOLD; i++) {
-        await breaker.execute(async () => { throw new Error('fail'); }).catch(() => {});
+        await breaker
+          .execute(async () => {
+            throw new Error('fail');
+          })
+          .catch(() => {});
       }
       jest.advanceTimersByTime(RESET_TIMEOUT + 1);
       // First call transitions to HALF_OPEN
@@ -105,24 +127,28 @@ describe('CircuitBreaker (Robust)', () => {
 
     it('should transition back to OPEN if a probe fails', async () => {
       const error = new Error('probe failed');
-      await expect(breaker.execute(async () => { throw error; })).rejects.toThrow(error);
+      await expect(
+        breaker.execute(async () => {
+          throw error;
+        })
+      ).rejects.toThrow(error);
       expect(breaker.getState()).toBe(CircuitBreakerState.OPEN);
     });
 
     it('should cap the number of parallel probes in HALF_OPEN', async () => {
-      // Current attempts = 1 (from beforeEach). 
+      // Current attempts = 1 (from beforeEach).
       // Next call will be attempt 2.
       // Call after that should be rejected if not finished.
       // (This tests the synchronous check before 'await fn()')
-      
+
       const slowProbe = breaker.execute(async () => {
-        await new Promise(resolve => setTimeout(resolve, 500));
+        await new Promise((resolve) => setTimeout(resolve, 500));
         return 'slow-success';
       });
-      
+
       // attempt 3 should be rejected immediately because maxAttempts is 2
       await expect(breaker.execute(async () => 'fast-fail')).rejects.toThrow(CircuitBreakerError);
-      
+
       jest.advanceTimersByTime(500);
       await slowProbe;
     });

--- a/tests/common/UtilityFunctions.test.ts
+++ b/tests/common/UtilityFunctions.test.ts
@@ -1,5 +1,5 @@
-import { getRandomDelay } from '../../src/common/getRandomDelay';
 import { getEmoji } from '../../src/common/getEmoji';
+import { getRandomDelay } from '../../src/common/getRandomDelay';
 
 describe('Utility Functions', () => {
   describe('getRandomDelay', () => {

--- a/tests/common/utils-comprehensive.test.ts
+++ b/tests/common/utils-comprehensive.test.ts
@@ -83,8 +83,8 @@ describe('Utility Functions Comprehensive Tests', () => {
     it('should return repeatable results within reasonable bounds', () => {
       // Call 1000 times and ensure no errors
       const results = Array.from({ length: 1000 }, () => getEmoji());
-      expect(results.every(r => typeof r === 'string')).toBe(true);
-      expect(results.every(r => r.length > 0)).toBe(true);
+      expect(results.every((r) => typeof r === 'string')).toBe(true);
+      expect(results.every((r) => r.length > 0)).toBe(true);
     });
   });
 
@@ -141,7 +141,7 @@ describe('Utility Functions Comprehensive Tests', () => {
         `${COMMAND_PREFIX}stop - Stop the bot`,
         `${COMMAND_PREFIX}help - Show help`,
       ];
-      expect(lines.every(l => l.startsWith(COMMAND_PREFIX))).toBe(true);
+      expect(lines.every((l) => l.startsWith(COMMAND_PREFIX))).toBe(true);
     });
 
     it('should demonstrate string splitting with prefix', () => {
@@ -186,7 +186,7 @@ describe('Utility Functions Comprehensive Tests', () => {
     it('should validate string length constraints', () => {
       const isValidLength = (s: string, min: number, max: number) =>
         s.length >= min && s.length <= max;
-      
+
       expect(isValidLength('test', 1, 10)).toBe(true);
       expect(isValidLength('', 1, 10)).toBe(false);
       expect(isValidLength('verylongstring', 1, 5)).toBe(false);
@@ -201,7 +201,7 @@ describe('Utility Functions Comprehensive Tests', () => {
     it('should validateCommandFormat for bot commands', () => {
       const isValidCommand = (input: string) =>
         input.startsWith(COMMAND_PREFIX) && input.length > COMMAND_PREFIX.length;
-      
+
       expect(isValidCommand(`${COMMAND_PREFIX}help`)).toBe(true);
       expect(isValidCommand(`${COMMAND_PREFIX}`)).toBe(false);
       expect(isValidCommand('help')).toBe(false);
@@ -210,7 +210,7 @@ describe('Utility Functions Comprehensive Tests', () => {
     it('should handle multiple prefix validation', () => {
       const validPrefixes = ['!', '/', '.', '?'];
       const isValidPrefix = (p: string) => validPrefixes.includes(p);
-      
+
       expect(isValidPrefix(COMMAND_PREFIX)).toBe(true);
       expect(isValidPrefix('invalid')).toBe(false);
     });
@@ -276,16 +276,17 @@ describe('Utility Functions Comprehensive Tests', () => {
         `${COMMAND_PREFIX}restart`,
         `${COMMAND_PREFIX}status`,
       ];
-      expect(commands.every(c => c.startsWith(COMMAND_PREFIX))).toBe(true);
+      expect(commands.every((c) => c.startsWith(COMMAND_PREFIX))).toBe(true);
     });
 
     it('should handle batch command generation', () => {
       const emoji = getEmoji();
-      const commands = Array.from({ length: 10 }, (_, i) =>
-        `${COMMAND_PREFIX}command${i} ${emoji}`
+      const commands = Array.from(
+        { length: 10 },
+        (_, i) => `${COMMAND_PREFIX}command${i} ${emoji}`
       );
       expect(commands.length).toBe(10);
-      expect(commands.every(c => c.startsWith(COMMAND_PREFIX))).toBe(true);
+      expect(commands.every((c) => c.startsWith(COMMAND_PREFIX))).toBe(true);
     });
 
     it('should validate command batch', () => {
@@ -294,8 +295,8 @@ describe('Utility Functions Comprehensive Tests', () => {
         `${COMMAND_PREFIX}valid2`,
         `${COMMAND_PREFIX}valid3`,
       ];
-      const allValid = commands.every(c =>
-        c.startsWith(COMMAND_PREFIX) && c.length > COMMAND_PREFIX.length
+      const allValid = commands.every(
+        (c) => c.startsWith(COMMAND_PREFIX) && c.length > COMMAND_PREFIX.length
       );
       expect(allValid).toBe(true);
     });
@@ -305,7 +306,7 @@ describe('Utility Functions Comprehensive Tests', () => {
       const commandPattern = new RegExp(`${COMMAND_PREFIX}\\w+`, 'g');
       const commands = mixedText.match(commandPattern) || [];
       expect(commands.length).toBeGreaterThan(0);
-      expect(commands.every(c => c.startsWith(COMMAND_PREFIX))).toBe(true);
+      expect(commands.every((c) => c.startsWith(COMMAND_PREFIX))).toBe(true);
     });
 
     it('should handle edge case of consecutive commands', () => {

--- a/tests/contracts/llmProviderContract.test.ts
+++ b/tests/contracts/llmProviderContract.test.ts
@@ -82,8 +82,8 @@ jest.mock('../../packages/llm-openwebui/src/openWebUIConfig', () => ({
       authMethod: 'apiKey',
       apiKey: 'fake-api-key',
       apiUrl: 'http://localhost:3000/api/',
-      model: 'llama3.2'
-    }))
+      model: 'llama3.2',
+    })),
   },
 }));
 

--- a/tests/database/ConnectionManager.test.ts
+++ b/tests/database/ConnectionManager.test.ts
@@ -1,5 +1,5 @@
-import { ConnectionManager } from '../../src/database/ConnectionManager';
 import Database from 'better-sqlite3';
+import { ConnectionManager } from '../../src/database/ConnectionManager';
 
 jest.mock('../../src/common/logger');
 
@@ -14,7 +14,7 @@ describe('ConnectionManager', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    
+
     // @ts-ignore - Database is mocked and has these methods on prototype
     runSpy = jest.spyOn(Database.prototype, 'prepare');
     // @ts-ignore
@@ -68,7 +68,9 @@ describe('ConnectionManager', () => {
 
     it('should throw if not connected', async () => {
       await connectionManager.disconnect();
-      await expect(connectionManager.executeQuery('SELECT 1')).rejects.toThrow('Database not connected');
+      await expect(connectionManager.executeQuery('SELECT 1')).rejects.toThrow(
+        'Database not connected'
+      );
     });
   });
 });

--- a/tests/database/DatabaseManager.test.ts
+++ b/tests/database/DatabaseManager.test.ts
@@ -1,6 +1,6 @@
 import { DatabaseManager } from '../../src/database/DatabaseManager';
-import { DatabaseError } from '../../src/types/errorClasses';
 import { SQLiteWrapper } from '../../src/database/sqliteWrapper';
+import { DatabaseError } from '../../src/types/errorClasses';
 
 // Spies on the mocked Database
 let runSpy: jest.SpyInstance;
@@ -18,8 +18,10 @@ describe('DatabaseManager', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    
-    runSpy = jest.spyOn(SQLiteWrapper.prototype, 'run').mockResolvedValue({ lastID: 1, changes: 1 });
+
+    runSpy = jest
+      .spyOn(SQLiteWrapper.prototype, 'run')
+      .mockResolvedValue({ lastID: 1, changes: 1 });
     getSpy = jest.spyOn(SQLiteWrapper.prototype, 'get').mockResolvedValue(undefined);
     allSpy = jest.spyOn(SQLiteWrapper.prototype, 'all').mockResolvedValue([]);
     execSpy = jest.spyOn(SQLiteWrapper.prototype, 'exec').mockResolvedValue(undefined);

--- a/tests/e2e/crud-backups.spec.ts
+++ b/tests/e2e/crud-backups.spec.ts
@@ -119,9 +119,7 @@ test.describe('Backups Page', () => {
     await page.waitForLoadState('networkidle');
 
     // Should show empty state message
-    await expect(
-      page.getByText(/no backups|create your first/i)
-    ).toBeVisible();
+    await expect(page.getByText(/no backups|create your first/i)).toBeVisible();
   });
 
   test('handles API errors gracefully', async ({ page }) => {
@@ -145,7 +143,7 @@ test.describe('Backups Page', () => {
 
     // Should show encrypted badge for encrypted backup
     const encryptedBadge = page.locator('[class*="badge"]').filter({ hasText: /encrypted/i });
-    if (await encryptedBadge.count() > 0) {
+    if ((await encryptedBadge.count()) > 0) {
       await expect(encryptedBadge.first()).toBeVisible();
     }
   });

--- a/tests/e2e/crud-plugin-security.spec.ts
+++ b/tests/e2e/crud-plugin-security.spec.ts
@@ -129,7 +129,7 @@ test.describe('Plugin Security Page', () => {
 
     // Refresh button should exist
     const refreshBtn = page.getByRole('button', { name: /refresh/i });
-    if (await refreshBtn.count() > 0) {
+    if ((await refreshBtn.count()) > 0) {
       await expect(refreshBtn).toBeEnabled();
     }
   });

--- a/tests/e2e/crud-response-profile-lifecycle.spec.ts
+++ b/tests/e2e/crud-response-profile-lifecycle.spec.ts
@@ -31,7 +31,13 @@ test.describe('Swarm Orchestration Mode', () => {
         return route.fulfill({
           status: 200,
           json: {
-            user: { id: 'admin', username: 'admin', email: 'admin@open-hivemind.com', role: 'owner', permissions: ['*'] },
+            user: {
+              id: 'admin',
+              username: 'admin',
+              email: 'admin@open-hivemind.com',
+              role: 'owner',
+              permissions: ['*'],
+            },
           },
         });
       }),

--- a/tests/e2e/crud-specs.spec.ts
+++ b/tests/e2e/crud-specs.spec.ts
@@ -170,8 +170,20 @@ test.describe('Specs Page Filtering', () => {
         json: {
           success: true,
           data: [
-            { id: '1', topic: 'Alpha Feature', tags: [], author: 'test', timestamp: new Date().toISOString() },
-            { id: '2', topic: 'Beta Feature', tags: [], author: 'test', timestamp: new Date().toISOString() },
+            {
+              id: '1',
+              topic: 'Alpha Feature',
+              tags: [],
+              author: 'test',
+              timestamp: new Date().toISOString(),
+            },
+            {
+              id: '2',
+              topic: 'Beta Feature',
+              tags: [],
+              author: 'test',
+              timestamp: new Date().toISOString(),
+            },
           ],
         },
       });
@@ -195,8 +207,20 @@ test.describe('Specs Page Filtering', () => {
         json: {
           success: true,
           data: [
-            { id: '1', topic: 'Spec A', tags: ['important'], author: 'test', timestamp: new Date().toISOString() },
-            { id: '2', topic: 'Spec B', tags: ['optional'], author: 'test', timestamp: new Date().toISOString() },
+            {
+              id: '1',
+              topic: 'Spec A',
+              tags: ['important'],
+              author: 'test',
+              timestamp: new Date().toISOString(),
+            },
+            {
+              id: '2',
+              topic: 'Spec B',
+              tags: ['optional'],
+              author: 'test',
+              timestamp: new Date().toISOString(),
+            },
           ],
         },
       });
@@ -221,7 +245,12 @@ test.describe('Specs Page Accessibility', () => {
 
     await page.route('**/api/specs', async (route) => {
       await route.fulfill({
-        json: { success: true, data: [{ id: '1', topic: 'Test', tags: [], author: 'a', timestamp: new Date().toISOString() }] },
+        json: {
+          success: true,
+          data: [
+            { id: '1', topic: 'Test', tags: [], author: 'a', timestamp: new Date().toISOString() },
+          ],
+        },
       });
     });
 

--- a/tests/e2e/crud-system-management.spec.ts
+++ b/tests/e2e/crud-system-management.spec.ts
@@ -176,7 +176,7 @@ test.describe('System Management Backup Operations', () => {
 
     // Enable encryption checkbox
     const encryptCheckbox = page.getByRole('checkbox', { name: /encrypt/i });
-    if (await encryptCheckbox.count() > 0) {
+    if ((await encryptCheckbox.count()) > 0) {
       await encryptCheckbox.check();
 
       // Should show encryption key input
@@ -207,7 +207,7 @@ test.describe('System Management Backup Operations', () => {
 
     // Look for restore button
     const restoreBtn = page.getByRole('button', { name: /restore/i }).first();
-    if (await restoreBtn.count() > 0) {
+    if ((await restoreBtn.count()) > 0) {
       await restoreBtn.click();
 
       // Should open confirmation modal
@@ -233,7 +233,7 @@ test.describe('System Management Backup Operations', () => {
 
     // Look for delete button
     const deleteBtn = page.getByRole('button', { name: /delete/i }).first();
-    if (await deleteBtn.count() > 0) {
+    if ((await deleteBtn.count()) > 0) {
       await deleteBtn.click();
 
       // Should open confirmation modal

--- a/tests/e2e/smoke-test-all-pages.spec.ts
+++ b/tests/e2e/smoke-test-all-pages.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test } from '@playwright/test';
-import { setupTestWithErrorDetection, waitForPageReady, registerViteSourceBypass } from './test-utils';
+import {
+  registerViteSourceBypass,
+  setupTestWithErrorDetection,
+  waitForPageReady,
+} from './test-utils';
 
 /**
  * Smoke Test - All Pages (Comprehensive)
@@ -250,8 +254,22 @@ async function mockAllApiEndpoints(page: import('@playwright/test').Page) {
         json: {
           success: true,
           data: {
-            llm: [{ key: 'openai', label: 'OpenAI', type: 'llm', fields: { required: [], optional: [], advanced: [] } }],
-            messenger: [{ key: 'discord', label: 'Discord', type: 'messenger', fields: { required: [], optional: [], advanced: [] } }],
+            llm: [
+              {
+                key: 'openai',
+                label: 'OpenAI',
+                type: 'llm',
+                fields: { required: [], optional: [], advanced: [] },
+              },
+            ],
+            messenger: [
+              {
+                key: 'discord',
+                label: 'Discord',
+                type: 'messenger',
+                fields: { required: [], optional: [], advanced: [] },
+              },
+            ],
             memory: [],
           },
         },

--- a/tests/e2e/smoke-test-bots.spec.ts
+++ b/tests/e2e/smoke-test-bots.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test } from '@playwright/test';
-import { setupTestWithErrorDetection, waitForPageReady, registerViteSourceBypass } from './test-utils';
+import {
+  registerViteSourceBypass,
+  setupTestWithErrorDetection,
+  waitForPageReady,
+} from './test-utils';
 
 /**
  * Smoke Test - Bot Management Pages
@@ -46,7 +50,17 @@ async function validatePageLoads(
 ) {
   const results: Array<{ label: string; status: 'pass' | 'fail'; error?: string }> = [];
 
-  const ACCEPTED_REDIRECTS = ['/onboarding', '/admin/bots?tab=', '/admin/developer?tab=', '/admin/providers?tab=', '/admin/overview?tab=', '/admin/llm', '/admin/memory', '/admin/tool', '/admin/message'];
+  const ACCEPTED_REDIRECTS = [
+    '/onboarding',
+    '/admin/bots?tab=',
+    '/admin/developer?tab=',
+    '/admin/providers?tab=',
+    '/admin/overview?tab=',
+    '/admin/llm',
+    '/admin/memory',
+    '/admin/tool',
+    '/admin/message',
+  ];
   function isAcceptedRedirect(url: string): boolean {
     return ACCEPTED_REDIRECTS.some((prefix) => url.includes(prefix));
   }

--- a/tests/e2e/smoke-test-config.spec.ts
+++ b/tests/e2e/smoke-test-config.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test } from '@playwright/test';
-import { setupTestWithErrorDetection, waitForPageReady, registerViteSourceBypass } from './test-utils';
+import {
+  registerViteSourceBypass,
+  setupTestWithErrorDetection,
+  waitForPageReady,
+} from './test-utils';
 
 /**
  * Smoke Test - Personas, MCP, and Guards Pages
@@ -46,7 +50,17 @@ async function validatePageLoads(
 ) {
   const results: Array<{ label: string; status: 'pass' | 'fail'; error?: string }> = [];
 
-  const ACCEPTED_REDIRECTS = ['/onboarding', '/admin/bots?tab=', '/admin/developer?tab=', '/admin/providers?tab=', '/admin/overview?tab=', '/admin/llm', '/admin/memory', '/admin/tool', '/admin/message'];
+  const ACCEPTED_REDIRECTS = [
+    '/onboarding',
+    '/admin/bots?tab=',
+    '/admin/developer?tab=',
+    '/admin/providers?tab=',
+    '/admin/overview?tab=',
+    '/admin/llm',
+    '/admin/memory',
+    '/admin/tool',
+    '/admin/message',
+  ];
   function isAcceptedRedirect(url: string): boolean {
     return ACCEPTED_REDIRECTS.some((prefix) => url.includes(prefix));
   }

--- a/tests/e2e/smoke-test-dashboard.spec.ts
+++ b/tests/e2e/smoke-test-dashboard.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test } from '@playwright/test';
-import { setupTestWithErrorDetection, waitForPageReady, registerViteSourceBypass } from './test-utils';
+import {
+  registerViteSourceBypass,
+  setupTestWithErrorDetection,
+  waitForPageReady,
+} from './test-utils';
 
 /**
  * Smoke Test - Dashboard & Admin Overview Pages
@@ -44,7 +48,17 @@ async function validatePageLoads(
 ) {
   const results: Array<{ label: string; status: 'pass' | 'fail'; error?: string }> = [];
 
-  const ACCEPTED_REDIRECTS = ['/onboarding', '/admin/bots?tab=', '/admin/developer?tab=', '/admin/providers?tab=', '/admin/overview?tab=', '/admin/llm', '/admin/memory', '/admin/tool', '/admin/message'];
+  const ACCEPTED_REDIRECTS = [
+    '/onboarding',
+    '/admin/bots?tab=',
+    '/admin/developer?tab=',
+    '/admin/providers?tab=',
+    '/admin/overview?tab=',
+    '/admin/llm',
+    '/admin/memory',
+    '/admin/tool',
+    '/admin/message',
+  ];
   function isAcceptedRedirect(url: string): boolean {
     return ACCEPTED_REDIRECTS.some((prefix) => url.includes(prefix));
   }

--- a/tests/e2e/smoke-test-monitoring.spec.ts
+++ b/tests/e2e/smoke-test-monitoring.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test } from '@playwright/test';
-import { setupTestWithErrorDetection, waitForPageReady, registerViteSourceBypass } from './test-utils';
+import {
+  registerViteSourceBypass,
+  setupTestWithErrorDetection,
+  waitForPageReady,
+} from './test-utils';
 
 /**
  * Smoke Test - Monitoring & System Pages
@@ -53,7 +57,17 @@ async function validatePageLoads(
 ) {
   const results: Array<{ label: string; status: 'pass' | 'fail'; error?: string }> = [];
 
-  const ACCEPTED_REDIRECTS = ['/onboarding', '/admin/bots?tab=', '/admin/developer?tab=', '/admin/providers?tab=', '/admin/overview?tab=', '/admin/llm', '/admin/memory', '/admin/tool', '/admin/message'];
+  const ACCEPTED_REDIRECTS = [
+    '/onboarding',
+    '/admin/bots?tab=',
+    '/admin/developer?tab=',
+    '/admin/providers?tab=',
+    '/admin/overview?tab=',
+    '/admin/llm',
+    '/admin/memory',
+    '/admin/tool',
+    '/admin/message',
+  ];
   function isAcceptedRedirect(url: string): boolean {
     return ACCEPTED_REDIRECTS.some((prefix) => url.includes(prefix));
   }

--- a/tests/e2e/smoke-test-providers.spec.ts
+++ b/tests/e2e/smoke-test-providers.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test } from '@playwright/test';
-import { setupTestWithErrorDetection, waitForPageReady, registerViteSourceBypass } from './test-utils';
+import {
+  registerViteSourceBypass,
+  setupTestWithErrorDetection,
+  waitForPageReady,
+} from './test-utils';
 
 /**
  * Smoke Test - Providers, Integrations & Documentation Pages
@@ -68,7 +72,17 @@ async function validatePageLoads(
 ) {
   const results: Array<{ label: string; status: 'pass' | 'fail'; error?: string }> = [];
 
-  const ACCEPTED_REDIRECTS = ['/onboarding', '/admin/bots?tab=', '/admin/developer?tab=', '/admin/providers?tab=', '/admin/overview?tab=', '/admin/llm', '/admin/memory', '/admin/tool', '/admin/message'];
+  const ACCEPTED_REDIRECTS = [
+    '/onboarding',
+    '/admin/bots?tab=',
+    '/admin/developer?tab=',
+    '/admin/providers?tab=',
+    '/admin/overview?tab=',
+    '/admin/llm',
+    '/admin/memory',
+    '/admin/tool',
+    '/admin/message',
+  ];
   function isAcceptedRedirect(url: string): boolean {
     return ACCEPTED_REDIRECTS.some((prefix) => url.includes(prefix));
   }

--- a/tests/getLlmProvider_caching.test.ts
+++ b/tests/getLlmProvider_caching.test.ts
@@ -115,7 +115,9 @@ describe('getLlmProvider Caching', () => {
 
     await getLlmProvider();
     expect(mockInstantiateLlmProvider).toHaveBeenCalledTimes(2);
-    expect(mockInstantiateLlmProvider).toHaveBeenLastCalledWith(expect.any(Object), { key: 'val2' });
+    expect(mockInstantiateLlmProvider).toHaveBeenLastCalledWith(expect.any(Object), {
+      key: 'val2',
+    });
   });
 
   it('cleans up stale providers and re-instantiates when added back', async () => {

--- a/tests/integration/Bots.integration.test.ts
+++ b/tests/integration/Bots.integration.test.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import request from 'supertest';
+import botsRouter from '../../src/server/routes/bots';
 
 // Hoisted mock
 jest.mock('../../src/managers/BotManager', () => {
@@ -20,8 +21,6 @@ jest.mock('../../src/managers/BotManager', () => {
   };
 });
 
-import botsRouter from '../../src/server/routes/bots';
-
 // Mock middlewares
 jest.mock('../../src/server/middleware/audit', () => ({
   auditMiddleware: (req: any, res: any, next: any) => next(),
@@ -38,7 +37,7 @@ describe('Bots API Integration', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    
+
     const { BotManager } = require('../../src/managers/BotManager');
     mockManager = await BotManager.getInstance();
 
@@ -47,21 +46,21 @@ describe('Bots API Integration', () => {
     app.use('/api/bots', botsRouter);
   });
 
-  const sampleBot = { 
-    id: 'bot-1', 
-    name: 'Test Bot', 
-    messageProvider: 'discord', 
+  const sampleBot = {
+    id: 'bot-1',
+    name: 'Test Bot',
+    messageProvider: 'discord',
     llmProvider: 'openai',
-    isActive: true 
+    isActive: true,
   };
 
   describe('GET /api/bots', () => {
     it('should return list of bots with status', async () => {
       mockManager.getAllBots.mockResolvedValue([sampleBot]);
       mockManager.getBotsStatus.mockResolvedValue([{ id: 'bot-1', isRunning: true }]);
-      
+
       const response = await request(app).get('/api/bots');
-      
+
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
       // The router returns result array directly in data
@@ -74,11 +73,11 @@ describe('Bots API Integration', () => {
     it('should create a new bot', async () => {
       mockManager.getAllBots.mockResolvedValue([]);
       mockManager.createBot.mockResolvedValue(sampleBot);
-      
+
       const response = await request(app)
         .post('/api/bots')
         .send({ name: 'Test Bot', messageProvider: 'discord', llmProvider: 'openai' });
-      
+
       expect(response.status).toBe(201);
       expect(response.body.success).toBe(true);
     });
@@ -87,9 +86,9 @@ describe('Bots API Integration', () => {
   describe('POST /api/bots/:id/start', () => {
     it('should start a bot', async () => {
       mockManager.startBot.mockResolvedValue({ success: true });
-      
+
       const response = await request(app).post('/api/bots/bot-1/start');
-      
+
       expect(response.status).toBe(200);
       expect(mockManager.startBot).toHaveBeenCalledWith('bot-1');
     });

--- a/tests/integration/LlmProviderTest.integration.test.ts
+++ b/tests/integration/LlmProviderTest.integration.test.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata';
 import express from 'express';
 import request from 'supertest';
+import providerRouter from '../../src/server/routes/admin/llmProviders';
 
 // Shared mock provider
 const mockLlmProvider = {
@@ -12,8 +13,6 @@ jest.mock('../../src/plugins/PluginLoader', () => ({
   loadPlugin: jest.fn().mockResolvedValue({}),
   instantiateLlmProvider: jest.fn(() => mockLlmProvider),
 }));
-
-import providerRouter from '../../src/server/routes/admin/llmProviders';
 
 // Mock auth middleware
 jest.mock('../../src/auth/middleware', () => ({
@@ -53,7 +52,7 @@ describe('LLM Provider Test Connection API', () => {
       .post('/api/admin/providers/test-connection')
       .send({
         providerType: 'openai',
-        config: { apiKey: 'test-key' }
+        config: { apiKey: 'test-key' },
       });
 
     expect(response.status).toBe(200);
@@ -68,7 +67,7 @@ describe('LLM Provider Test Connection API', () => {
       .post('/api/admin/providers/test-connection')
       .send({
         providerType: 'openai',
-        config: { apiKey: 'invalid-key' }
+        config: { apiKey: 'invalid-key' },
       });
 
     // The route returns 200 but body.success is false
@@ -82,7 +81,7 @@ describe('LLM Provider Test Connection API', () => {
       .post('/api/admin/providers/test-connection')
       .send({
         providerType: 'non-existent',
-        config: { apiKey: 'test' }
+        config: { apiKey: 'test' },
       });
 
     expect(response.status).toBe(400);

--- a/tests/integration/app-routing.integration.test.ts
+++ b/tests/integration/app-routing.integration.test.ts
@@ -1,9 +1,8 @@
-import request from 'supertest';
-import { WebUIServer } from '../../src/server/server';
 import express from 'express';
-
+import request from 'supertest';
 // We may need to mock registerServices to prevent missing dependency errors.
 import { registerServices } from '../../src/di/registration';
+import { WebUIServer } from '../../src/server/server';
 
 describe('App Routing Integration', () => {
   let app: express.Application;
@@ -49,7 +48,7 @@ describe('App Routing Integration', () => {
   it('should serve HTML index for frontend routes', async () => {
     // /admin/* fallback
     const resWebUI = await request(app).get('/admin/some-frontend-path');
-    
+
     // We just check if it doesn't give a raw Express 404 HTML but returns the index.html or 404
     // Usually res.text will be index.html or if missing dist, a string
     expect(resWebUI.status).toBe(200);

--- a/tests/integration/app-security.integration.test.ts
+++ b/tests/integration/app-security.integration.test.ts
@@ -1,6 +1,6 @@
+import express from 'express';
 import request from 'supertest';
 import { WebUIServer } from '../../src/server/server';
-import express from 'express';
 
 describe('App Security Middleware Integration', () => {
   let app: express.Application;
@@ -13,7 +13,7 @@ describe('App Security Middleware Integration', () => {
 
   it('should apply security headers to all responses', async () => {
     const response = await request(app).get('/health');
-    
+
     // Assert real security headers added by `securityHeaders` middleware
     expect(response.headers['x-content-type-options']).toBe('nosniff');
     expect(response.headers['x-frame-options']).toBe('DENY');
@@ -26,17 +26,15 @@ describe('App Security Middleware Integration', () => {
     const response = await request(app)
       .options('/api/health')
       .set('Origin', 'http://localhost:3000');
-    
+
     expect(response.status).toBe(200); // Options success status
     expect(response.headers['access-control-allow-origin']).toBe('http://localhost:3000');
   });
 
   it('should prevent giant payloads on API endpoints', async () => {
     const largePayload = { data: 'A'.repeat(11 * 1024 * 1024) }; // 11 MB
-    const response = await request(app)
-      .post('/api/config')
-      .send(largePayload);
-    
+    const response = await request(app).post('/api/config').send(largePayload);
+
     // Express body-parser should reject it (413 Payload Too Large)
     expect(response.status).toBe(413);
   });

--- a/tests/integration/letta/PluginLoaderLetta.test.ts
+++ b/tests/integration/letta/PluginLoaderLetta.test.ts
@@ -88,10 +88,7 @@ describe('PluginLoader → LettaProvider integration', () => {
 
     expect(result).toBe('hello from letta');
     // SDK call: client.agents.messages.create(agentId, body)
-    expect(mockCreateMessages).toHaveBeenCalledWith(
-      'agent-test',
-      expect.anything()
-    );
+    expect(mockCreateMessages).toHaveBeenCalledWith('agent-test', expect.anything());
   });
 
   it('should prepend system prompt when provided', async () => {
@@ -117,9 +114,7 @@ describe('PluginLoader → LettaProvider integration', () => {
   // ---- Per-Channel Mode ----
 
   it('should list existing conversations and reuse a matching one', async () => {
-    mockListConversations.mockResolvedValue([
-      { id: 'conv-existing-123', summary: 'channel-456' },
-    ]);
+    mockListConversations.mockResolvedValue([{ id: 'conv-existing-123', summary: 'channel-456' }]);
     mockCreateConvMessages.mockResolvedValue({
       messages: [{ role: 'assistant', content: 'reused' }],
     });
@@ -137,10 +132,7 @@ describe('PluginLoader → LettaProvider integration', () => {
     // Should NOT have called create conversation since one exists
     expect(mockCreateConversation).not.toHaveBeenCalled();
     // SDK call signature is: client.conversations.messages.create(conversationId, body)
-    expect(mockCreateConvMessages).toHaveBeenCalledWith(
-      'conv-existing-123',
-      expect.anything()
-    );
+    expect(mockCreateConvMessages).toHaveBeenCalledWith('conv-existing-123', expect.anything());
   });
 
   it('should create a new conversation when none exists', async () => {
@@ -203,10 +195,7 @@ describe('PluginLoader → LettaProvider integration', () => {
 
     expect(result).toBe('fixed response');
     // SDK call: client.conversations.messages.create(conversationId, body)
-    expect(mockCreateConvMessages).toHaveBeenCalledWith(
-      'conv-fixed-999',
-      expect.anything()
-    );
+    expect(mockCreateConvMessages).toHaveBeenCalledWith('conv-fixed-999', expect.anything());
   });
 
   it('should fall back to default when conversationId is missing in fixed mode', async () => {
@@ -321,9 +310,9 @@ describe('PluginLoader → LettaProvider integration', () => {
   it('should throw when no agent ID is provided', async () => {
     const provider = instantiateLlmProvider(llmLettaModule, { agentId: undefined as any });
 
-    await expect(
-      provider.generateChatCompletion('hello', [], {})
-    ).rejects.toThrow('No agent ID provided');
+    await expect(provider.generateChatCompletion('hello', [], {})).rejects.toThrow(
+      'No agent ID provided'
+    );
   });
 
   it('should handle SDK errors gracefully and fall back to default conversation', async () => {

--- a/tests/integration/memory/memoryIntegration.test.ts
+++ b/tests/integration/memory/memoryIntegration.test.ts
@@ -1,9 +1,3 @@
-// Mock isSafeUrl BEFORE any other imports to ensure it is applied correctly
-jest.mock('@hivemind/shared-types', () => ({
-  ...jest.requireActual('@hivemind/shared-types'),
-  isSafeUrl: jest.fn().mockResolvedValue({ safe: true }),
-}));
-
 import { Mem0Provider } from '../../../packages/memory-mem0/src/Mem0Provider';
 import { Mem0ApiError } from '../../../packages/memory-mem0/src/types';
 import { create as createMem4ai } from '../../../packages/memory-mem4ai/src/index';
@@ -12,6 +6,12 @@ import {
   CircuitBreakerError,
   clearCircuitBreakerRegistry,
 } from '../../../src/common/CircuitBreaker';
+
+// Mock isSafeUrl BEFORE any other imports to ensure it is applied correctly
+jest.mock('@hivemind/shared-types', () => ({
+  ...jest.requireActual('@hivemind/shared-types'),
+  isSafeUrl: jest.fn().mockResolvedValue({ safe: true }),
+}));
 
 // ---------------------------------------------------------------------------
 // Fetch mock helpers

--- a/tests/integration/message/message-handler.integration.test.ts
+++ b/tests/integration/message/message-handler.integration.test.ts
@@ -1,20 +1,33 @@
+import { MessageBus } from '../../../src/events/MessageBus';
 import { handleMessage } from '../../../src/message/handlers/messageHandler';
 import { IMessage } from '../../../src/message/interfaces/IMessage';
-import { MessageBus } from '../../../src/events/MessageBus';
 
 // Extend IMessage to create a concrete test message
 class TestMessage extends IMessage {
-  constructor(public text: string, public isUnsolicited = false) {
+  constructor(
+    public text: string,
+    public isUnsolicited = false
+  ) {
     super({}, 'user');
     this.content = text;
     this.channelId = 'test-channel';
     this.platform = 'test-platform';
   }
-  getMessageId() { return 'test-msg-id'; }
-  getText() { return this.text; }
-  getTimestamp() { return new Date(); }
-  getChannelId() { return 'test-channel'; }
-  getAuthorId() { return 'test-user'; }
+  getMessageId() {
+    return 'test-msg-id';
+  }
+  getText() {
+    return this.text;
+  }
+  getTimestamp() {
+    return new Date();
+  }
+  getChannelId() {
+    return 'test-channel';
+  }
+  getAuthorId() {
+    return 'test-user';
+  }
 }
 
 describe('Message Handler Integration', () => {

--- a/tests/integration/observability/pipeline-tracing.integration.test.ts
+++ b/tests/integration/observability/pipeline-tracing.integration.test.ts
@@ -1,14 +1,29 @@
 import { MessageBus } from '../../../src/events/MessageBus';
-import { PipelineTracer } from '../../../src/observability/PipelineTracer';
 import { IMessage } from '../../../src/message/interfaces/IMessage';
+import { PipelineTracer } from '../../../src/observability/PipelineTracer';
 
 class TestMessage extends IMessage {
-  constructor(public text: string) { super({}, 'user'); this.content = text; this.channelId = 'c1'; this.platform = 'test'; }
-  getMessageId() { return 'm1'; }
-  getText() { return this.text; }
-  getTimestamp() { return new Date(); }
-  getChannelId() { return 'c1'; }
-  getAuthorId() { return 'u1'; }
+  constructor(public text: string) {
+    super({}, 'user');
+    this.content = text;
+    this.channelId = 'c1';
+    this.platform = 'test';
+  }
+  getMessageId() {
+    return 'm1';
+  }
+  getText() {
+    return this.text;
+  }
+  getTimestamp() {
+    return new Date();
+  }
+  getChannelId() {
+    return 'c1';
+  }
+  getAuthorId() {
+    return 'u1';
+  }
 }
 
 describe('PipelineTracer Integration', () => {
@@ -23,28 +38,34 @@ describe('PipelineTracer Integration', () => {
 
   it('should create a trace when a message flow starts and finishes', async () => {
     const message = new TestMessage('hello');
-    const context = { message, botName: 'bot1', requestId: 'r1', channelId: 'c1', platform: 'test' };
+    const context = {
+      message,
+      botName: 'bot1',
+      requestId: 'r1',
+      channelId: 'c1',
+      platform: 'test',
+    };
 
     // Simulate pipeline stages
     bus.emit('message:incoming', context);
-    
+
     // Some "work"
-    await new Promise(resolve => setTimeout(resolve, 10));
-    
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
     bus.emit('message:enriched', { ...context, systemPrompt: 'p', userPrompt: 'u' });
-    
-    await new Promise(resolve => setTimeout(resolve, 10));
-    
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
     bus.emit('message:response', { ...context, responseText: 'hi' });
-    
-    await new Promise(resolve => setTimeout(resolve, 10));
-    
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
     bus.emit('message:sent', { ...context, responseText: 'hi' });
 
     const stats = tracer.getStats();
     expect(stats.totalTraces).toBe(1);
     expect(stats.avgDurationMs).toBeGreaterThan(0);
-    
+
     const traces = tracer.getCompletedTraces();
     expect(traces).toHaveLength(1);
     expect(traces[0].spans.length).toBeGreaterThanOrEqual(1);
@@ -52,14 +73,20 @@ describe('PipelineTracer Integration', () => {
 
   it('should record errors in spans', async () => {
     const message = new TestMessage('fail');
-    const context = { message, botName: 'bot1', requestId: 'r2', channelId: 'c1', platform: 'test' };
+    const context = {
+      message,
+      botName: 'bot1',
+      requestId: 'r2',
+      channelId: 'c1',
+      platform: 'test',
+    };
 
     bus.emit('message:incoming', context);
     bus.emit('message:error', { ...context, error: new Error('boom'), stage: 'inference' });
 
     const stats = tracer.getStats();
     expect(stats.errorRate).toBe(1);
-    
+
     const traces = tracer.getCompletedTraces();
     expect(traces[0].rootSpan.status).toBe('error');
   });

--- a/tests/integration/openai/OpenAIIntegration.test.ts
+++ b/tests/integration/openai/OpenAIIntegration.test.ts
@@ -1,3 +1,5 @@
+import { OpenAI } from 'openai';
+
 /**
  * OpenAI Integration Tests
  *
@@ -35,8 +37,6 @@ jest.mock('openai', () => {
     })),
   };
 });
-
-import { OpenAI } from 'openai';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -121,9 +121,7 @@ describe('OpenAI Integration', () => {
     });
 
     it('should propagate errors when model retrieval fails', async () => {
-      mockModelsRetrieve.mockRejectedValue(
-        new Error('Model not found')
-      );
+      mockModelsRetrieve.mockRejectedValue(new Error('Model not found'));
 
       const client = createClient();
       await expect(client.models.retrieve('nonexistent')).rejects.toThrow('Model not found');
@@ -188,7 +186,13 @@ describe('OpenAI Integration', () => {
     it('should handle multi-turn conversation with system message', async () => {
       mockChatCreate.mockResolvedValue({
         ...successResponse,
-        choices: [{ index: 0, message: { role: 'assistant', content: 'The capital is Paris.' }, finish_reason: 'stop' }],
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: 'The capital is Paris.' },
+            finish_reason: 'stop',
+          },
+        ],
       });
 
       const client = createClient();
@@ -223,9 +227,7 @@ describe('OpenAI Integration', () => {
       });
 
       expect(response.choices[0].finish_reason).toBe('length');
-      expect(mockChatCreate).toHaveBeenCalledWith(
-        expect.objectContaining({ max_tokens: 1 })
-      );
+      expect(mockChatCreate).toHaveBeenCalledWith(expect.objectContaining({ max_tokens: 1 }));
     });
 
     it('should pass temperature and top_p parameters', async () => {

--- a/tests/integration/pipeline/error-propagation.integration.test.ts
+++ b/tests/integration/pipeline/error-propagation.integration.test.ts
@@ -1,19 +1,34 @@
 import { MessageBus } from '../../../src/events/MessageBus';
-import { InferenceStage } from '../../../src/pipeline/InferenceStage';
 import { IMessage } from '../../../src/message/interfaces/IMessage';
+import { InferenceStage } from '../../../src/pipeline/InferenceStage';
 
 class TestMessage extends IMessage {
-  constructor(public text: string) { super({}, 'user'); this.content = text; this.channelId = 'c1'; this.platform = 'test'; }
-  getMessageId() { return 'm1'; }
-  getText() { return this.text; }
-  getTimestamp() { return new Date(); }
-  getChannelId() { return 'c1'; }
-  getAuthorId() { return 'u1'; }
+  constructor(public text: string) {
+    super({}, 'user');
+    this.content = text;
+    this.channelId = 'c1';
+    this.platform = 'test';
+  }
+  getMessageId() {
+    return 'm1';
+  }
+  getText() {
+    return this.text;
+  }
+  getTimestamp() {
+    return new Date();
+  }
+  getChannelId() {
+    return 'c1';
+  }
+  getAuthorId() {
+    return 'u1';
+  }
 }
 
 describe('Pipeline Error Propagation Integration', () => {
   let bus: MessageBus;
-  
+
   beforeEach(() => {
     bus = new MessageBus();
   });
@@ -21,19 +36,21 @@ describe('Pipeline Error Propagation Integration', () => {
   it('should emit message:error when inference fails', async () => {
     const mockInvoker = { invoke: jest.fn().mockRejectedValue(new Error('LLM down')) };
     const inference = new InferenceStage(bus, mockInvoker as any);
-    
+
     const errorSpy = jest.fn();
     bus.on('message:error', errorSpy);
 
     const message = new TestMessage('hello');
     const context = { message, botName: 'bot1', requestId: 'r1' };
-    
+
     bus.emit('message:enriched', { ...context, systemPrompt: 'p', userPrompt: 'u' });
 
-    await new Promise(resolve => setTimeout(resolve, 50));
+    await new Promise((resolve) => setTimeout(resolve, 50));
 
-    expect(errorSpy).toHaveBeenCalledWith(expect.objectContaining({
-      error: expect.objectContaining({ message: 'LLM down' })
-    }));
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({ message: 'LLM down' }),
+      })
+    );
   });
 });

--- a/tests/integration/pipeline/fullPipeline.integration.test.ts
+++ b/tests/integration/pipeline/fullPipeline.integration.test.ts
@@ -23,8 +23,8 @@ import {
   type MessageSender,
   type PromptBuilder,
 } from '@src/pipeline';
-import { IMessage } from '@message/interfaces/IMessage';
 import { SwarmCoordinator } from '@src/services/SwarmCoordinator';
+import { IMessage } from '@message/interfaces/IMessage';
 
 // ---------------------------------------------------------------------------
 // StubMessage

--- a/tests/integration/pipeline/stage-transitions.integration.test.ts
+++ b/tests/integration/pipeline/stage-transitions.integration.test.ts
@@ -1,21 +1,36 @@
 import { MessageBus } from '../../../src/events/MessageBus';
+import { IMessage } from '../../../src/message/interfaces/IMessage';
 import { EnrichStage } from '../../../src/pipeline/EnrichStage';
 import { InferenceStage } from '../../../src/pipeline/InferenceStage';
 import { SendStage } from '../../../src/pipeline/SendStage';
-import { IMessage } from '../../../src/message/interfaces/IMessage';
 
 class TestMessage extends IMessage {
-  constructor(public text: string) { super({}, 'user'); this.content = text; this.channelId = 'c1'; this.platform = 'test'; }
-  getMessageId() { return 'm1'; }
-  getText() { return this.text; }
-  getTimestamp() { return new Date(); }
-  getChannelId() { return 'c1'; }
-  getAuthorId() { return 'u1'; }
+  constructor(public text: string) {
+    super({}, 'user');
+    this.content = text;
+    this.channelId = 'c1';
+    this.platform = 'test';
+  }
+  getMessageId() {
+    return 'm1';
+  }
+  getText() {
+    return this.text;
+  }
+  getTimestamp() {
+    return new Date();
+  }
+  getChannelId() {
+    return 'c1';
+  }
+  getAuthorId() {
+    return 'u1';
+  }
 }
 
 describe('Pipeline Stage Transitions Integration', () => {
   let bus: MessageBus;
-  
+
   beforeEach(() => {
     bus = new MessageBus();
   });
@@ -23,39 +38,41 @@ describe('Pipeline Stage Transitions Integration', () => {
   it('should flow from enriched to inference to response', async () => {
     const mockInvoker = { invoke: jest.fn().mockResolvedValue('bot response') };
     const inference = new InferenceStage(bus, mockInvoker as any);
-    
+
     const responseSpy = jest.fn();
     bus.on('message:response', responseSpy);
 
     // Manually trigger the start of this sub-flow
     const message = new TestMessage('hello');
     const context = { message, botName: 'bot1', requestId: 'r1' };
-    
+
     bus.emit('message:enriched', { ...context, systemPrompt: 'p', userPrompt: 'u' });
 
     // Allow async handlers to run
-    await new Promise(resolve => setTimeout(resolve, 50));
+    await new Promise((resolve) => setTimeout(resolve, 50));
 
     expect(mockInvoker.invoke).toHaveBeenCalled();
-    expect(responseSpy).toHaveBeenCalledWith(expect.objectContaining({
-      responseText: 'bot response'
-    }));
+    expect(responseSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        responseText: 'bot response',
+      })
+    );
   });
 
   it('should flow from response to send', async () => {
     const mockSender = { send: jest.fn().mockResolvedValue(undefined) };
     const mockStorer = { store: jest.fn().mockResolvedValue(undefined) };
     const send = new SendStage(bus, mockSender as any, mockStorer as any);
-    
+
     const sentSpy = jest.fn();
     bus.on('message:sent', sentSpy);
 
     const message = new TestMessage('hello');
     const context = { message, botName: 'bot1', requestId: 'r1', responseText: 'hi' };
-    
+
     bus.emit('message:response', context);
 
-    await new Promise(resolve => setTimeout(resolve, 50));
+    await new Promise((resolve) => setTimeout(resolve, 50));
 
     expect(mockSender.send).toHaveBeenCalled();
     expect(mockStorer.store).toHaveBeenCalled();

--- a/tests/integration/plugins/plugin-lifecycle.integration.test.ts
+++ b/tests/integration/plugins/plugin-lifecycle.integration.test.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
-import * as path from 'path';
 import * as os from 'os';
+import * as path from 'path';
 
 describe('Plugin Lifecycle Integration', () => {
   const originalEnv = { ...process.env };
@@ -51,18 +51,18 @@ describe('Plugin Lifecycle Integration', () => {
     // Manually create a dummy plugin directory and registry entry
     const pluginDir = path.join(tempPluginsDir, pluginName);
     fs.mkdirSync(pluginDir, { recursive: true });
-    
+
     const registryFile = path.join(tempPluginsDir, 'registry.json');
     const dummyEntry = {
       name: pluginName,
       repoUrl: 'https://github.com/test/test',
       installedAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
-      version: '1.0.0'
+      version: '1.0.0',
     };
-    
+
     fs.writeFileSync(registryFile, JSON.stringify([dummyEntry]));
-    
+
     // We also need to mock loadPlugin to return something or at least not fail
     jest.doMock('../../../src/plugins/PluginLoader', () => {
       const actual = jest.requireActual('../../../src/plugins/PluginLoader');
@@ -72,7 +72,7 @@ describe('Plugin Lifecycle Integration', () => {
         loadPlugin: jest.fn().mockResolvedValue({ manifest: { name: pluginName, type: 'llm' } }),
       };
     });
-    
+
     const { listInstalledPlugins } = require('../../../src/plugins/PluginManager');
     const plugins = await listInstalledPlugins();
     expect(plugins).toHaveLength(1);

--- a/tests/integration/providers/memory-functional.integration.test.ts
+++ b/tests/integration/providers/memory-functional.integration.test.ts
@@ -8,13 +8,13 @@ describe('Memory Provider Functional Integration', () => {
   const mem0Options = {
     apiKey: 'fake-key',
     baseUrl: 'http://localhost:1234',
-    userId: 'u1'
+    userId: 'u1',
   };
 
   const mem4aiOptions = {
     apiKey: 'fake-key',
     apiUrl: 'http://localhost:5678',
-    userId: 'u1'
+    userId: 'u1',
   };
 
   it('should instantiate Mem0Provider with real schema validation', () => {

--- a/tests/integration/registries/sync-provider-loading.integration.test.ts
+++ b/tests/integration/registries/sync-provider-loading.integration.test.ts
@@ -1,6 +1,6 @@
-import { SyncProviderRegistry } from '@src/registries/SyncProviderRegistry';
-import * as path from 'path';
 import * as fs from 'fs';
+import * as path from 'path';
+import { SyncProviderRegistry } from '@src/registries/SyncProviderRegistry';
 
 describe('SyncProviderRegistry Loading Integration', () => {
   const originalEnv = { ...process.env };
@@ -30,7 +30,7 @@ describe('SyncProviderRegistry Loading Integration', () => {
   it('should gracefully handle empty configurations during init', async () => {
     const registry = SyncProviderRegistry.getInstance();
     const result = await registry.initialize();
-    
+
     expect(result.failed).toHaveLength(0);
     expect(registry.isInitialized()).toBe(true);
     // Should have 0 providers if config dir is empty

--- a/tests/integration/services/memory-manager.integration.test.ts
+++ b/tests/integration/services/memory-manager.integration.test.ts
@@ -1,5 +1,5 @@
-import { MemoryManager } from '../../../src/services/MemoryManager';
 import { registerServices } from '../../../src/di/registration';
+import { MemoryManager } from '../../../src/services/MemoryManager';
 
 describe('MemoryManager Integration', () => {
   beforeAll(() => {
@@ -10,7 +10,11 @@ describe('MemoryManager Integration', () => {
     const manager = MemoryManager.getInstance();
     expect(manager).toBeDefined();
 
-    const results = await manager.retrieveRelevantMemories('non-existent-bot', 'test query', 'user1');
+    const results = await manager.retrieveRelevantMemories(
+      'non-existent-bot',
+      'test query',
+      'user1'
+    );
     expect(results).toHaveLength(0);
   });
 

--- a/tests/integration/services/template-service.integration.test.ts
+++ b/tests/integration/services/template-service.integration.test.ts
@@ -1,8 +1,8 @@
-import { ConfigurationTemplateService } from '../../../src/server/services/ConfigurationTemplateService';
-import { registerServices } from '../../../src/di/registration';
-import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
+import * as path from 'path';
+import { registerServices } from '../../../src/di/registration';
+import { ConfigurationTemplateService } from '../../../src/server/services/ConfigurationTemplateService';
 
 describe('ConfigurationTemplateService Integration', () => {
   let service: ConfigurationTemplateService;

--- a/tests/integrations/flowise/flowiseRestClient.test.ts
+++ b/tests/integrations/flowise/flowiseRestClient.test.ts
@@ -1,3 +1,4 @@
+import { http } from '@hivemind/shared-types';
 import { ConfigurationManager } from '@config/ConfigurationManager';
 import { resetAllCircuitBreakers } from '@common/CircuitBreaker';
 import flowiseConfig from '../../../packages/llm-flowise/src/flowiseConfig';
@@ -14,7 +15,6 @@ jest.mock('@hivemind/shared-types', () => ({
   isSafeUrl: jest.fn().mockResolvedValue({ safe: true }),
 }));
 
-import { http } from '@hivemind/shared-types';
 const mockedHttp = http as jest.Mocked<typeof http>;
 
 jest.mock('../../../packages/llm-flowise/src/flowiseConfig', () => {
@@ -96,7 +96,8 @@ describe('flowiseRestClient.getFlowiseResponse', () => {
     mgr.setSession('flowise', channelId, 'old-chat');
 
     mockedHttp.post.mockResolvedValueOnce({
-      text: 'answer', chatId: 'new-chat'
+      text: 'answer',
+      chatId: 'new-chat',
     } as any);
 
     const text = await getFlowiseResponse(channelId, 'hello');

--- a/tests/integrations/mattermost/MattermostService.test.ts
+++ b/tests/integrations/mattermost/MattermostService.test.ts
@@ -7,8 +7,8 @@
  * The MattermostClient is mocked at the module boundary so the real
  * MattermostService executes its actual logic paths.
  */
-import { MattermostService } from '@src/integrations/mattermost/MattermostService';
 import BotConfigurationManager from '@src/config/BotConfigurationManager';
+import { MattermostService } from '@src/integrations/mattermost/MattermostService';
 
 // ---------------------------------------------------------------------------
 // Mock boundaries — only the client and config manager, NOT the service itself
@@ -101,7 +101,11 @@ describe('MattermostService', () => {
     configureMockBots([
       validBot('valid-bot'),
       { name: 'no-url-bot', messageProvider: 'mattermost', mattermost: { token: 'tok' } },
-      { name: 'no-token-bot', messageProvider: 'mattermost', mattermost: { serverUrl: 'https://x' } },
+      {
+        name: 'no-token-bot',
+        messageProvider: 'mattermost',
+        mattermost: { serverUrl: 'https://x' },
+      },
       { name: 'discord-bot', messageProvider: 'discord' },
     ]);
     const service = MattermostService.getInstance();
@@ -123,7 +127,8 @@ describe('MattermostService', () => {
     failingClient.connect.mockRejectedValueOnce(new Error('ENOTFOUND'));
 
     const workingClient = createMockClient();
-    jest.requireMock('../../../packages/message-mattermost/src/mattermostClient')
+    jest
+      .requireMock('../../../packages/message-mattermost/src/mattermostClient')
       .mockImplementationOnce(() => failingClient)
       .mockImplementationOnce(() => workingClient);
 
@@ -158,7 +163,13 @@ describe('MattermostService', () => {
   it('should send a reply in a thread when replyToMessageId is provided', async () => {
     configureMockBots([validBot('thread-bot')]);
     const service = MattermostService.getInstance();
-    const postId = await service.sendMessageToChannel('general', 'Reply text', undefined, undefined, 'parent-123');
+    const postId = await service.sendMessageToChannel(
+      'general',
+      'Reply text',
+      undefined,
+      undefined,
+      'parent-123'
+    );
     // Should return a post id from the mocked client
     expect(postId).toBe('post-abc');
   });

--- a/tests/integrations/openai/openAiProvider.test.ts
+++ b/tests/integrations/openai/openAiProvider.test.ts
@@ -1,7 +1,7 @@
 import { OpenAI } from 'openai';
 import { OpenAiProvider, openAiProvider } from '@hivemind/llm-openai';
-import openaiConfig from '@config/openaiConfig';
 import { ConfigurationError } from '@src/types/errorClasses';
+import openaiConfig from '@config/openaiConfig';
 import { IMessage } from '@message/interfaces/IMessage';
 import { resetAllCircuitBreakers } from '@common/CircuitBreaker';
 

--- a/tests/integrations/openwebui/sessionManager.test.ts
+++ b/tests/integrations/openwebui/sessionManager.test.ts
@@ -1,4 +1,8 @@
-import { getSessionKey, refreshSessionKey } from '../../../packages/llm-openwebui/src/sessionManager';
+import { http } from '@hivemind/shared-types';
+import {
+  getSessionKey,
+  refreshSessionKey,
+} from '../../../packages/llm-openwebui/src/sessionManager';
 
 // Silence debug logs during tests
 jest.mock('debug', () => () => jest.fn());
@@ -15,7 +19,6 @@ jest.mock('@hivemind/shared-types', () => {
   };
 });
 
-import { http } from '@hivemind/shared-types';
 const mockedHttp = http as jest.Mocked<typeof http>;
 
 const mockedConfig = {
@@ -46,7 +49,7 @@ jest.mock(
  */
 function loadIsolated() {
   jest.resetModules();
-  
+
   // Re-mock dependencies for the isolated module
   jest.doMock('@hivemind/shared-types', () => ({
     http: {
@@ -67,7 +70,7 @@ function loadIsolated() {
 
   const isolatedHttp = require('@hivemind/shared-types').http;
   const mod = require('../../../packages/llm-openwebui/src/sessionManager');
-  
+
   return { mod, isolatedHttp };
 }
 

--- a/tests/integrations/slack/SlackBotManager.test.ts
+++ b/tests/integrations/slack/SlackBotManager.test.ts
@@ -1,7 +1,7 @@
-import { SlackBotManager } from '@src/integrations/slack/SlackBotManager';
-import { WebClient } from '@slack/web-api';
-import { SocketModeClient } from '@slack/socket-mode';
 import { RTMClient } from '@slack/rtm-api';
+import { SocketModeClient } from '@slack/socket-mode';
+import { WebClient } from '@slack/web-api';
+import { SlackBotManager } from '@src/integrations/slack/SlackBotManager';
 
 // Silence debug logs during tests
 jest.mock('debug', () => () => jest.fn());
@@ -87,7 +87,7 @@ describe('SlackBotManager', () => {
     // Initialize
     await manager.initialize();
     console.log('DEBUG: manager.initialize completed');
-    
+
     // Check that auth.test was called on the web client
     expect(mockAuthTest).toHaveBeenCalled();
     expect(MockSocketModeClient).toHaveBeenCalled();
@@ -110,7 +110,7 @@ describe('SlackBotManager', () => {
     }
 
     // Give some time for async message handling
-    await new Promise(resolve => setTimeout(resolve, 50));
+    await new Promise((resolve) => setTimeout(resolve, 50));
 
     expect(mockHandler).toHaveBeenCalled();
     const handlerCall = mockHandler.mock.calls[0];

--- a/tests/integrations/slack/SlackEventListener.test.ts
+++ b/tests/integrations/slack/SlackEventListener.test.ts
@@ -9,8 +9,8 @@
  * SlackService and asserted nothing about real code paths.
  */
 import crypto from 'crypto';
-import { SlackSignatureVerifier } from '@hivemind/message-slack/SlackSignatureVerifier';
 import { extractSlackMetadata } from '@hivemind/message-slack/slackMetadata';
+import { SlackSignatureVerifier } from '@hivemind/message-slack/SlackSignatureVerifier';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -18,7 +18,11 @@ import { extractSlackMetadata } from '@hivemind/message-slack/slackMetadata';
 
 const SIGNING_SECRET = 'test-signing-secret-abc123';
 
-function generateSignature(payload: string, timestamp: string, secret: string = SIGNING_SECRET): string {
+function generateSignature(
+  payload: string,
+  timestamp: string,
+  secret: string = SIGNING_SECRET
+): string {
   const baseString = `v0:${timestamp}:${payload}`;
   const hmac = crypto.createHmac('sha256', secret).update(baseString).digest('hex');
   return `v0=${hmac}`;
@@ -73,9 +77,12 @@ describe('Slack Event Processing', () => {
     });
 
     it('should reject requests missing the timestamp header', () => {
-      const req = createMockReq({ type: 'event_callback' }, {
-        'x-slack-signature': 'v0=abc123',
-      });
+      const req = createMockReq(
+        { type: 'event_callback' },
+        {
+          'x-slack-signature': 'v0=abc123',
+        }
+      );
 
       verifier.verify(req, mockRes, mockNext);
 
@@ -85,9 +92,12 @@ describe('Slack Event Processing', () => {
     });
 
     it('should reject requests missing the signature header', () => {
-      const req = createMockReq({ type: 'event_callback' }, {
-        'x-slack-request-timestamp': '1700000000',
-      });
+      const req = createMockReq(
+        { type: 'event_callback' },
+        {
+          'x-slack-request-timestamp': '1700000000',
+        }
+      );
 
       verifier.verify(req, mockRes, mockNext);
 

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -45,7 +45,7 @@ process.env = new Proxy(process.env, {
           if (process.env.ALLOW_REAL_SECRETS === 'true') {
             return target[prop];
           }
-           console.error(
+          console.error(
             `\x1b[31m[SECURITY WARNING]\x1b[0m Accessing protected env var "${prop}" without explicit mock in test. Set ALLOW_REAL_SECRETS=true to allow this.`
           );
           return undefined; // Block access to real secret
@@ -90,10 +90,14 @@ process.env.NODE_CONFIG_DIR = 'config/test/';
 process.env.ALLOW_LOCAL_NETWORK_ACCESS = 'true';
 
 // Global mock for better-sqlite3
-jest.mock('better-sqlite3', () => {
-  const mockSqlite = jest.requireActual('./mocks/sqlite');
-  return mockSqlite.default || mockSqlite;
-}, { virtual: true });
+jest.mock(
+  'better-sqlite3',
+  () => {
+    const mockSqlite = jest.requireActual('./mocks/sqlite');
+    return mockSqlite.default || mockSqlite;
+  },
+  { virtual: true }
+);
 
 // Set default timeout for all tests
 jest.setTimeout(60000);
@@ -131,12 +135,16 @@ afterEach(async () => {
   } catch (err) {}
 
   try {
-    const { GlobalActivityTracker } = require('../src/message/helpers/processing/GlobalActivityTracker');
+    const {
+      GlobalActivityTracker,
+    } = require('../src/message/helpers/processing/GlobalActivityTracker');
     GlobalActivityTracker.getInstance().reset();
   } catch (err) {}
 
   try {
-    const { IncomingMessageDensity } = require('../src/message/helpers/processing/IncomingMessageDensity');
+    const {
+      IncomingMessageDensity,
+    } = require('../src/message/helpers/processing/IncomingMessageDensity');
     IncomingMessageDensity.getInstance().clear();
   } catch (err) {}
 

--- a/tests/llm/LlmProviderCaching.integration.test.ts
+++ b/tests/llm/LlmProviderCaching.integration.test.ts
@@ -1,8 +1,8 @@
-import { getLlmProvider } from '../../src/llm/getLlmProvider';
 import ProviderConfigManager from '../../src/config/ProviderConfigManager';
-import { SyncProviderRegistry } from '../../src/registries/SyncProviderRegistry';
 import { UserConfigStore } from '../../src/config/UserConfigStore';
+import { getLlmProvider } from '../../src/llm/getLlmProvider';
 import * as PluginLoader from '../../src/plugins/PluginLoader';
+import { SyncProviderRegistry } from '../../src/registries/SyncProviderRegistry';
 
 jest.mock('../../src/config/ProviderConfigManager');
 jest.mock('../../src/registries/SyncProviderRegistry');
@@ -49,7 +49,7 @@ describe('LLM Provider Caching and Resolution', () => {
     mockRegistry.getLlmProviders.mockReturnValue(mockProviders);
 
     const providers = await getLlmProvider();
-    
+
     expect(providers).toBe(mockProviders);
     expect(mockRegistry.getLlmProviders).toHaveBeenCalled();
   });
@@ -59,7 +59,7 @@ describe('LLM Provider Caching and Resolution', () => {
       id: 'p1',
       enabled: true,
       type: 'openai',
-      config: { name: 'openai-1', apiKey: 'key1' }
+      config: { name: 'openai-1', apiKey: 'key1' },
     };
     mockProviderManager.getAllProviders.mockReturnValue([config]);
 
@@ -80,7 +80,7 @@ describe('LLM Provider Caching and Resolution', () => {
       id: 'p-reinstantiate',
       enabled: true,
       type: 'openai',
-      config: { name: 'openai-1', apiKey: 'key1' }
+      config: { name: 'openai-1', apiKey: 'key1' },
     };
     mockProviderManager.getAllProviders.mockReturnValue([config1]);
 
@@ -92,7 +92,7 @@ describe('LLM Provider Caching and Resolution', () => {
       id: 'p-reinstantiate',
       enabled: true,
       type: 'openai',
-      config: { name: 'openai-1', apiKey: 'key2' } // New API key
+      config: { name: 'openai-1', apiKey: 'key2' }, // New API key
     };
     mockProviderManager.getAllProviders.mockClear();
     mockProviderManager.getAllProviders.mockReturnValue([config2]);
@@ -110,8 +110,8 @@ describe('LLM Provider Caching and Resolution', () => {
 
     const providers = await getLlmProvider();
     expect(providers).toHaveLength(2);
-    expect(providers.map(p => p.name)).toContain('p1');
-    expect(providers.map(p => p.name)).toContain('p2');
+    expect(providers.map((p) => p.name)).toContain('p1');
+    expect(providers.map((p) => p.name)).toContain('p2');
   });
 
   it('should wrap providers with token counting', async () => {

--- a/tests/managers/BotManager.test.ts
+++ b/tests/managers/BotManager.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
-import { BotManager } from '../../src/managers/BotManager';
 import { BotConfigurationManager } from '../../src/config/BotConfigurationManager';
+import { BotManager } from '../../src/managers/BotManager';
 import { webUIStorage } from '../../src/storage/webUIStorage';
 
 jest.mock('../../src/config/BotConfigurationManager');
@@ -10,15 +10,15 @@ jest.mock('../../src/config/ProviderConfigManager', () => ({
     getInstance: jest.fn(() => ({
       getMessageProviderIdForBot: jest.fn(),
       getLlmProviderIdForBot: jest.fn(),
-    }))
-  }
+    })),
+  },
 }));
 jest.mock('../../src/config/SecureConfigManager', () => ({
   SecureConfigManager: {
     getInstanceSync: jest.fn(() => ({
       storeConfig: jest.fn().mockResolvedValue(undefined),
-    }))
-  }
+    })),
+  },
 }));
 jest.mock('../../src/storage/webUIStorage');
 
@@ -28,15 +28,15 @@ describe('BotManager', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    
+
     mockBotConfigManager = {
       getAllBots: jest.fn().mockReturnValue([]),
       getBot: jest.fn().mockReturnValue(null),
     };
     (BotConfigurationManager.getInstance as jest.Mock).mockReturnValue(mockBotConfigManager);
-    
+
     (webUIStorage.getAgents as jest.Mock).mockResolvedValue([]);
-    
+
     // Reset singleton
     (BotManager as any).instance = undefined;
     manager = await BotManager.getInstance();
@@ -51,15 +51,15 @@ describe('BotManager', () => {
     it('should combine configured and custom bots', async () => {
       const configuredBot = { name: 'conf-1', messageProvider: 'discord', llmProvider: 'openai' };
       const customBot = { id: 'cust-1', name: 'Custom 1', messageProvider: 'slack' };
-      
+
       mockBotConfigManager.getAllBots.mockReturnValue([configuredBot]);
       (webUIStorage.getAgents as jest.Mock).mockResolvedValue([customBot]);
-      
+
       const allBots = await manager.getAllBots();
-      
+
       expect(allBots).toHaveLength(2);
-      expect(allBots.some(b => b.name === 'conf-1')).toBe(true);
-      expect(allBots.some(b => b.id === 'cust-1')).toBe(true);
+      expect(allBots.some((b) => b.name === 'conf-1')).toBe(true);
+      expect(allBots.some((b) => b.id === 'cust-1')).toBe(true);
     });
   });
 
@@ -67,7 +67,7 @@ describe('BotManager', () => {
     it('should find bot in configured bots', async () => {
       const configuredBot = { name: 'bot-1', messageProvider: 'd', llmProvider: 'o' };
       mockBotConfigManager.getBot.mockReturnValue(configuredBot);
-      
+
       const bot = await manager.getBot('bot-1');
       expect(bot).not.toBeNull();
       expect(bot?.name).toBe('bot-1');
@@ -86,13 +86,13 @@ describe('BotManager', () => {
         messageProvider: 'discord',
         llmProvider: 'openai',
         mcpServers: [],
-        mcpGuard: { enabled: false, type: 'owner' as const, allowedUserIds: [] }
+        mcpGuard: { enabled: false, type: 'owner' as const, allowedUserIds: [] },
       };
-      
+
       (webUIStorage.saveAgent as jest.Mock).mockResolvedValue(undefined);
-      
+
       const bot = await manager.createBot(request);
-      
+
       expect(bot.name).toBe('New Bot');
       expect(webUIStorage.saveAgent).toHaveBeenCalled();
     });

--- a/tests/message/helpers/handler/sendFollowUpRequest.test.ts
+++ b/tests/message/helpers/handler/sendFollowUpRequest.test.ts
@@ -1,3 +1,5 @@
+import { getTaskLlm } from '@src/llm/taskLlmRouter';
+import discordConfig from '@config/discordConfig';
 import { sendFollowUpRequest } from '../../../../src/message/helpers/handler/sendFollowUpRequest';
 
 jest.mock('@src/llm/taskLlmRouter', () => ({
@@ -10,9 +12,6 @@ jest.mock('@config/discordConfig', () => ({
     get: jest.fn(),
   },
 }));
-
-import { getTaskLlm } from '@src/llm/taskLlmRouter';
-import discordConfig from '@config/discordConfig';
 
 describe('sendFollowUpRequest', () => {
   const mockSendMessageToChannel = jest.fn();
@@ -28,8 +27,12 @@ describe('sendFollowUpRequest', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (discordConfig.get as jest.Mock).mockImplementation((key: string) => {
-      if (key === 'DISCORD_CHANNEL_BONUSES') {return {};}
-      if (key === 'DISCORD_UNSOLICITED_CHANCE_MODIFIER') {return 1.0;}
+      if (key === 'DISCORD_CHANNEL_BONUSES') {
+        return {};
+      }
+      if (key === 'DISCORD_UNSOLICITED_CHANCE_MODIFIER') {
+        return 1.0;
+      }
       return undefined;
     });
   });
@@ -65,8 +68,12 @@ describe('sendFollowUpRequest', () => {
   it('sends follow-up when random gate passes using channel bonus', async () => {
     (global as any).mockRandom(0.01);
     (discordConfig.get as jest.Mock).mockImplementation((key: string) => {
-      if (key === 'DISCORD_CHANNEL_BONUSES') {return { 'channel-1': 5 };}
-      if (key === 'DISCORD_UNSOLICITED_CHANCE_MODIFIER') {return 1.0;}
+      if (key === 'DISCORD_CHANNEL_BONUSES') {
+        return { 'channel-1': 5 };
+      }
+      if (key === 'DISCORD_UNSOLICITED_CHANCE_MODIFIER') {
+        return 1.0;
+      }
       return undefined;
     });
 
@@ -87,11 +94,9 @@ describe('sendFollowUpRequest', () => {
       'sender-key-1'
     );
 
-    expect(generateChatCompletion).toHaveBeenCalledWith(
-      'follow up',
-      [mockMessage],
-      { route: 'followup' }
-    );
+    expect(generateChatCompletion).toHaveBeenCalledWith('follow up', [mockMessage], {
+      route: 'followup',
+    });
     expect(mockSendMessageToChannel).toHaveBeenCalledWith(
       'channel-1',
       'follow up AI reply',

--- a/tests/message/helpers/processing/shouldReplyToMessage.test.ts
+++ b/tests/message/helpers/processing/shouldReplyToMessage.test.ts
@@ -5,12 +5,11 @@ import {
 } from '../../../../src/message/helpers/processing/ChannelActivity';
 import { IncomingMessageDensity } from '../../../../src/message/helpers/processing/IncomingMessageDensity';
 import { shouldReplyToMessage } from '../../../../src/message/helpers/processing/shouldReplyToMessage';
-import { SwarmCoordinator } from '../../../../src/services/SwarmCoordinator';
 import {
   looksLikeOpportunity,
   shouldReplyToUnsolicitedMessage,
 } from '../../../../src/message/helpers/unsolicitedMessageHandler';
-import { SwarmCoordinator } from '../../../../src/services/SwarmCoordinator';
+import { SwarmCoordinator, SwarmCoordinator } from '../../../../src/services/SwarmCoordinator';
 
 // Mocks
 jest.mock('../../../../src/message/helpers/processing/IncomingMessageDensity');

--- a/tests/message/management/getMessengerProvider.filtering.test.ts
+++ b/tests/message/management/getMessengerProvider.filtering.test.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 import path from 'path';
+import { getMessengerProvider } from '../../../src/message/management/getMessengerProvider';
 
 // Class-based mocks for tsyringe compatibility
 class MockStartupGreetingService {
@@ -61,8 +62,6 @@ jest.mock('../../../src/server/services/WebSocketService', () => ({
   WebSocketService: MockWebSocketService,
   default: MockWebSocketService,
 }));
-
-import { getMessengerProvider } from '../../../src/message/management/getMessengerProvider';
 
 describe('getMessengerProvider filtering', () => {
   const originalEnv = process.env;

--- a/tests/message/management/getMessengerProvider.integration.test.ts
+++ b/tests/message/management/getMessengerProvider.integration.test.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 import path from 'path';
+import { getMessengerProvider } from '../../../src/message/management/getMessengerProvider';
 
 // Define mocks on global object to make them accessible to hoisted jest.mock()
 (global as any).mockWSFunctions = {
@@ -77,8 +78,6 @@ jest.mock('../../../src/server/services/websocket', () => {
     default: MockWebSocketService,
   };
 });
-
-import { getMessengerProvider } from '../../../src/message/management/getMessengerProvider';
 
 describe('getMessengerProvider Unit Test', () => {
   const originalEnv = process.env;

--- a/tests/message/management/getMessengerProvider.test.ts
+++ b/tests/message/management/getMessengerProvider.test.ts
@@ -295,8 +295,12 @@ describe('getMessengerProvider additional branch coverage', () => {
       throw new Error(`Unknown plugin: ${name}`);
     });
     instantiateMessageService.mockImplementation((mod: any) => {
-      if (mod?.DiscordService) {return mockDiscordService;}
-      if (mod?.SlackService) {return mockSlackService;}
+      if (mod?.DiscordService) {
+        return mockDiscordService;
+      }
+      if (mod?.SlackService) {
+        return mockSlackService;
+      }
       return null;
     });
     mockFsPromises.readFile.mockResolvedValue(
@@ -315,7 +319,10 @@ describe('getMessengerProvider additional branch coverage', () => {
     mockFsPromises.readFile.mockResolvedValue(
       JSON.stringify({
         MESSAGE_PROVIDER: ['discord', 'slack'],
-        providers: [{ type: 'discord', enabled: true }, { type: 'slack', enabled: true }],
+        providers: [
+          { type: 'discord', enabled: true },
+          { type: 'slack', enabled: true },
+        ],
       }) as any
     );
 
@@ -345,7 +352,7 @@ describe('getMessengerProvider additional branch coverage', () => {
 
   it('resets cache and rereads config after reset', async () => {
     delete process.env.MESSAGE_PROVIDER;
-    
+
     mockFsPromises.readFile.mockResolvedValueOnce(
       JSON.stringify({ providers: [{ type: 'discord', enabled: true }] }) as any
     );
@@ -353,9 +360,7 @@ describe('getMessengerProvider additional branch coverage', () => {
     const first = await getMessengerProvider();
     expect(first.length).toBeGreaterThan(0);
 
-    mockFsPromises.readFile.mockResolvedValueOnce(
-      JSON.stringify({ providers: [] }) as any
-    );
+    mockFsPromises.readFile.mockResolvedValueOnce(JSON.stringify({ providers: [] }) as any);
 
     resetMessengerProviderCache();
     const second = await getMessengerProvider();

--- a/tests/message/moderation-comprehensive.test.ts
+++ b/tests/message/moderation-comprehensive.test.ts
@@ -15,12 +15,12 @@
 
 import fs from 'fs';
 import path from 'path';
+import openaiConfig from '../../src/config/openaiConfig';
+import loadServerPolicy from '../../src/message/helpers/moderation/loadServerPolicy';
 import {
   checkVotingEligibility,
   startVotingProcess,
 } from '../../src/message/helpers/moderation/votingUtils';
-import loadServerPolicy from '../../src/message/helpers/moderation/loadServerPolicy';
-import openaiConfig from '../../src/config/openaiConfig';
 
 describe('Moderation Utilities Comprehensive Tests', () => {
   // ============================================================================
@@ -52,16 +52,14 @@ describe('Moderation Utilities Comprehensive Tests', () => {
         startVotingProcess('user-3'),
       ]);
       expect(results.length).toBe(3);
-      expect(results.every(r => r && r.votePassed !== undefined)).toBe(true);
+      expect(results.every((r) => r && r.votePassed !== undefined)).toBe(true);
     });
 
     it('should handle concurrent voting requests', async () => {
-      const promises = Array.from({ length: 10 }, (_, i) =>
-        startVotingProcess(`user-${i}`)
-      );
+      const promises = Array.from({ length: 10 }, (_, i) => startVotingProcess(`user-${i}`));
       const results = await Promise.all(promises);
       expect(results.length).toBe(10);
-      expect(results.every(r => r && typeof r === 'object')).toBe(true);
+      expect(results.every((r) => r && typeof r === 'object')).toBe(true);
     });
 
     it('should not throw on repeated calls for same user', async () => {
@@ -106,7 +104,7 @@ describe('Moderation Utilities Comprehensive Tests', () => {
     it('should handle multiple users eligibility check', () => {
       const users = ['user-1', 'user-2', 'user-3', 'user-4', 'user-5'];
       const results = users.map(checkVotingEligibility);
-      expect(results.every(r => typeof r === 'boolean')).toBe(true);
+      expect(results.every((r) => typeof r === 'boolean')).toBe(true);
     });
 
     it('should handle consecutive eligibility checks', () => {
@@ -117,15 +115,9 @@ describe('Moderation Utilities Comprehensive Tests', () => {
     });
 
     it('should handle special character user IDs', () => {
-      const specialIds = [
-        'user@domain.com',
-        'user-123',
-        'user_name',
-        'user.name',
-        'user123',
-      ];
+      const specialIds = ['user@domain.com', 'user-123', 'user_name', 'user.name', 'user123'];
       const results = specialIds.map(checkVotingEligibility);
-      expect(results.every(r => typeof r === 'boolean')).toBe(true);
+      expect(results.every((r) => typeof r === 'boolean')).toBe(true);
     });
 
     it('should handle edge case empty string', () => {
@@ -139,10 +131,8 @@ describe('Moderation Utilities Comprehensive Tests', () => {
     });
 
     it('should maintain consistent return type', () => {
-      const calls = Array.from({ length: 50 }, (_, i) =>
-        checkVotingEligibility(`user-${i}`)
-      );
-      expect(calls.every(r => typeof r === 'boolean')).toBe(true);
+      const calls = Array.from({ length: 50 }, (_, i) => checkVotingEligibility(`user-${i}`));
+      expect(calls.every((r) => typeof r === 'boolean')).toBe(true);
     });
   });
 
@@ -228,7 +218,7 @@ describe('Moderation Utilities Comprehensive Tests', () => {
       resolveSpy.mockRestore();
     });
 
-    it('should treat malformed JSON as a valid string (it doesn\'t parse)', async () => {
+    it("should treat malformed JSON as a valid string (it doesn't parse)", async () => {
       fs.writeFileSync(policyPath, '{ invalid json }');
 
       const resolveSpy = jest.spyOn(path, 'resolve').mockImplementation((...args: string[]) => {
@@ -368,8 +358,8 @@ describe('Moderation Utilities Comprehensive Tests', () => {
       const votingPromises = userIds.map(startVotingProcess);
       const votingResults = await Promise.all(votingPromises);
 
-      expect(eligibilityResults.every(r => typeof r === 'boolean')).toBe(true);
-      expect(votingResults.every(r => r && typeof r === 'object')).toBe(true);
+      expect(eligibilityResults.every((r) => typeof r === 'boolean')).toBe(true);
+      expect(votingResults.every((r) => r && typeof r === 'object')).toBe(true);
     });
   });
 });

--- a/tests/middleware/Validation.integration.test.ts
+++ b/tests/middleware/Validation.integration.test.ts
@@ -1,8 +1,8 @@
 import express from 'express';
-import request from 'supertest';
 import { body } from 'express-validator';
+import request from 'supertest';
 import { z } from 'zod';
-import { validate, commonValidations } from '../../src/middleware/validationMiddleware';
+import { commonValidations, validate } from '../../src/middleware/validationMiddleware';
 import { validateRequest } from '../../src/validation/validateRequest';
 
 describe('Validation Integration', () => {
@@ -15,20 +15,20 @@ describe('Validation Integration', () => {
 
   describe('express-validator (validate)', () => {
     beforeEach(() => {
-      app.post('/test-ev', [
-        body('email').isEmail(),
-        body('username').isLength({ min: 3 }),
-        validate
-      ], (req: express.Request, res: express.Response) => {
-        res.status(200).json({ success: true });
-      });
+      app.post(
+        '/test-ev',
+        [body('email').isEmail(), body('username').isLength({ min: 3 }), validate],
+        (req: express.Request, res: express.Response) => {
+          res.status(200).json({ success: true });
+        }
+      );
     });
 
     it('should pass with valid data', async () => {
       const response = await request(app)
         .post('/test-ev')
         .send({ email: 'test@example.com', username: 'tester' });
-      
+
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
     });
@@ -37,7 +37,7 @@ describe('Validation Integration', () => {
       const response = await request(app)
         .post('/test-ev')
         .send({ email: 'not-an-email', username: 'hi' });
-      
+
       expect(response.status).toBe(400);
       expect(response.body.errors).toBeDefined();
       expect(response.body.errors.length).toBe(2);
@@ -46,18 +46,18 @@ describe('Validation Integration', () => {
 
   describe('commonValidations', () => {
     it('should validate common patterns correctly using validate middleware', async () => {
-      app.post('/test-common', [
-        commonValidations.email(),
-        commonValidations.username(),
-        validate
-      ], (req: express.Request, res: express.Response) => {
-        res.status(200).json({ success: true });
-      });
+      app.post(
+        '/test-common',
+        [commonValidations.email(), commonValidations.username(), validate],
+        (req: express.Request, res: express.Response) => {
+          res.status(200).json({ success: true });
+        }
+      );
 
       const response = await request(app)
         .post('/test-common')
         .send({ email: 'valid@example.com', username: 'valid_user' });
-      
+
       expect(response.status).toBe(200);
     });
   });
@@ -70,28 +70,28 @@ describe('Validation Integration', () => {
       }),
       query: z.object({
         detailed: z.string().optional(),
-      })
+      }),
     });
 
     beforeEach(() => {
-      app.post('/test-zod', validateRequest(schema), (req: express.Request, res: express.Response) => {
-        res.status(200).json({ success: true });
-      });
+      app.post(
+        '/test-zod',
+        validateRequest(schema),
+        (req: express.Request, res: express.Response) => {
+          res.status(200).json({ success: true });
+        }
+      );
     });
 
     it('should pass with valid Zod schema data', async () => {
-      const response = await request(app)
-        .post('/test-zod')
-        .send({ name: 'Bot', age: 10 });
-      
+      const response = await request(app).post('/test-zod').send({ name: 'Bot', age: 10 });
+
       expect(response.status).toBe(200);
     });
 
     it('should fail with invalid Zod data and return consistent error structure', async () => {
-      const response = await request(app)
-        .post('/test-zod')
-        .send({ name: '', age: -5 });
-      
+      const response = await request(app).post('/test-zod').send({ name: '', age: -5 });
+
       expect(response.status).toBe(400);
       expect(response.body.error).toBe('Validation failed');
       expect(response.body.details).toBeDefined();
@@ -102,7 +102,7 @@ describe('Validation Integration', () => {
       const response = await request(app)
         .post('/test-zod?detailed=true')
         .send({ name: 'Bot', age: 10 });
-      
+
       expect(response.status).toBe(200);
     });
   });

--- a/tests/middleware/correlationId.integration.test.ts
+++ b/tests/middleware/correlationId.integration.test.ts
@@ -8,7 +8,7 @@ describe('Correlation ID Integration', () => {
   beforeEach(() => {
     app = express();
     app.use(correlationIdMiddleware);
-    
+
     app.get('/test', (req, res) => {
       const id = getCorrelationId();
       res.json({ correlationId: id });
@@ -34,20 +34,16 @@ describe('Correlation ID Integration', () => {
 
   it('should use correlation ID from request header if provided', async () => {
     const customId = 'test-id-123';
-    const response = await request(app)
-      .get('/test')
-      .set('X-Correlation-ID', customId);
-    
+    const response = await request(app).get('/test').set('X-Correlation-ID', customId);
+
     expect(response.headers['x-correlation-id']).toBe(customId);
     expect(response.body.correlationId).toBe(customId);
   });
 
   it('should use X-Request-ID as fallback for incoming correlation ID', async () => {
     const requestId = 'req-456';
-    const response = await request(app)
-      .get('/test')
-      .set('X-Request-ID', requestId);
-    
+    const response = await request(app).get('/test').set('X-Request-ID', requestId);
+
     expect(response.headers['x-correlation-id']).toBe(requestId);
   });
 
@@ -60,14 +56,14 @@ describe('Correlation ID Integration', () => {
   it('should maintain separate correlation IDs for concurrent requests', async () => {
     app.get('/delay', async (req, res) => {
       const idBefore = getCorrelationId();
-      await new Promise(resolve => setTimeout(resolve, 50));
+      await new Promise((resolve) => setTimeout(resolve, 50));
       const idAfter = getCorrelationId();
       res.json({ idBefore, idAfter });
     });
 
     const [res1, res2] = await Promise.all([
       request(app).get('/delay').set('X-Correlation-ID', 'id-1'),
-      request(app).get('/delay').set('X-Correlation-ID', 'id-2')
+      request(app).get('/delay').set('X-Correlation-ID', 'id-2'),
     ]);
 
     expect(res1.body.idBefore).toBe('id-1');

--- a/tests/middleware/maintenanceMiddleware.test.ts
+++ b/tests/middleware/maintenanceMiddleware.test.ts
@@ -4,9 +4,9 @@
  * and blocks requests accordingly.
  */
 
-import { Request, Response, NextFunction } from 'express';
-import { maintenanceModeMiddleware } from '../../src/middleware/maintenanceMiddleware';
+import { NextFunction, Request, Response } from 'express';
 import { UserConfigStore } from '../../src/config/UserConfigStore';
+import { maintenanceModeMiddleware } from '../../src/middleware/maintenanceMiddleware';
 
 // Mock UserConfigStore
 const mockUserConfigStore = {
@@ -63,9 +63,9 @@ describe('Maintenance Mode Middleware', () => {
       it('should return 503 for POST /api/messages', async () => {
         req.path = '/api/messages';
         req.method = 'POST';
-        
+
         await maintenanceModeMiddleware(req, res, next);
-        
+
         expect(res.status).toHaveBeenCalledWith(503);
         expect(res.json).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -79,9 +79,9 @@ describe('Maintenance Mode Middleware', () => {
       it('should return 503 for GET /api/bots', async () => {
         req.path = '/api/bots';
         req.method = 'GET';
-        
+
         await maintenanceModeMiddleware(req, res, next);
-        
+
         expect(res.status).toHaveBeenCalledWith(503);
         expect(next).not.toHaveBeenCalled();
       });
@@ -103,9 +103,9 @@ describe('Maintenance Mode Middleware', () => {
       allowedPaths.forEach((path) => {
         it(`should allow ${path}`, async () => {
           req.path = path;
-          
+
           await maintenanceModeMiddleware(req, res, next);
-          
+
           expect(next).toHaveBeenCalled();
           expect(res.status).not.toHaveBeenCalled();
         });
@@ -114,36 +114,36 @@ describe('Maintenance Mode Middleware', () => {
 
     it('should allow admin routes', async () => {
       req.path = '/api/admin/settings';
-      
+
       await maintenanceModeMiddleware(req, res, next);
-      
+
       expect(next).toHaveBeenCalled();
       expect(res.status).not.toHaveBeenCalled();
     });
 
     it('should allow auth routes', async () => {
       req.path = '/api/auth/login';
-      
+
       await maintenanceModeMiddleware(req, res, next);
-      
+
       expect(next).toHaveBeenCalled();
       expect(res.status).not.toHaveBeenCalled();
     });
 
     it('should allow static assets', async () => {
       req.path = '/assets/main.js';
-      
+
       await maintenanceModeMiddleware(req, res, next);
-      
+
       expect(next).toHaveBeenCalled();
       expect(res.status).not.toHaveBeenCalled();
     });
 
     it('should add maintenanceMode=true to request object', async () => {
       req.path = '/admin';
-      
+
       await maintenanceModeMiddleware(req, res, next);
-      
+
       expect(req.maintenanceMode).toBe(true);
     });
   });
@@ -155,7 +155,7 @@ describe('Maintenance Mode Middleware', () => {
       });
 
       await maintenanceModeMiddleware(req, res, next);
-      
+
       // Should let the request proceed even if config can't be read
       expect(next).toHaveBeenCalled();
       expect(res.status).not.toHaveBeenCalled();

--- a/tests/mocks/slackWebApiMock.js
+++ b/tests/mocks/slackWebApiMock.js
@@ -1,18 +1,18 @@
 class WebClient {
   constructor() {
-    this.chat = { 
-      postMessage: jest.fn().mockResolvedValue({ ok: true, ts: '123' }) 
+    this.chat = {
+      postMessage: jest.fn().mockResolvedValue({ ok: true, ts: '123' }),
     };
-    this.conversations = { 
+    this.conversations = {
       history: jest.fn().mockResolvedValue({ ok: true, messages: [] }),
       list: jest.fn().mockResolvedValue({ ok: true, channels: [] }),
       join: jest.fn().mockResolvedValue({ ok: true }),
     };
-    this.users = { 
-      info: jest.fn().mockResolvedValue({ ok: true, user: { id: 'U123', name: 'testuser' } }) 
+    this.users = {
+      info: jest.fn().mockResolvedValue({ ok: true, user: { id: 'U123', name: 'testuser' } }),
     };
     this.auth = {
-      test: jest.fn().mockResolvedValue({ ok: true, user_id: 'U123', bot_id: 'B123' })
+      test: jest.fn().mockResolvedValue({ ok: true, user_id: 'U123', bot_id: 'B123' }),
     };
   }
 }

--- a/tests/mocks/sqlite.ts
+++ b/tests/mocks/sqlite.ts
@@ -68,10 +68,10 @@ export class Database {
         if (args.length === 1 && Array.isArray(args[0])) {
           args = args[0];
         }
-        
+
         // Mocking better-sqlite3 style
         mockRun(sql, ...args);
-        
+
         const id = this.lastId++;
         globalLastId = id;
 
@@ -163,26 +163,26 @@ export class Database {
             createdAt: new Date(),
           });
         } else if (sql.includes('UPDATE approval_requests SET ')) {
-           const requests = this.data.get('approval_requests') || [];
-           const targetId = args[args.length - 1];
-           const req = requests.find(r => r.id === targetId);
-           if (req) {
-             if (sql.includes('status = ?')) req.status = args[0];
-             if (sql.includes('reviewedBy = ?')) req.reviewedBy = args[1];
-             if (sql.includes('reviewedAt = ?')) req.reviewedAt = normalizeDate(args[2]);
-             if (sql.includes('reviewComments = ?')) req.reviewComments = args[3];
-             return { lastInsertRowid: targetId, changes: 1 };
-           }
-           return { lastInsertRowid: targetId, changes: 0 };
+          const requests = this.data.get('approval_requests') || [];
+          const targetId = args[args.length - 1];
+          const req = requests.find((r) => r.id === targetId);
+          if (req) {
+            if (sql.includes('status = ?')) req.status = args[0];
+            if (sql.includes('reviewedBy = ?')) req.reviewedBy = args[1];
+            if (sql.includes('reviewedAt = ?')) req.reviewedAt = normalizeDate(args[2]);
+            if (sql.includes('reviewComments = ?')) req.reviewComments = args[3];
+            return { lastInsertRowid: targetId, changes: 1 };
+          }
+          return { lastInsertRowid: targetId, changes: 0 };
         } else if (sql.includes('DELETE FROM approval_requests WHERE id = ?')) {
-           const requests = this.data.get('approval_requests') || [];
-           const targetId = args[0];
-           const index = requests.findIndex(r => r.id === targetId);
-           if (index !== -1) {
-             requests.splice(index, 1);
-             return { lastInsertRowid: targetId, changes: 1 };
-           }
-           return { lastInsertRowid: targetId, changes: 0 };
+          const requests = this.data.get('approval_requests') || [];
+          const targetId = args[0];
+          const index = requests.findIndex((r) => r.id === targetId);
+          if (index !== -1) {
+            requests.splice(index, 1);
+            return { lastInsertRowid: targetId, changes: 1 };
+          }
+          return { lastInsertRowid: targetId, changes: 0 };
         }
 
         return { lastInsertRowid: id, changes: 1 };
@@ -192,14 +192,14 @@ export class Database {
           args = args[0];
         }
         mockAll(sql, ...args);
-        
+
         if (sql.includes('FROM bot_configuration_versions')) {
           const versions = this.data.get('bot_configuration_versions') || [];
           if (args.length > 0) {
             // Handle bulk query (IN clause)
             if (sql.includes(' IN ')) {
-               const ids = new Set(args);
-               return versions.filter((v: any) => ids.has(v.botConfigurationId));
+              const ids = new Set(args);
+              return versions.filter((v: any) => ids.has(v.botConfigurationId));
             }
             return versions.filter((v: any) => v.botConfigurationId === args[0]);
           }
@@ -208,11 +208,11 @@ export class Database {
         if (sql.includes('FROM bot_configuration_audit')) {
           const audits = this.data.get('bot_configuration_audit') || [];
           if (args.length > 0) {
-             // Handle bulk query (IN clause)
-             if (sql.includes(' IN ')) {
-                const ids = new Set(args);
-                return audits.filter((a: any) => ids.has(a.botConfigurationId));
-             }
+            // Handle bulk query (IN clause)
+            if (sql.includes(' IN ')) {
+              const ids = new Set(args);
+              return audits.filter((a: any) => ids.has(a.botConfigurationId));
+            }
             return audits.filter((a: any) => a.botConfigurationId === args[0]);
           }
           return audits;
@@ -221,11 +221,11 @@ export class Database {
           return this.data.get('bot_configurations') || [];
         }
         if (sql.includes('FROM approval_requests')) {
-           let results = this.data.get('approval_requests') || [];
-           if (sql.includes('resourceType = ?')) {
-             results = results.filter(r => r.resourceType === args[0]);
-           }
-           return results;
+          let results = this.data.get('approval_requests') || [];
+          if (sql.includes('resourceType = ?')) {
+            results = results.filter((r) => r.resourceType === args[0]);
+          }
+          return results;
         }
         return [];
       },
@@ -234,20 +234,20 @@ export class Database {
           args = args[0];
         }
         mockGet(sql, ...args);
-        
+
         if (sql.includes('FROM bot_configurations')) {
           const configs = this.data.get('bot_configurations') || [];
           if (args.length > 0) {
-             return configs.find((c: any) => c.id === args[0]);
+            return configs.find((c: any) => c.id === args[0]);
           }
           return configs[0];
         }
         if (sql.includes('FROM approval_requests')) {
-           const requests = this.data.get('approval_requests') || [];
-           return requests.find(r => r.id === args[0]);
+          const requests = this.data.get('approval_requests') || [];
+          return requests.find((r) => r.id === args[0]);
         }
         return undefined;
-      }
+      },
     };
   }
 

--- a/tests/performance/map-lookup-benchmarks.test.ts
+++ b/tests/performance/map-lookup-benchmarks.test.ts
@@ -2,7 +2,7 @@
  * Performance benchmarks for Map-based lookup optimizations.
  * Verifies the claimed ~60x improvement for collections of ~1000 items.
  */
-import { describe, test, expect } from '@jest/globals';
+import { describe, expect, test } from '@jest/globals';
 
 // Simulate the Map-based vs Array-based lookup patterns
 const COLLECTION_SIZE = 1000;

--- a/tests/providers/providers-comprehensive.test.ts
+++ b/tests/providers/providers-comprehensive.test.ts
@@ -130,7 +130,7 @@ describe('Provider Implementations Comprehensive Tests', () => {
       const schema = provider.getSchema();
       const keys = provider.getSensitiveKeys();
       expect(keys).toContain('OPENAI_API_KEY');
-      
+
       const props = (schema as any).properties || (schema as any)._cvtProperties || schema;
       for (const key of keys) {
         expect(props[key]).toBeDefined();
@@ -202,7 +202,7 @@ describe('Provider Implementations Comprehensive Tests', () => {
 
     it('should have all sensitive keys as strings', () => {
       const keys = provider.getSensitiveKeys();
-      expect(keys.every(k => typeof k === 'string')).toBe(true);
+      expect(keys.every((k) => typeof k === 'string')).toBe(true);
     });
 
     it('should not have duplicate sensitive keys', () => {
@@ -215,7 +215,7 @@ describe('Provider Implementations Comprehensive Tests', () => {
       const keys = provider.getSensitiveKeys();
       const schema = provider.getSchema();
       const props = (schema as any).properties || (schema as any)._cvtProperties || schema;
-      
+
       for (const key of keys) {
         expect(props[key]).toBeDefined();
       }
@@ -260,19 +260,13 @@ describe('Provider Implementations Comprehensive Tests', () => {
 
     it('should handle boundary temperature values', () => {
       const config = provider.getConfig();
-      expect(() =>
-        config.validate({ OPENAI_TEMPERATURE: 0 })
-      ).not.toThrow();
-      expect(() =>
-        config.validate({ OPENAI_TEMPERATURE: 2 })
-      ).not.toThrow();
+      expect(() => config.validate({ OPENAI_TEMPERATURE: 0 })).not.toThrow();
+      expect(() => config.validate({ OPENAI_TEMPERATURE: 2 })).not.toThrow();
     });
 
     it('should handle boundary max tokens values', () => {
       const config = provider.getConfig();
-      expect(() =>
-        config.validate({ OPENAI_MAX_TOKENS: 1 })
-      ).not.toThrow();
+      expect(() => config.validate({ OPENAI_MAX_TOKENS: 1 })).not.toThrow();
     });
   });
 
@@ -366,7 +360,7 @@ describe('Provider Implementations Comprehensive Tests', () => {
 
     it('should have string type for all sensitive keys', () => {
       const keys = provider.getSensitiveKeys();
-      expect(keys.every(k => typeof k === 'string')).toBe(true);
+      expect(keys.every((k) => typeof k === 'string')).toBe(true);
     });
 
     it('should have function type for getConfig', () => {
@@ -430,7 +424,7 @@ describe('Provider Implementations Comprehensive Tests', () => {
     it('should handle concurrent instance creation', () => {
       const providers = Array.from({ length: 10 }, () => new OpenAIProvider());
       expect(providers.length).toBe(10);
-      expect(providers.every(p => p.id === 'openai')).toBe(true);
+      expect(providers.every((p) => p.id === 'openai')).toBe(true);
     });
   });
 
@@ -478,11 +472,11 @@ describe('Provider Implementations Comprehensive Tests', () => {
     it('should maintain consistency under stress', () => {
       const config = provider.getConfig();
       const originalModel = config.get('OPENAI_MODEL');
-      
+
       for (let i = 0; i < 50; i++) {
         config.validate({ OPENAI_MODEL: `gpt-${i}` });
       }
-      
+
       // Should still be able to get values
       expect(config.get('OPENAI_TEMPERATURE')).toBeDefined();
     });

--- a/tests/routes/admin/config.test.ts
+++ b/tests/routes/admin/config.test.ts
@@ -1,5 +1,5 @@
-import request from 'supertest';
 import express from 'express';
+import request from 'supertest';
 import adminConfigRouter from '../../../src/server/routes/admin/config';
 
 // Mock webUIStorage
@@ -9,9 +9,9 @@ jest.mock('../../../src/storage/webUIStorage', () => ({
       { id: 'openai', name: 'OpenAI', type: 'openai', isActive: true },
       { id: 'anthropic', name: 'Anthropic', type: 'anthropic', isActive: false },
     ]),
-    getMessengerProviders: jest.fn().mockReturnValue([
-      { id: 'discord', name: 'Discord', type: 'discord', isActive: true },
-    ]),
+    getMessengerProviders: jest
+      .fn()
+      .mockReturnValue([{ id: 'discord', name: 'Discord', type: 'discord', isActive: true }]),
     getLlmProvider: jest.fn().mockImplementation((id: string) => {
       if (id === 'openai') {
         return { id: 'openai', name: 'OpenAI', type: 'openai', isActive: true };
@@ -84,9 +84,7 @@ describe('Admin Config Routes', () => {
 
   describe('POST /api/admin/llm-providers', () => {
     it('should return 400 for invalid provider data', async () => {
-      const res = await request(app)
-        .post('/api/admin/llm-providers')
-        .send({});
+      const res = await request(app).post('/api/admin/llm-providers').send({});
 
       expect(res.status).toBe(400);
     });

--- a/tests/routes/mcp/providers.test.ts
+++ b/tests/routes/mcp/providers.test.ts
@@ -1,5 +1,5 @@
-import request from 'supertest';
 import express from 'express';
+import request from 'supertest';
 import mcpProvidersRouter from '../../../src/server/routes/mcp/providers';
 
 // Mock MCPProviderManager
@@ -12,9 +12,9 @@ jest.mock('../../../src/config/MCPProviderManager', () => ({
     provider1: { id: 'provider1', status: 'running', lastCheck: new Date() },
     provider2: { id: 'provider2', status: 'stopped', lastCheck: new Date() },
   }),
-  getTemplates: jest.fn().mockReturnValue([
-    { id: 'template1', name: 'Template 1', description: 'Test template' },
-  ]),
+  getTemplates: jest
+    .fn()
+    .mockReturnValue([{ id: 'template1', name: 'Template 1', description: 'Test template' }]),
   getStats: jest.fn().mockReturnValue({
     total: 2,
     enabled: 1,
@@ -28,17 +28,23 @@ jest.mock('../../../src/config/MCPProviderManager', () => ({
   }),
   getProviderStatus: jest.fn().mockReturnValue({
     status: 'running',
-    lastCheck: new Date()
+    lastCheck: new Date(),
   }),
-  validateProviderConfig: jest.fn().mockReturnValue({ isValid: true, errors: [], warnings: [], suggestions: [] }),
-  addProvider: jest.fn().mockImplementation((config: any) => Promise.resolve({
-    id: 'new-provider',
-    ...config,
-  })),
-  updateProvider: jest.fn().mockImplementation((id: string, config: any) => Promise.resolve({
-    id,
-    ...config,
-  })),
+  validateProviderConfig: jest
+    .fn()
+    .mockReturnValue({ isValid: true, errors: [], warnings: [], suggestions: [] }),
+  addProvider: jest.fn().mockImplementation((config: any) =>
+    Promise.resolve({
+      id: 'new-provider',
+      ...config,
+    })
+  ),
+  updateProvider: jest.fn().mockImplementation((id: string, config: any) =>
+    Promise.resolve({
+      id,
+      ...config,
+    })
+  ),
   removeProvider: jest.fn().mockResolvedValue(undefined),
   startProvider: jest.fn().mockResolvedValue(true),
   stopProvider: jest.fn().mockResolvedValue(true),
@@ -117,9 +123,7 @@ describe('MCP Providers Router', () => {
         config: { command: 'test' },
       };
 
-      const res = await request(app)
-        .post('/api/mcp/providers')
-        .send(newProvider);
+      const res = await request(app).post('/api/mcp/providers').send(newProvider);
 
       expect(res.status).toBe(201);
       expect(res.body.success).toBe(true);
@@ -127,9 +131,7 @@ describe('MCP Providers Router', () => {
     });
 
     it('should return 400 for invalid provider data', async () => {
-      const res = await request(app)
-        .post('/api/mcp/providers')
-        .send({});
+      const res = await request(app).post('/api/mcp/providers').send({});
 
       expect(res.status).toBe(400);
     });
@@ -139,9 +141,7 @@ describe('MCP Providers Router', () => {
     it('should update an existing provider', async () => {
       const updates = { name: 'Updated Provider' };
 
-      const res = await request(app)
-        .put('/api/mcp/providers/provider1')
-        .send(updates);
+      const res = await request(app).put('/api/mcp/providers/provider1').send(updates);
 
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);

--- a/tests/security/ConfigurationImportExportService.test.ts
+++ b/tests/security/ConfigurationImportExportService.test.ts
@@ -24,12 +24,14 @@ jest.mock('../../src/server/services/ConfigurationVersionService', () => ({
 
 // Mock BackupManager constructor
 jest.mock('../../src/server/services/configImportExport/backupManager.ts', () => {
-  const actual = jest.requireActual('../../src/server/services/configImportExport/backupManager.ts');
+  const actual = jest.requireActual(
+    '../../src/server/services/configImportExport/backupManager.ts'
+  );
   return {
     ...actual,
     BackupManager: class extends actual.BackupManager {
       listBackups = jest.fn();
-    }
+    },
   };
 });
 

--- a/tests/security/importExport_verification.test.ts
+++ b/tests/security/importExport_verification.test.ts
@@ -8,8 +8,8 @@
  * entire service and tested nothing about actual path traversal attacks.
  */
 import path from 'path';
-import { ConfigurationImportExportService } from '../../src/server/services/ConfigurationImportExportService';
 import { BackupManager } from '../../src/server/services/configImportExport/backupManager';
+import { ConfigurationImportExportService } from '../../src/server/services/ConfigurationImportExportService';
 import { PathSecurityUtils } from '../../src/utils/PathSecurityUtils';
 
 // ---------------------------------------------------------------------------
@@ -27,7 +27,9 @@ describe('Import/Export Security', () => {
     it('should strip Unix path traversal sequences via basename', () => {
       expect(PathSecurityUtils.sanitizeFilename('../../../etc/passwd')).toBe('passwd');
       // On Linux, backslashes are NOT path separators, so they're preserved
-      expect(PathSecurityUtils.sanitizeFilename('..\\..\\windows\\system32')).toBe('..\\..\\windows\\system32');
+      expect(PathSecurityUtils.sanitizeFilename('..\\..\\windows\\system32')).toBe(
+        '..\\..\\windows\\system32'
+      );
     });
 
     it('should handle filenames with null bytes (passed through by basename)', () => {

--- a/tests/server/routes-comprehensive.test.ts
+++ b/tests/server/routes-comprehensive.test.ts
@@ -15,9 +15,9 @@
 
 import express from 'express';
 import request from 'supertest';
-import sitemapRouter from '../../src/server/routes/sitemap';
-import webhookConfig from '../../src/config/webhookConfig';
 import telegramConfig from '../../src/config/telegramConfig';
+import webhookConfig from '../../src/config/webhookConfig';
+import sitemapRouter from '../../src/server/routes/sitemap';
 
 describe('API Routes Comprehensive Tests', () => {
   // ============================================================================

--- a/tests/server/routes/health.maintenance.test.ts
+++ b/tests/server/routes/health.maintenance.test.ts
@@ -5,6 +5,7 @@ import 'reflect-metadata';
 import express from 'express';
 import request from 'supertest';
 import { UserConfigStore } from '../../../src/config/UserConfigStore';
+import basicRouter from '../../../src/server/routes/health/basic';
 
 // Mock UserConfigStore
 const mockUserConfigStore = {
@@ -26,8 +27,6 @@ jest.mock('../../../src/database/DatabaseManager', () => ({
   },
 }));
 
-import basicRouter from '../../../src/server/routes/health/basic';
-
 describe('Health Routes - Maintenance Mode', () => {
   let app: express.Express;
 
@@ -42,7 +41,7 @@ describe('Health Routes - Maintenance Mode', () => {
       mockUserConfigStore.isMaintenanceMode.mockReturnValue(false);
 
       const res = await request(app).get('/api/health/maintenance');
-      
+
       expect(res.status).toBe(200);
       expect(res.body.maintenanceMode).toBe(false);
       expect(res.body.message).toBe('System is operating normally');
@@ -52,7 +51,7 @@ describe('Health Routes - Maintenance Mode', () => {
       mockUserConfigStore.isMaintenanceMode.mockReturnValue(true);
 
       const res = await request(app).get('/api/health/maintenance');
-      
+
       expect(res.status).toBe(200);
       expect(res.body.maintenanceMode).toBe(true);
       expect(res.body.message).toBe('System is currently in maintenance mode');
@@ -64,7 +63,7 @@ describe('Health Routes - Maintenance Mode', () => {
       mockUserConfigStore.isMaintenanceMode.mockReturnValue(true);
 
       const res = await request(app).get('/api/health');
-      
+
       expect(res.status).toBe(200);
       expect(res.body.maintenanceMode).toBe(true);
       expect(res.body.status).toBe('degraded');

--- a/tests/services/ConfigurationImportExportService.test.ts
+++ b/tests/services/ConfigurationImportExportService.test.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs';
-import { ConfigurationImportExportService } from '../../src/server/services/ConfigurationImportExportService';
 import { DatabaseManager } from '../../src/database/DatabaseManager';
+import { ConfigurationImportExportService } from '../../src/server/services/ConfigurationImportExportService';
 
 jest.mock('fs', () => ({
   existsSync: jest.fn().mockReturnValue(true),
@@ -8,7 +8,7 @@ jest.mock('fs', () => ({
     readFile: jest.fn(),
     writeFile: jest.fn(),
     mkdir: jest.fn().mockResolvedValue(undefined),
-  }
+  },
 }));
 
 jest.mock('../../src/database/DatabaseManager', () => {
@@ -56,7 +56,7 @@ describe('ConfigurationImportExportService', () => {
     id: 1,
     name: 'Test Config',
     llmProvider: 'openai',
-    messageProvider: 'discord'
+    messageProvider: 'discord',
   };
 
   describe('exportConfigurations', () => {
@@ -68,7 +68,7 @@ describe('ConfigurationImportExportService', () => {
 
       expect(result.success).toBe(true);
       expect(fs.writeFile).toHaveBeenCalled();
-      
+
       const savedContent = JSON.parse((fs.writeFile as jest.Mock).mock.calls[0][1]);
       expect(savedContent.configurations).toHaveLength(1);
       expect(savedContent.configurations[0].id).toBe(1);
@@ -76,9 +76,9 @@ describe('ConfigurationImportExportService', () => {
 
     it('should return error if no configurations found', async () => {
       mockDb.getBotConfigurationsBulk.mockResolvedValue([]);
-      
+
       const result = await service.exportConfigurations([999], { format: 'json' });
-      
+
       expect(result.success).toBe(false);
       expect(result.error).toContain('No configurations found');
     });
@@ -87,13 +87,15 @@ describe('ConfigurationImportExportService', () => {
   describe('importConfigurations', () => {
     it('should import new configurations', async () => {
       const importData = {
-        configurations: [sampleConfig]
+        configurations: [sampleConfig],
       };
       (fs.readFile as jest.Mock).mockResolvedValue(Buffer.from(JSON.stringify(importData)));
       mockDb.getBotConfigurationsBulk.mockResolvedValue([]); // No existing config
       mockDb.createBotConfiguration.mockResolvedValue(undefined);
 
-      const result = await service.importConfigurations('test-import.json', { format: 'json' } as any);
+      const result = await service.importConfigurations('test-import.json', {
+        format: 'json',
+      } as any);
 
       expect(result.success).toBe(true);
       expect(result.importedCount).toBe(1);
@@ -102,15 +104,15 @@ describe('ConfigurationImportExportService', () => {
 
     it('should update existing configurations if overwrite is true', async () => {
       const importData = {
-        configurations: [sampleConfig]
+        configurations: [sampleConfig],
       };
       (fs.readFile as jest.Mock).mockResolvedValue(Buffer.from(JSON.stringify(importData)));
       mockDb.getBotConfigurationsBulk.mockResolvedValue([sampleConfig]); // Existing config
       mockDb.updateBotConfiguration.mockResolvedValue(undefined);
 
-      const result = await service.importConfigurations('test-import.json', { 
-        format: 'json', 
-        overwrite: true 
+      const result = await service.importConfigurations('test-import.json', {
+        format: 'json',
+        overwrite: true,
       } as any);
 
       expect(result.success).toBe(true);
@@ -120,14 +122,14 @@ describe('ConfigurationImportExportService', () => {
 
     it('should skip existing configurations if overwrite is false', async () => {
       const importData = {
-        configurations: [sampleConfig]
+        configurations: [sampleConfig],
       };
       (fs.readFile as jest.Mock).mockResolvedValue(Buffer.from(JSON.stringify(importData)));
       mockDb.getBotConfigurationsBulk.mockResolvedValue([sampleConfig]); // Existing config
 
-      const result = await service.importConfigurations('test-import.json', { 
-        format: 'json', 
-        overwrite: false 
+      const result = await service.importConfigurations('test-import.json', {
+        format: 'json',
+        overwrite: false,
       } as any);
 
       expect(result.success).toBe(true);

--- a/tests/services/ToolExecutionHistoryService.test.ts
+++ b/tests/services/ToolExecutionHistoryService.test.ts
@@ -1,6 +1,9 @@
 import fs from 'fs';
 import path from 'path';
-import { ToolExecutionHistoryService, type ToolExecutionRecord } from '../../src/server/services/ToolExecutionHistoryService';
+import {
+  ToolExecutionHistoryService,
+  type ToolExecutionRecord,
+} from '../../src/server/services/ToolExecutionHistoryService';
 
 jest.mock('fs', () => {
   const actualFs = jest.requireActual('fs');
@@ -13,7 +16,7 @@ jest.mock('fs', () => {
       writeFile: jest.fn().mockResolvedValue(undefined),
       access: jest.fn().mockResolvedValue(undefined),
       readFile: jest.fn().mockResolvedValue(''),
-    }
+    },
   };
 });
 
@@ -35,7 +38,7 @@ describe('ToolExecutionHistoryService (Robust)', () => {
     result: { forecast: 'sunny' },
     status: 'success',
     executedAt: new Date().toISOString(),
-    duration: 150
+    duration: 150,
   };
 
   it('should be a singleton', () => {
@@ -45,7 +48,9 @@ describe('ToolExecutionHistoryService (Robust)', () => {
 
   it('should create the data directory if it does not exist', async () => {
     await service.logExecution(record);
-    expect(fs.promises.mkdir).toHaveBeenCalledWith(expect.stringContaining('data'), { recursive: true });
+    expect(fs.promises.mkdir).toHaveBeenCalledWith(expect.stringContaining('data'), {
+      recursive: true,
+    });
   });
 
   it('should append tool executions to the log file', async () => {
@@ -59,17 +64,19 @@ describe('ToolExecutionHistoryService (Robust)', () => {
   });
 
   it('should handle file append errors', async () => {
-    (fs.appendFile as unknown as jest.Mock).mockImplementationOnce((_f, _d, _o, cb) => cb(new Error('Disk Full')));
-    
+    (fs.appendFile as unknown as jest.Mock).mockImplementationOnce((_f, _d, _o, cb) =>
+      cb(new Error('Disk Full'))
+    );
+
     await expect(service.logExecution(record)).rejects.toThrow('Disk Full');
   });
 
   it('should apply retention policy when logging', async () => {
     // Spy on applyRetentionPolicy (private method)
     const spy = jest.spyOn(service as any, 'applyRetentionPolicy');
-    
+
     await service.logExecution(record);
-    
+
     // retention policy is async and not awaited in logExecution
     // but in tests we want to ensure it's called
     expect(spy).toHaveBeenCalled();

--- a/tests/services/UsageTrackerService.test.ts
+++ b/tests/services/UsageTrackerService.test.ts
@@ -1,6 +1,9 @@
 import fs from 'fs';
 import path from 'path';
-import { UsageTrackerService, type UsageUpdateData } from '../../src/server/services/UsageTrackerService';
+import {
+  UsageTrackerService,
+  type UsageUpdateData,
+} from '../../src/server/services/UsageTrackerService';
 
 jest.mock('fs', () => {
   const actualFs = jest.requireActual('fs');
@@ -12,7 +15,7 @@ jest.mock('fs', () => {
       writeFile: jest.fn().mockResolvedValue(undefined),
       access: jest.fn().mockResolvedValue(undefined),
       readFile: jest.fn().mockResolvedValue('{}'),
-    }
+    },
   };
 });
 
@@ -39,7 +42,7 @@ describe('UsageTrackerService', () => {
     toolName: 'get_forecast',
     success: true,
     duration: 100,
-    timestamp: new Date().toISOString()
+    timestamp: new Date().toISOString(),
   };
 
   it('should be a singleton', () => {
@@ -49,7 +52,7 @@ describe('UsageTrackerService', () => {
 
   it('should record tool usage and aggregate metrics', async () => {
     await service.recordUsage(sampleUpdate);
-    
+
     const metrics = service.getToolMetrics(sampleUpdate.toolId);
     expect(metrics).not.toBeNull();
     expect(metrics?.usageCount).toBe(1);
@@ -59,7 +62,7 @@ describe('UsageTrackerService', () => {
 
   it('should record provider usage metrics', async () => {
     await service.recordUsage(sampleUpdate);
-    
+
     const metrics = service.getProviderMetrics(sampleUpdate.serverName);
     expect(metrics).not.toBeNull();
     expect(metrics?.usageCount).toBe(1);
@@ -69,7 +72,7 @@ describe('UsageTrackerService', () => {
   it('should handle multiple tool executions and update averages', async () => {
     await service.recordUsage(sampleUpdate);
     await service.recordUsage({ ...sampleUpdate, duration: 200 });
-    
+
     const metrics = service.getToolMetrics(sampleUpdate.toolId);
     expect(metrics?.usageCount).toBe(2);
     expect(metrics?.totalDuration).toBe(300);
@@ -78,13 +81,13 @@ describe('UsageTrackerService', () => {
 
   it('should debounce saving to disk', async () => {
     await service.recordUsage(sampleUpdate);
-    
+
     // Should not have saved yet
     expect(fs.promises.writeFile).not.toHaveBeenCalled();
-    
+
     // Fast-forward time
     jest.advanceTimersByTime(1500);
-    
+
     expect(fs.promises.writeFile).toHaveBeenCalledWith(
       expect.stringContaining('tool-usage-metrics.json'),
       expect.any(String),
@@ -95,22 +98,22 @@ describe('UsageTrackerService', () => {
   it('should load existing data on initialization', async () => {
     const existingData = {
       tools: {
-        'old-tool': { toolId: 'old-tool', usageCount: 5, successCount: 5 }
+        'old-tool': { toolId: 'old-tool', usageCount: 5, successCount: 5 },
       },
       providers: {},
-      lastUpdated: new Date().toISOString()
+      lastUpdated: new Date().toISOString(),
     };
     (fs.promises.readFile as jest.Mock).mockResolvedValue(JSON.stringify(existingData));
-    
+
     // Re-initialize to trigger load
     (UsageTrackerService as any).instance = undefined;
     const newService = UsageTrackerService.getInstance();
-    
+
     // Use real timers for this part to allow async init to complete
     jest.useRealTimers();
-    await new Promise(resolve => setTimeout(resolve, 50));
+    await new Promise((resolve) => setTimeout(resolve, 50));
     jest.useFakeTimers();
-    
+
     expect(newService.getToolMetrics('old-tool')).toMatchObject({ usageCount: 5 });
   });
 
@@ -119,7 +122,7 @@ describe('UsageTrackerService', () => {
     await service.recordUsage({ ...sampleUpdate, toolId: 't1' }); // 1 call
     await service.recordUsage({ ...sampleUpdate, toolId: 't2' }); // 1 call
     await service.recordUsage({ ...sampleUpdate, toolId: 't2' }); // 2 calls total for t2
-    
+
     const top = service.getTopTools(5);
     expect(top[0].toolId).toBe('t2');
   });

--- a/tests/unit/architecture/single-minimatch-version.test.ts
+++ b/tests/unit/architecture/single-minimatch-version.test.ts
@@ -15,7 +15,7 @@ describe('Architecture: single minimatch major version', () => {
     const majors = [...new Set(versions)];
     // Allow known versions that are currently required by the project dependencies
     const allowedMajors = ['3', '5', '9', '10'];
-    majors.forEach(major => {
+    majors.forEach((major) => {
       expect(allowedMajors).toContain(major);
     });
   });

--- a/tests/unit/di/registration.test.ts
+++ b/tests/unit/di/registration.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 import { container } from 'tsyringe';
-import { registerServices, areServicesRegistered, TOKENS } from '../../../src/di/registration';
+import { areServicesRegistered, registerServices, TOKENS } from '../../../src/di/registration';
 
 // Use a shared mock object defined in a way that avoids hoisting issues
 (global as any).mockLogger = {
@@ -43,7 +43,7 @@ jest.mock('../../../src/config/ProviderConfigManager', () => ({
   },
   default: {
     getInstance: jest.fn().mockReturnValue({ syncBotProviders: jest.fn() }),
-  }
+  },
 }));
 
 jest.mock('../../../src/common/logger', () => {

--- a/tests/unit/hooks/useMCPToolsHooks.test.ts
+++ b/tests/unit/hooks/useMCPToolsHooks.test.ts
@@ -14,9 +14,9 @@
  * @jest-environment jsdom
  */
 import { act, renderHook } from '@testing-library/react';
-import { apiService } from '../../../src/client/src/services/api';
-import { useToolHistory } from '../../../src/client/src/pages/MCPToolsPage/hooks/useToolHistory';
 import { useToolExecution } from '../../../src/client/src/pages/MCPToolsPage/hooks/useToolExecution';
+import { useToolHistory } from '../../../src/client/src/pages/MCPToolsPage/hooks/useToolHistory';
+import { apiService } from '../../../src/client/src/services/api';
 
 // ---------------------------------------------------------------------------
 // Mocks

--- a/tests/unit/middleware/auth.test.ts
+++ b/tests/unit/middleware/auth.test.ts
@@ -1,7 +1,12 @@
-import request from 'supertest';
 import express from 'express';
-import { authenticateToken, requirePermission, requireRole, optionalAuth } from '../../../src/server/middleware/auth';
+import request from 'supertest';
 import { AuthManager } from '../../../src/auth/AuthManager';
+import {
+  authenticateToken,
+  optionalAuth,
+  requirePermission,
+  requireRole,
+} from '../../../src/server/middleware/auth';
 
 // Mock AuthManager
 jest.mock('../../../src/auth/AuthManager', () => ({
@@ -46,9 +51,7 @@ describe('Auth Middleware', () => {
       app.use(authenticateToken);
       app.get('/test', (req, res) => res.json({ ok: true }));
 
-      const res = await request(app)
-        .get('/test')
-        .set('Authorization', 'Bearer invalid-token');
+      const res = await request(app).get('/test').set('Authorization', 'Bearer invalid-token');
 
       expect(res.status).toBe(403);
       expect(res.body.error).toBe('Invalid or expired token');
@@ -60,9 +63,7 @@ describe('Auth Middleware', () => {
       app.use(authenticateToken);
       app.get('/test', (req, res) => res.json({ ok: true }));
 
-      const res = await request(app)
-        .get('/test')
-        .set('Authorization', 'Bearer null-token');
+      const res = await request(app).get('/test').set('Authorization', 'Bearer null-token');
 
       expect(res.status).toBe(403);
       expect(res.body.error).toBe('Invalid or expired token');
@@ -75,9 +76,7 @@ describe('Auth Middleware', () => {
       app.use(authenticateToken);
       app.get('/test', (req, res) => res.json({ user: req.user }));
 
-      const res = await request(app)
-        .get('/test')
-        .set('Authorization', 'Bearer valid-token');
+      const res = await request(app).get('/test').set('Authorization', 'Bearer valid-token');
 
       expect(res.status).toBe(200);
       expect(res.body.user).toEqual(mockPayload);
@@ -202,9 +201,7 @@ describe('Auth Middleware', () => {
       app.use(optionalAuth);
       app.get('/test', (req, res) => res.json({ user: req.user }));
 
-      const res = await request(app)
-        .get('/test')
-        .set('Authorization', 'Bearer valid-token');
+      const res = await request(app).get('/test').set('Authorization', 'Bearer valid-token');
 
       expect(res.status).toBe(200);
       expect(res.body.user).toEqual(mockPayload);
@@ -218,9 +215,7 @@ describe('Auth Middleware', () => {
       app.use(optionalAuth);
       app.get('/test', (req, res) => res.json({ user: req.user || null }));
 
-      const res = await request(app)
-        .get('/test')
-        .set('Authorization', 'Bearer invalid-token');
+      const res = await request(app).get('/test').set('Authorization', 'Bearer invalid-token');
 
       expect(res.status).toBe(200);
       expect(res.body.user).toBeNull();

--- a/tests/unit/middleware/errorHandler.test.ts
+++ b/tests/unit/middleware/errorHandler.test.ts
@@ -1,6 +1,14 @@
-import { globalErrorHandler, asyncErrorHandler, rateLimitErrorHandler } from '../../../src/middleware/errorHandler';
-import { BaseHivemindError, NetworkError, ConfigurationError } from '../../../src/types/errorClasses';
+import {
+  asyncErrorHandler,
+  globalErrorHandler,
+  rateLimitErrorHandler,
+} from '../../../src/middleware/errorHandler';
 import { MetricsCollector } from '../../../src/monitoring/MetricsCollector';
+import {
+  BaseHivemindError,
+  ConfigurationError,
+  NetworkError,
+} from '../../../src/types/errorClasses';
 
 // Mock MetricsCollector
 jest.mock('../../../src/monitoring/MetricsCollector', () => ({
@@ -154,7 +162,7 @@ describe('Error Handler Middleware', () => {
       handler(mockReq, mockRes, mockNext);
 
       // Wait for promise to resolve
-      await new Promise(resolve => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
 
       expect(mockNext).toHaveBeenCalledWith(expect.any(Error));
     });
@@ -165,7 +173,7 @@ describe('Error Handler Middleware', () => {
 
       handler(mockReq, mockRes, mockNext);
 
-      await new Promise(resolve => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
 
       expect(mockNext).not.toHaveBeenCalled();
     });

--- a/tests/unit/providers/circuitBreakerConfig.test.ts
+++ b/tests/unit/providers/circuitBreakerConfig.test.ts
@@ -7,17 +7,14 @@
  * that many failures (not the default of 5).
  */
 
+import * as sharedTypes from '@hivemind/shared-types';
 import { Mem0Provider } from '../../../packages/memory-mem0/src/Mem0Provider';
 import {
-  resetAllCircuitBreakers as resetAllMem4aiCircuitBreakers,
   CircuitBreakerError as Mem4aiCircuitBreakerError,
+  resetAllCircuitBreakers as resetAllMem4aiCircuitBreakers,
 } from '../../../packages/memory-mem4ai/src/CircuitBreaker';
 import { Mem4aiProvider } from '../../../packages/memory-mem4ai/src/Mem4aiProvider';
-import {
-  CircuitBreakerError,
-  resetAllCircuitBreakers,
-} from '../../../src/common/CircuitBreaker';
-import * as sharedTypes from '@hivemind/shared-types';
+import { CircuitBreakerError, resetAllCircuitBreakers } from '../../../src/common/CircuitBreaker';
 
 // Mock isSafeUrl so injected test URLs don't trigger SSRF guard failures
 jest.mock('@hivemind/shared-types', () => {
@@ -50,7 +47,7 @@ beforeEach(() => {
   resetAllMem4aiCircuitBreakers();
   fetchMock = jest.fn();
   global.fetch = fetchMock;
-  
+
   // Ensure isSafeUrl mock is set up correctly for every test
   (sharedTypes.isSafeUrl as jest.Mock).mockResolvedValue({ safe: true });
 });
@@ -87,7 +84,7 @@ describe('Mem0Provider injectable circuit breaker config', () => {
     // Second failure - this should trip the circuit breaker
     await expect(provider.search('q')).rejects.toThrow();
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    
+
     // Third call should be rejected by the circuit breaker itself (fetch NOT called)
     await expect(provider.search('q')).rejects.toThrow(CircuitBreakerError);
     expect(fetchMock).toHaveBeenCalledTimes(2);

--- a/tests/unit/routes/demo.test.ts
+++ b/tests/unit/routes/demo.test.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata';
 import express from 'express';
 import request from 'supertest';
+import router from '../../../src/server/routes/demo';
 
 const mockDemoService = {
   getDemoStatus: jest.fn(),
@@ -46,8 +47,6 @@ jest.mock('../../../src/server/services/WebSocketService', () => ({
   },
 }));
 
-import router from '../../../src/server/routes/demo';
-
 describe('Demo Routes', () => {
   let app: express.Application;
 
@@ -72,7 +71,7 @@ describe('Demo Routes', () => {
   describe('POST /demo/toggle', () => {
     it('should toggle demo mode', async () => {
       mockDemoService.isInDemoMode.mockReturnValueOnce(false).mockReturnValue(true);
-      
+
       const res = await request(app).post('/demo/toggle');
       expect(res.status).toBe(200);
       expect(res.body.data.enabled).toBe(true);
@@ -107,7 +106,7 @@ describe('Demo Routes', () => {
       const res = await request(app)
         .post('/demo/chat')
         .send({ message: 'hello', botName: 'TestBot' });
-      
+
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
       expect(res.body.data.isDemo).toBe(true);

--- a/tests/unit/routes/specs.test.ts
+++ b/tests/unit/routes/specs.test.ts
@@ -100,15 +100,17 @@ describe('Specs Routes', () => {
     });
 
     it('should return 400 for invalid spec data', async () => {
-      const res = await request(app).post('/specs').send({
-        content: 'test',
-        id: 'invalid id!',
-        topic: 'Testing',
-        tags: ['unit'],
-        author: 'tester',
-        timestamp: '2025-01-01T00:00:00.000Z',
-        version: '1.0.0',
-      });
+      const res = await request(app)
+        .post('/specs')
+        .send({
+          content: 'test',
+          id: 'invalid id!',
+          topic: 'Testing',
+          tags: ['unit'],
+          author: 'tester',
+          timestamp: '2025-01-01T00:00:00.000Z',
+          version: '1.0.0',
+        });
       expect(res.status).toBe(400);
       expect(res.body.success).toBe(false);
     });

--- a/tests/unit/security/ipExtraction.test.ts
+++ b/tests/unit/security/ipExtraction.test.ts
@@ -1,9 +1,5 @@
 import { Request } from 'express';
-import {
-  getClientKey,
-  isIPInCIDR,
-  validateIP,
-} from '@src/middleware/rateLimiter';
+import { getClientKey, isIPInCIDR, validateIP } from '@src/middleware/rateLimiter';
 
 describe('Rate Limiter IP Extraction Security', () => {
   let mockReq: Partial<Request>;

--- a/tests/unit/server/services/BotConfigService.test.ts
+++ b/tests/unit/server/services/BotConfigService.test.ts
@@ -1,5 +1,5 @@
-import { BotConfigService } from '../../../../src/server/services/BotConfigService';
 import { DatabaseManager } from '../../../../src/database/DatabaseManager';
+import { BotConfigService } from '../../../../src/server/services/BotConfigService';
 import { ConfigurationError } from '../../../../src/types/errorClasses';
 
 // Use a shared mock object for database
@@ -24,14 +24,18 @@ jest.mock('../../../../src/database/DatabaseManager', () => {
         isConfigured: () => true,
         configured: true, // Internal property used by some methods
         ensureConnected: () => {}, // Method used by repositories
-        getBotConfigurationByName: (name: string) => (global as any).mockDb.getBotConfigurationByName(name),
+        getBotConfigurationByName: (name: string) =>
+          (global as any).mockDb.getBotConfigurationByName(name),
         createBotConfiguration: (data: any) => (global as any).mockDb.createBotConfiguration(data),
         getBotConfiguration: (id: any) => (global as any).mockDb.getBotConfiguration(id),
-        getBotConfigurationVersions: (id: any) => (global as any).mockDb.getBotConfigurationVersions(id),
+        getBotConfigurationVersions: (id: any) =>
+          (global as any).mockDb.getBotConfigurationVersions(id),
         getBotConfigurationAudit: (id: any) => (global as any).mockDb.getBotConfigurationAudit(id),
-        createBotConfigurationAudit: (data: any) => (global as any).mockDb.createBotConfigurationAudit(data),
+        createBotConfigurationAudit: (data: any) =>
+          (global as any).mockDb.createBotConfigurationAudit(data),
         getAllBotConfigurations: () => (global as any).mockDb.getAllBotConfigurations(),
-        updateBotConfiguration: (id: any, data: any) => (global as any).mockDb.updateBotConfiguration(id, data),
+        updateBotConfiguration: (id: any, data: any) =>
+          (global as any).mockDb.updateBotConfiguration(id, data),
         deleteBotConfiguration: (id: any) => (global as any).mockDb.deleteBotConfiguration(id),
       })),
     },
@@ -49,28 +53,44 @@ describe('BotConfigService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    
+
     // Create a mock instance
     const mockDbManager = {
       isConfigured: jest.fn().mockReturnValue(true),
       configured: true,
       ensureConnected: jest.fn(),
-      getBotConfigurationByName: jest.fn((name: string) => (global as any).mockDb.getBotConfigurationByName(name)),
-      createBotConfiguration: jest.fn((data: any) => (global as any).mockDb.createBotConfiguration(data)),
+      getBotConfigurationByName: jest.fn((name: string) =>
+        (global as any).mockDb.getBotConfigurationByName(name)
+      ),
+      createBotConfiguration: jest.fn((data: any) =>
+        (global as any).mockDb.createBotConfiguration(data)
+      ),
       getBotConfiguration: jest.fn((id: any) => (global as any).mockDb.getBotConfiguration(id)),
-      getBotConfigurationVersions: jest.fn((id: any) => (global as any).mockDb.getBotConfigurationVersions(id)),
-      getBotConfigurationAudit: jest.fn((id: any) => (global as any).mockDb.getBotConfigurationAudit(id)),
-      createBotConfigurationAudit: jest.fn((data: any) => (global as any).mockDb.createBotConfigurationAudit(data)),
+      getBotConfigurationVersions: jest.fn((id: any) =>
+        (global as any).mockDb.getBotConfigurationVersions(id)
+      ),
+      getBotConfigurationAudit: jest.fn((id: any) =>
+        (global as any).mockDb.getBotConfigurationAudit(id)
+      ),
+      createBotConfigurationAudit: jest.fn((data: any) =>
+        (global as any).mockDb.createBotConfigurationAudit(data)
+      ),
       getAllBotConfigurations: jest.fn(() => (global as any).mockDb.getAllBotConfigurations()),
-      getAllBotConfigurationsWithDetails: jest.fn(() => (global as any).mockDb.getAllBotConfigurations()),
-      updateBotConfiguration: jest.fn((id: any, data: any) => (global as any).mockDb.updateBotConfiguration(id, data)),
-      deleteBotConfiguration: jest.fn((id: any) => (global as any).mockDb.deleteBotConfiguration(id)),
+      getAllBotConfigurationsWithDetails: jest.fn(() =>
+        (global as any).mockDb.getAllBotConfigurations()
+      ),
+      updateBotConfiguration: jest.fn((id: any, data: any) =>
+        (global as any).mockDb.updateBotConfiguration(id, data)
+      ),
+      deleteBotConfiguration: jest.fn((id: any) =>
+        (global as any).mockDb.deleteBotConfiguration(id)
+      ),
     };
 
     // Spy on getInstance and return our mock
     jest.spyOn(DatabaseManager, 'getInstance').mockReturnValue({
       ...mockDbManager,
-      isConfigured: () => true
+      isConfigured: () => true,
     } as any);
 
     BotConfigService.resetInstance();
@@ -91,7 +111,7 @@ describe('BotConfigService', () => {
       messageProvider: 'discord',
       llmProvider: 'openai',
       openai: { apiKey: 'test-key' },
-      discord: { botToken: 'test-token' }
+      discord: { botToken: 'test-token' },
     };
 
     it('should create a bot configuration successfully', async () => {
@@ -101,7 +121,10 @@ describe('BotConfigService', () => {
     });
 
     it('should throw when bot name already exists', async () => {
-      (global as any).mockDb.getBotConfigurationByName.mockResolvedValue({ id: 1, name: 'test-bot' });
+      (global as any).mockDb.getBotConfigurationByName.mockResolvedValue({
+        id: 1,
+        name: 'test-bot',
+      });
 
       await expect(service.createBotConfig(validConfig as any)).rejects.toThrow(
         "Bot configuration with name 'test-bot' already exists"

--- a/tests/unit/server/services/ConfigurationValidator.test.ts
+++ b/tests/unit/server/services/ConfigurationValidator.test.ts
@@ -40,7 +40,7 @@ describe('ConfigurationValidator', () => {
       });
 
       expect(result.isValid).toBe(false);
-      expect(result.errors.some(e => e.includes('character') || e.includes('least'))).toBe(true);
+      expect(result.errors.some((e) => e.includes('character') || e.includes('least'))).toBe(true);
     });
 
     it('should fail when name is too long', () => {
@@ -51,7 +51,7 @@ describe('ConfigurationValidator', () => {
       });
 
       expect(result.isValid).toBe(false);
-      expect(result.errors.some(e => e.includes('less than') || e.includes('most'))).toBe(true);
+      expect(result.errors.some((e) => e.includes('less than') || e.includes('most'))).toBe(true);
     });
 
     it('should fail when messageProvider is missing', () => {
@@ -73,7 +73,7 @@ describe('ConfigurationValidator', () => {
       });
 
       expect(result.isValid).toBe(false);
-      expect(result.errors.some(e => e.includes('Invalid message provider'))).toBe(true);
+      expect(result.errors.some((e) => e.includes('Invalid message provider'))).toBe(true);
     });
 
     it('should warn when Discord token format is unusual', () => {
@@ -86,7 +86,7 @@ describe('ConfigurationValidator', () => {
       });
 
       expect(result.isValid).toBe(true);
-      expect(result.warnings.some(w => w.includes('Discord token'))).toBe(true);
+      expect(result.warnings.some((w) => w.includes('Discord token'))).toBe(true);
     });
 
     it('should fail when Discord token is missing', () => {
@@ -138,7 +138,7 @@ describe('ConfigurationValidator', () => {
       });
 
       expect(result.isValid).toBe(true);
-      expect(result.warnings.some(w => w.includes('Slack app token'))).toBe(true);
+      expect(result.warnings.some((w) => w.includes('Slack app token'))).toBe(true);
     });
 
     it('should fail when Mattermost URL is missing', () => {
@@ -203,7 +203,7 @@ describe('ConfigurationValidator', () => {
       });
 
       expect(result.isValid).toBe(true);
-      expect(result.warnings.some(w => w.includes('OpenAI API key'))).toBe(true);
+      expect(result.warnings.some((w) => w.includes('OpenAI API key'))).toBe(true);
     });
 
     it('should suggest specifying OpenAI model when not provided', () => {
@@ -216,7 +216,7 @@ describe('ConfigurationValidator', () => {
       });
 
       expect(result.isValid).toBe(true);
-      expect(result.suggestions.some(s => s.includes('OpenAI model'))).toBe(true);
+      expect(result.suggestions.some((s) => s.includes('OpenAI model'))).toBe(true);
     });
 
     it('should fail when Flowise endpoint is missing', () => {
@@ -308,7 +308,7 @@ describe('ConfigurationValidator', () => {
       });
 
       expect(result.isValid).toBe(true);
-      expect(result.warnings.some(w => w.includes('System instruction is very long'))).toBe(true);
+      expect(result.warnings.some((w) => w.includes('System instruction is very long'))).toBe(true);
     });
 
     it('should suggest when system instruction is too short', () => {
@@ -322,7 +322,9 @@ describe('ConfigurationValidator', () => {
       });
 
       expect(result.isValid).toBe(true);
-      expect(result.suggestions.some(s => s.includes('System instruction is very short'))).toBe(true);
+      expect(result.suggestions.some((s) => s.includes('System instruction is very short'))).toBe(
+        true
+      );
     });
 
     it('should warn when MCP Guard has no allowed users', () => {
@@ -336,7 +338,7 @@ describe('ConfigurationValidator', () => {
       });
 
       expect(result.isValid).toBe(true);
-      expect(result.warnings.some(w => w.includes('MCP Guard'))).toBe(true);
+      expect(result.warnings.some((w) => w.includes('MCP Guard'))).toBe(true);
     });
 
     it('should warn for custom persona', () => {
@@ -350,7 +352,7 @@ describe('ConfigurationValidator', () => {
       });
 
       expect(result.isValid).toBe(true);
-      expect(result.warnings.some(w => w.includes('Custom persona'))).toBe(true);
+      expect(result.warnings.some((w) => w.includes('Custom persona'))).toBe(true);
     });
 
     it('should validate string-based provider configs', () => {

--- a/tests/unit/server/services/WebSocketService.fillers.test.ts
+++ b/tests/unit/server/services/WebSocketService.fillers.test.ts
@@ -76,14 +76,19 @@ function buildService() {
   } as any;
 
   // Per-bot metrics store so getBotStats returns real data
-  const botMetricsStore: Record<string, { messageCount: number; errorCount: number; errors: string[] }> = {};
+  const botMetricsStore: Record<
+    string,
+    { messageCount: number; errorCount: number; errors: string[] }
+  > = {};
   const mockBotMetricsService = {
     incrementMessageCount: jest.fn((botName: string) => {
-      if (!botMetricsStore[botName]) botMetricsStore[botName] = { messageCount: 0, errorCount: 0, errors: [] };
+      if (!botMetricsStore[botName])
+        botMetricsStore[botName] = { messageCount: 0, errorCount: 0, errors: [] };
       botMetricsStore[botName].messageCount++;
     }),
     incrementErrorCount: jest.fn((botName: string, error: string) => {
-      if (!botMetricsStore[botName]) botMetricsStore[botName] = { messageCount: 0, errorCount: 0, errors: [] };
+      if (!botMetricsStore[botName])
+        botMetricsStore[botName] = { messageCount: 0, errorCount: 0, errors: [] };
       botMetricsStore[botName].errorCount++;
       botMetricsStore[botName].errors.push(error);
     }),

--- a/tests/unit/server/services/websocket/BroadcastService.test.ts
+++ b/tests/unit/server/services/websocket/BroadcastService.test.ts
@@ -1,8 +1,8 @@
-import { BroadcastService } from '../../../../../src/server/services/websocket/BroadcastService';
-import { DeliveryStatus } from '../../../../../src/types/websocket';
 import { BotConfigurationManager } from '../../../../../src/config/BotConfigurationManager';
 import { ActivityLogger } from '../../../../../src/server/services/ActivityLogger';
 import { BotMetricsService } from '../../../../../src/server/services/BotMetricsService';
+import { BroadcastService } from '../../../../../src/server/services/websocket/BroadcastService';
+import { DeliveryStatus } from '../../../../../src/types/websocket';
 
 jest.mock('../../../../../src/config/BotConfigurationManager');
 jest.mock('../../../../../src/server/services/ActivityLogger');
@@ -118,7 +118,11 @@ describe('websocket/BroadcastService', () => {
       getWarnings: jest.fn(() => []),
     });
 
-    const service = new BroadcastService(connectionManager, apiMonitorService, demoModeService as any);
+    const service = new BroadcastService(
+      connectionManager,
+      apiMonitorService,
+      demoModeService as any
+    );
     service.sendBotStatus(socket);
 
     expect(socket.emit).toHaveBeenCalledWith(
@@ -142,7 +146,11 @@ describe('websocket/BroadcastService', () => {
       throw new Error('config failure');
     });
 
-    const service = new BroadcastService(connectionManager, apiMonitorService, demoModeService as any);
+    const service = new BroadcastService(
+      connectionManager,
+      apiMonitorService,
+      demoModeService as any
+    );
     service.sendConfigValidation(socket);
 
     expect(socket.emit).toHaveBeenCalledWith('error', {
@@ -151,7 +159,11 @@ describe('websocket/BroadcastService', () => {
   });
 
   it('retries tracked messages then marks timed out after max retries', () => {
-    const service = new BroadcastService(connectionManager, apiMonitorService, demoModeService as any);
+    const service = new BroadcastService(
+      connectionManager,
+      apiMonitorService,
+      demoModeService as any
+    );
     service.configureAck({ enabled: true, messageTimeoutMs: 10, maxRetries: 1 });
 
     const envelope = service.sendTrackedMessage('evt', { ok: true }, 'chan');
@@ -167,7 +179,11 @@ describe('websocket/BroadcastService', () => {
   });
 
   it('broadcastMonitoringData tolerates bot stats aggregation failure', () => {
-    const service = new BroadcastService(connectionManager, apiMonitorService, demoModeService as any);
+    const service = new BroadcastService(
+      connectionManager,
+      apiMonitorService,
+      demoModeService as any
+    );
     jest.spyOn(service as any, 'getAllBotStats').mockImplementation(() => {
       throw new Error('stats fail');
     });

--- a/tests/unit/server/services/websocket/ConnectionManager.test.ts
+++ b/tests/unit/server/services/websocket/ConnectionManager.test.ts
@@ -18,7 +18,14 @@ describe('websocket/ConnectionManager', () => {
       sockets: {
         sockets: new Map([
           ['1', { disconnect: jest.fn() }],
-          ['2', { disconnect: jest.fn(() => { throw new Error('disconnect fail'); }) }],
+          [
+            '2',
+            {
+              disconnect: jest.fn(() => {
+                throw new Error('disconnect fail');
+              }),
+            },
+          ],
         ]),
       },
       removeAllListeners: jest.fn(),

--- a/tests/unit/utils/errorLogger.test.ts
+++ b/tests/unit/utils/errorLogger.test.ts
@@ -1,5 +1,9 @@
+import {
+  BaseHivemindError,
+  ConfigurationError,
+  NetworkError,
+} from '../../../src/types/errorClasses';
 import { ErrorLogger, type ErrorContext } from '../../../src/utils/errorLogger';
-import { BaseHivemindError, NetworkError, ConfigurationError } from '../../../src/types/errorClasses';
 
 describe('ErrorLogger', () => {
   let logger: ErrorLogger;

--- a/tests/unit/utils/errorRecovery.test.ts
+++ b/tests/unit/utils/errorRecovery.test.ts
@@ -1,8 +1,8 @@
 import {
   CircuitBreaker,
   RetryHandler,
-  type RetryConfig,
   type CircuitBreakerConfig,
+  type RetryConfig,
 } from '../../../src/utils/errorRecovery';
 
 describe('CircuitBreaker', () => {

--- a/tests/unit/utils/errorResponse.test.ts
+++ b/tests/unit/utils/errorResponse.test.ts
@@ -1,5 +1,10 @@
-import { ErrorResponseBuilder, createErrorResponse } from '../../../src/utils/errorResponse';
-import { ConfigurationError, AuthenticationError, NetworkError, ValidationError } from '../../../src/types/errorClasses';
+import {
+  AuthenticationError,
+  ConfigurationError,
+  NetworkError,
+  ValidationError,
+} from '../../../src/types/errorClasses';
+import { createErrorResponse, ErrorResponseBuilder } from '../../../src/utils/errorResponse';
 
 describe('ErrorResponseBuilder', () => {
   describe('basic error response', () => {
@@ -23,7 +28,12 @@ describe('ErrorResponseBuilder', () => {
     });
 
     it('should include error details when available', () => {
-      const error = new ValidationError('Validation failed', 'email', 'invalid@email', 'valid email');
+      const error = new ValidationError(
+        'Validation failed',
+        'email',
+        'invalid@email',
+        'valid email'
+      );
       const builder = new ErrorResponseBuilder(error);
       const response = builder.build();
 
@@ -100,12 +110,14 @@ describe('ErrorResponseBuilder', () => {
       builder.send(mockRes);
 
       expect(mockRes.status).toHaveBeenCalledWith(500);
-      expect(mockRes.json).toHaveBeenCalledWith(expect.objectContaining({
-        success: false,
-        error: expect.objectContaining({
-          message: 'Test error',
-        }),
-      }));
+      expect(mockRes.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          error: expect.objectContaining({
+            message: 'Test error',
+          }),
+        })
+      );
     });
   });
 

--- a/tests/utils/shell-utils.integration.test.ts
+++ b/tests/utils/shell-utils.integration.test.ts
@@ -3,7 +3,10 @@ import { executeCommandSafe } from '../../src/utils/utils';
 describe('Shell Utils Integration', () => {
   it('should successfully execute a safe command', async () => {
     // We use node directly to ensure it is found in PATH
-    const result = await executeCommandSafe(process.execPath, ['-e', 'process.stdout.write("hello")']);
+    const result = await executeCommandSafe(process.execPath, [
+      '-e',
+      'process.stdout.write("hello")',
+    ]);
     expect(result.trim()).toBe('hello');
   });
 

--- a/tests/utils/utils.test.ts
+++ b/tests/utils/utils.test.ts
@@ -82,10 +82,14 @@ describe('executeCommandSafe', () => {
     });
 
     it('should pass custom env and cwd options to command execution', async () => {
-      const output = await executeCommandSafe('node', ['-e', 'process.stdout.write(process.env.CUSTOM_ENV || "")'], {
-        env: { ...process.env, CUSTOM_ENV: 'custom-value' } as NodeJS.ProcessEnv,
-        cwd: process.cwd(),
-      });
+      const output = await executeCommandSafe(
+        'node',
+        ['-e', 'process.stdout.write(process.env.CUSTOM_ENV || "")'],
+        {
+          env: { ...process.env, CUSTOM_ENV: 'custom-value' } as NodeJS.ProcessEnv,
+          cwd: process.cwd(),
+        }
+      );
       expect(output).toBe('custom-value');
     });
 

--- a/tests/webhook/security/webhookSecurity.edgecases.test.ts
+++ b/tests/webhook/security/webhookSecurity.edgecases.test.ts
@@ -9,7 +9,10 @@
  * and never executed a single assertion.
  */
 import type { Request, Response } from 'express';
-import { verifyIpWhitelist, verifyWebhookToken } from '../../../src/webhook/security/webhookSecurity';
+import {
+  verifyIpWhitelist,
+  verifyWebhookToken,
+} from '../../../src/webhook/security/webhookSecurity';
 
 // ---------------------------------------------------------------------------
 // Mock webhook config with per-test overrides

--- a/tests/webhook/slack-integration.test.ts
+++ b/tests/webhook/slack-integration.test.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata';
 import express from 'express';
 import request from 'supertest';
+import { configureWebhookRoutes } from '../../src/webhook/routes/webhookRoutes';
 
 // Define mock config inside hoisted mock factory
 jest.mock('../../src/config/webhookConfig', () => {
@@ -18,8 +19,6 @@ jest.mock('../../src/config/webhookConfig', () => {
     default: mockInstance,
   };
 });
-
-import { configureWebhookRoutes } from '../../src/webhook/routes/webhookRoutes';
 
 // Helper to spoof the source IP for testing whitelist logic
 const spoofIp = (ip: string) => (req: any, res: any, next: any) => {
@@ -43,7 +42,7 @@ describe('Slack Webhook Integration', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    
+
     app = express();
     app.use(express.json());
     app.use(spoofIp('127.0.0.1'));
@@ -78,7 +77,7 @@ describe('Slack Webhook Integration', () => {
       sendPublicAnnouncement: jest.fn().mockResolvedValue(undefined),
       getDefaultChannel: jest.fn().mockReturnValue('general'),
     };
-    
+
     const fallbackApp = express();
     fallbackApp.use(express.json());
     fallbackApp.use(spoofIp('127.0.0.1'));

--- a/tests/webhook/webhookRoutes.integration.test.ts
+++ b/tests/webhook/webhookRoutes.integration.test.ts
@@ -120,7 +120,9 @@ describe('Webhook Routes Integration', () => {
 
       expect(res.status).toBe(400);
       expect(res.body.error).toBe('Invalid request body');
-      expect(res.body.details.some((d: string) => d.includes('Missing or invalid "id" field'))).toBe(true);
+      expect(
+        res.body.details.some((d: string) => d.includes('Missing or invalid "id" field'))
+      ).toBe(true);
     });
 
     it('should reject invalid status values', async () => {
@@ -130,7 +132,9 @@ describe('Webhook Routes Integration', () => {
         .send({ id: 'pred-1', status: 'invalid-status' });
 
       expect(res.status).toBe(400);
-      expect(res.body.details.some((d: string) => d.includes('Invalid status "invalid-status"'))).toBe(true);
+      expect(
+        res.body.details.some((d: string) => d.includes('Invalid status "invalid-status"'))
+      ).toBe(true);
     });
 
     it('should reject output arrays exceeding 10 items', async () => {
@@ -240,10 +244,7 @@ describe('Webhook Routes Integration', () => {
         .post('/webhook/slack')
         .set('x-webhook-token', 'secret-token')
         .send({
-          attachments: [
-            { text: 'Attachment 1', fallback: 'Fallback 1' },
-            { text: 'Attachment 2' },
-          ],
+          attachments: [{ text: 'Attachment 1', fallback: 'Fallback 1' }, { text: 'Attachment 2' }],
         });
 
       expect(res.status).toBe(200);


### PR DESCRIPTION
## Changes

### Auto-fix (commit 1)
- 714 prettier formatting errors auto-fixed from PR #2590 merge

### as-any cleanup (commit 2)
- **IProvider.ts**: all `any` → `unknown`/`Record<string, unknown>` (10 warnings removed)
- **discord.ts**: `any` → `unknown`/typed alternatives in interfaces + type guards (11 warnings removed)
- **DatabaseManager.ts + DecisionRepository.ts**: removed `as any` casts, typed getDb/getRecentDecisions (11 warnings removed)
- Updated all 8 provider implementors to match new interface signatures
- adminRoutes.ts: cast req.body for addBot calls

### Results
- **Lint**: 846 → 775 warnings (71 fewer), no-explicit-any: 436 → 387 (49 fewer)
- **tsc**: 20 errors (same as main)
- **Tests**: no regressions