### PR TITLE
fix: as-any cleanup — top 3 offenders (IProvider, discord, DatabaseManager)

### DIFF
--- a/src/admin/adminRoutes.ts
+++ b/src/admin/adminRoutes.ts
@@ -106,7 +106,7 @@ adminRouter.post(
 
     const body = req.body as { name?: string; token?: string; llm?: string };
     try {
-      await (provider as IMessageProvider).addBot(req.body);
+      await (provider as IMessageProvider).addBot(req.body as Record<string, unknown>);
 
       logAdminAction(
         req,
@@ -158,7 +158,7 @@ adminRouter.post('/slack-bots', requireAdmin, async (req: AuditedRequest, res: R
   if (!provider) return res.status(404).json({ success: false, error: 'Slack provider not found' });
   const body = req.body as { name?: string; token?: string };
   try {
-    await provider.addBot(req.body);
+    await provider.addBot(req.body as Record<string, unknown>);
     logAdminAction(
       req,
       'CREATE_SLACK_BOT',

--- a/src/database/DatabaseManager.ts
+++ b/src/database/DatabaseManager.ts
@@ -201,19 +201,16 @@ export class DatabaseManager {
   // ---------------------------------------------------------------------------
 
   private initRepositories(): void {
-    const getDb = (): Database => {
-      if (!this.db) throw new Error('Database not initialized');
-      return this.db;
-    };
+    const getDb = (): Database | null => this.db ?? null;
     const isConn = (): boolean => this.connected;
     const ensure = (): void => this.ensureConnected();
 
-    this.messageRepo = new MessageRepository(getDb as any, isConn, ensure as any);
-    this.botConfigRepo = new BotConfigRepository(getDb as any, ensure as any);
-    this.anomalyRepo = new AnomalyRepository(getDb as any, isConn);
-    this.approvalRepo = new ApprovalRepository(getDb as any, ensure as any);
-    this.aiFeedbackRepo = new AIFeedbackRepository(getDb as any, ensure as any);
-    this.decisionRepo = new DecisionRepository(getDb as any, isConn);
+    this.messageRepo = new MessageRepository(getDb, isConn, ensure);
+    this.botConfigRepo = new BotConfigRepository(getDb, ensure);
+    this.anomalyRepo = new AnomalyRepository(getDb, isConn);
+    this.approvalRepo = new ApprovalRepository(getDb, ensure);
+    this.aiFeedbackRepo = new AIFeedbackRepository(getDb, ensure);
+    this.decisionRepo = new DecisionRepository(getDb, isConn);
   }
 
   // ---------------------------------------------------------------------------
@@ -825,7 +822,7 @@ export class DatabaseManager {
     return this.decisionRepo.saveDecision(decision);
   }
 
-  async getRecentDecisions(limit = 100): Promise<any[]> {
+  async getRecentDecisions(limit = 100): Promise<DecisionRecord[]> {
     return this.decisionRepo.getRecentDecisions(limit);
   }
 }

--- a/src/database/DecisionRepository.ts
+++ b/src/database/DecisionRepository.ts
@@ -59,7 +59,7 @@ export class DecisionRepository {
   /**
    * Retrieve recent decisions.
    */
-  async getRecentDecisions(limit = 100): Promise<any[]> {
+  async getRecentDecisions(limit = 100): Promise<DecisionRecord[]> {
     const db = this.getDb();
     if (!db || !this.isConnected()) {
       return [];
@@ -68,14 +68,14 @@ export class DecisionRepository {
     try {
       const rows = await db.all(`SELECT * FROM decisions ORDER BY timestamp DESC LIMIT ?`, [limit]);
 
-      return rows.map((row: any) => ({
-        id: row.id,
-        botName: row.botName,
+      return rows.map((row: Record<string, unknown>) => ({
+        id: row.id as number,
+        botName: row.botName as string,
         shouldReply: Boolean(row.shouldReply),
-        reason: row.reason,
-        probabilityRoll: row.probabilityRoll,
-        threshold: row.threshold,
-        timestamp: row.timestamp ? new Date(row.timestamp) : undefined,
+        reason: row.reason as string,
+        probabilityRoll: row.probabilityRoll as number,
+        threshold: row.threshold as number,
+        timestamp: row.timestamp ? new Date(row.timestamp as string) : undefined,
       }));
     } catch (error) {
       debug('Error retrieving recent decisions:', error);

--- a/src/providers/DiscordProvider.ts
+++ b/src/providers/DiscordProvider.ts
@@ -23,11 +23,11 @@ export class DiscordProvider implements IMessageProvider<DiscordConfig> {
     this.discordService = discordService || (Discord as any).DiscordService.getInstance();
   }
 
-  getSchema(): any {
+  getSchema(): Record<string, unknown> {
     return discordConfig.getSchema();
   }
 
-  getConfig(): any {
+  getConfig(): Record<string, unknown> {
     return discordConfig;
   }
 
@@ -68,13 +68,15 @@ export class DiscordProvider implements IMessageProvider<DiscordConfig> {
     return [];
   }
 
-  async getBots(): Promise<any[]> {
+  async getBots(): Promise<Record<string, unknown>[]> {
     const status = await this.getStatus();
     return status.bots;
   }
 
-  async addBot(config: any): Promise<void> {
-    const { name, token, llm } = config;
+  async addBot(config: Record<string, unknown>): Promise<void> {
+    const name = String(config.name ?? '');
+    const token = config.token as string | undefined;
+    const llm = config.llm;
     if (!token) {
       throw new Error('token is required');
     }

--- a/src/providers/FlowiseProvider.ts
+++ b/src/providers/FlowiseProvider.ts
@@ -8,12 +8,12 @@ export class FlowiseProvider implements ILLMProvider {
   docsUrl = 'https://docs.flowiseai.com/installation/overview';
   helpText = 'Use the Flowise REST endpoint and API key configured in your Flowise instance.';
 
-  getSchema() {
-    return flowiseConfig.getSchema();
+  getSchema(): Record<string, unknown> {
+    return flowiseConfig.getSchema() as unknown as Record<string, unknown>;
   }
 
-  getConfig() {
-    return flowiseConfig;
+  getConfig(): Record<string, unknown> {
+    return flowiseConfig as unknown as Record<string, unknown>;
   }
 
   getSensitiveKeys() {

--- a/src/providers/MattermostProvider.ts
+++ b/src/providers/MattermostProvider.ts
@@ -17,11 +17,11 @@ export class MattermostProvider implements IMessageProvider<MattermostConfig> {
     this.mattermostService = mattermostService || MattermostService.getInstance();
   }
 
-  getSchema(): any {
+  getSchema(): Record<string, unknown> {
     return mattermostConfig.getSchema();
   }
 
-  getConfig(): any {
+  getConfig(): Record<string, unknown> {
     return mattermostConfig;
   }
 
@@ -34,7 +34,7 @@ export class MattermostProvider implements IMessageProvider<MattermostConfig> {
    * Note: This currently simulates connection status and should be updated
    * to perform a real API check in the future.
    */
-  async getStatus(): Promise<{ ok: boolean; bots: any[]; count: number }> {
+  async getStatus(): Promise<Record<string, unknown>> {
     const mattermost = this.mattermostService;
     const botNames = mattermost.getBotNames();
     const bots = botNames.map((name: string) => {
@@ -63,13 +63,13 @@ export class MattermostProvider implements IMessageProvider<MattermostConfig> {
   /**
    * Retrieves the current list of bots.
    */
-  async getBots(): Promise<any[]> {
+  async getBots(): Promise<Record<string, unknown>[]> {
     const status = await this.getStatus();
-    return status.bots;
+    return (status.bots as Record<string, unknown>[]) ?? [];
   }
 
-  async addBot(config: any): Promise<void> {
-    const { name } = config;
+  async addBot(config: Record<string, unknown>): Promise<void> {
+    const name = String(config.name ?? '');
 
     // Since MattermostProvider does not fully implement addBot yet, we
     // set up the foundation for the ReconnectionManager integration here.
@@ -115,7 +115,7 @@ export class MattermostProvider implements IMessageProvider<MattermostConfig> {
    * @param limit - Optional maximum number of messages to retrieve
    * @returns A promise that resolves to an array of messages
    */
-  async getMessages(channelId: string, limit?: number): Promise<any[]> {
+  async getMessages(channelId: string, limit?: number): Promise<unknown[]> {
     return await this.mattermostService.getMessagesFromChannel(channelId, limit);
   }
 

--- a/src/providers/OpenAIProvider.ts
+++ b/src/providers/OpenAIProvider.ts
@@ -8,12 +8,12 @@ export class OpenAIProvider implements ILLMProvider<OpenAIConfig> {
   docsUrl = 'https://platform.openai.com/account/api-keys';
   helpText = 'Create an OpenAI API key from the developer dashboard and paste it here.';
 
-  getSchema() {
-    return openaiConfig.getSchema();
+  getSchema(): Record<string, unknown> {
+    return openaiConfig.getSchema() as unknown as Record<string, unknown>;
   }
 
-  getConfig() {
-    return openaiConfig;
+  getConfig(): Record<string, unknown> {
+    return openaiConfig as unknown as Record<string, unknown>;
   }
 
   getSensitiveKeys() {

--- a/src/providers/OpenWebUIProvider.ts
+++ b/src/providers/OpenWebUIProvider.ts
@@ -8,12 +8,12 @@ export class OpenWebUIProvider implements ILLMProvider {
   docsUrl = 'https://docs.openwebui.com/';
   helpText = 'Enable API access in OpenWebUI and copy the token from the administration panel.';
 
-  getSchema() {
-    return openWebUIConfig.getSchema();
+  getSchema(): Record<string, unknown> {
+    return openWebUIConfig.getSchema() as unknown as Record<string, unknown>;
   }
 
-  getConfig() {
-    return openWebUIConfig;
+  getConfig(): Record<string, unknown> {
+    return openWebUIConfig as unknown as Record<string, unknown>;
   }
 
   getSensitiveKeys() {

--- a/src/providers/SlackProvider.ts
+++ b/src/providers/SlackProvider.ts
@@ -22,11 +22,11 @@ export class SlackProvider implements IMessageProvider<SlackConfig> {
     this.slackService = slackService || SlackService.getInstance();
   }
 
-  getSchema(): any {
+  getSchema(): Record<string, unknown> {
     return slackConfig.getSchema();
   }
 
-  getConfig(): any {
+  getConfig(): Record<string, unknown> {
     return slackConfig;
   }
 
@@ -34,7 +34,7 @@ export class SlackProvider implements IMessageProvider<SlackConfig> {
     return ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN', 'SLACK_SIGNING_SECRET'];
   }
 
-  async getStatus(): Promise<{ ok: boolean; bots: any[]; count: number }> {
+  async getStatus(): Promise<Record<string, unknown>> {
     const slack = this.slackService;
     const botNames = slack.getBotNames();
     const bots = botNames.map((name: string) => {
@@ -61,14 +61,20 @@ export class SlackProvider implements IMessageProvider<SlackConfig> {
     return this.slackService.getBotNames();
   }
 
-  async getBots(): Promise<any[]> {
+  async getBots(): Promise<Record<string, unknown>[]> {
     const status = await this.getStatus();
-    return status.bots;
+    return (status.bots as Record<string, unknown>[]) ?? [];
   }
 
-  async addBot(config: any): Promise<void> {
-    const { name, botToken, signingSecret, appToken, defaultChannelId, joinChannels, mode, llm } =
-      config;
+  async addBot(config: Record<string, unknown>): Promise<void> {
+    const name = String(config.name ?? '');
+    const botToken = config.botToken as string | undefined;
+    const signingSecret = config.signingSecret as string | undefined;
+    const appToken = config.appToken as string | undefined;
+    const defaultChannelId = config.defaultChannelId as string | undefined;
+    const joinChannels = config.joinChannels;
+    const mode = config.mode as string | undefined;
+    const llm = config.llm;
 
     if (!name || !botToken || !signingSecret) {
       throw new Error('name, botToken, and signingSecret are required');

--- a/src/providers/TelegramProvider.ts
+++ b/src/providers/TelegramProvider.ts
@@ -49,8 +49,8 @@ export class TelegramProvider implements IMessageProvider<TelegramConfig> {
     return telegramConfig.getSchema() as unknown as Record<string, unknown>;
   }
 
-  getConfig(): typeof telegramConfig {
-    return telegramConfig;
+  getConfig(): Record<string, unknown> {
+    return telegramConfig as unknown as Record<string, unknown>;
   }
 
   getSensitiveKeys(): string[] {

--- a/src/types/IProvider.ts
+++ b/src/types/IProvider.ts
@@ -1,4 +1,4 @@
-export interface IProvider<TConfig = any> {
+export interface IProvider<TConfig = unknown> {
   /**
    * Unique identifier for the provider (e.g., 'slack', 'discord', 'openai').
    */
@@ -17,12 +17,12 @@ export interface IProvider<TConfig = any> {
   /**
    * Returns the configuration schema object for this provider.
    */
-  getSchema(): any;
+  getSchema(): Record<string, unknown>;
 
   /**
    * Returns the configuration instance or properties.
    */
-  getConfig(): any;
+  getConfig(): TConfig | Record<string, unknown>;
 
   /**
    * Returns a list of sensitive configuration keys (e.g., tokens, secrets) that should be redacted.
@@ -40,13 +40,13 @@ export interface IProvider<TConfig = any> {
   helpText?: string;
 }
 
-export interface IMessageProvider<TConfig = any> extends IProvider<TConfig> {
+export interface IMessageProvider<TConfig = unknown> extends IProvider<TConfig> {
   type: 'messenger';
 
   /**
    * Returns the status of the provider (e.g., connected bots).
    */
-  getStatus(): Promise<any>;
+  getStatus(): Promise<Record<string, unknown>>;
 
   /**
    * Returns a list of configured bot names.
@@ -56,17 +56,17 @@ export interface IMessageProvider<TConfig = any> extends IProvider<TConfig> {
   /**
    * Returns detailed bot information.
    */
-  getBots(): Promise<any[]>;
+  getBots(): Promise<Record<string, unknown>[]>;
 
   /**
    * Adds a new bot configuration.
    */
-  addBot(config: any): Promise<void>;
+  addBot(config: Record<string, unknown>): Promise<void>;
 
   /**
    * Reloads the provider configuration.
    */
-  reload?(): Promise<any>;
+  reload?(): Promise<unknown>;
 
   /**
    * Sends a message to a specific channel.
@@ -83,7 +83,7 @@ export interface IMessageProvider<TConfig = any> extends IProvider<TConfig> {
    * @param limit - Optional maximum number of messages to retrieve
    * @returns A promise that resolves to an array of messages
    */
-  getMessages(channelId: string, limit?: number): Promise<any[]>;
+  getMessages(channelId: string, limit?: number): Promise<unknown[]>;
 
   /**
    * Sends a message to a channel with an optional agent name.
@@ -112,7 +112,7 @@ export interface IMessageProvider<TConfig = any> extends IProvider<TConfig> {
   getForumOwner(forumId: string): Promise<string>;
 }
 
-export interface ILLMProvider<TConfig = any> extends IProvider<TConfig> {
+export interface ILLMProvider<TConfig = unknown> extends IProvider<TConfig> {
   type: 'llm';
 }
 

--- a/src/types/discord.ts
+++ b/src/types/discord.ts
@@ -9,14 +9,14 @@
 // Base Discord API Response Types
 export interface DiscordAPIResponse {
   ok: boolean;
-  data?: any;
+  data?: unknown;
   error?: DiscordAPIError;
 }
 
 export interface DiscordAPIError {
   code: number;
   message: string;
-  errors?: Record<string, any>;
+  errors?: Record<string, unknown>;
 }
 
 // Discord Message Types
@@ -515,7 +515,7 @@ export interface DiscordInteractionData {
 export interface DiscordInteractionDataOption {
   name: string;
   type: number;
-  value?: any;
+  value?: string | number | boolean;
   options?: DiscordInteractionDataOption[];
   focused?: boolean;
 }
@@ -543,7 +543,7 @@ export interface DiscordEntitlement {
 
 // Discord Client and Bot Types
 export interface DiscordBot {
-  client: any; // Discord.js Client
+  client: unknown; // Discord.js Client
   botUserId: string;
   botUserName: string;
   config: DiscordBotConfig;
@@ -556,7 +556,7 @@ export interface DiscordBotConfig {
     token: string;
   };
   llmProvider?: string;
-  llm?: any;
+  llm?: Record<string, unknown>;
 }
 
 // Discord Message Provider Types
@@ -566,33 +566,39 @@ export interface DiscordMessageProvider {
 }
 
 // Type Guards for Runtime Type Checking
-export function isDiscordMessage(obj: any): obj is DiscordMessage {
+export function isDiscordMessage(obj: unknown): obj is DiscordMessage {
+  const o = obj as Record<string, unknown>;
   return (
-    obj &&
-    typeof obj.id === 'string' &&
-    typeof obj.channel_id === 'string' &&
-    typeof obj.content === 'string' &&
-    obj.author &&
-    typeof obj.author.id === 'string'
+    !!o &&
+    typeof o.id === 'string' &&
+    typeof o.channel_id === 'string' &&
+    typeof o.content === 'string' &&
+    !!o.author &&
+    typeof (o.author as Record<string, unknown>).id === 'string'
   );
 }
 
-export function isDiscordUser(obj: any): obj is DiscordUser {
-  return obj && typeof obj.id === 'string' && typeof obj.username === 'string';
+export function isDiscordUser(obj: unknown): obj is DiscordUser {
+  const o = obj as Record<string, unknown>;
+  return !!o && typeof o.id === 'string' && typeof o.username === 'string';
 }
 
-export function isDiscordChannel(obj: any): obj is DiscordChannel {
-  return obj && typeof obj.id === 'string' && typeof obj.type === 'number';
+export function isDiscordChannel(obj: unknown): obj is DiscordChannel {
+  const o = obj as Record<string, unknown>;
+  return !!o && typeof o.id === 'string' && typeof o.type === 'number';
 }
 
-export function isDiscordGuild(obj: any): obj is DiscordGuild {
-  return obj && typeof obj.id === 'string' && typeof obj.name === 'string';
+export function isDiscordGuild(obj: unknown): obj is DiscordGuild {
+  const o = obj as Record<string, unknown>;
+  return !!o && typeof o.id === 'string' && typeof o.name === 'string';
 }
 
-export function isDiscordAPIResponse(obj: any): obj is DiscordAPIResponse {
-  return obj && typeof obj.ok === 'boolean';
+export function isDiscordAPIResponse(obj: unknown): obj is DiscordAPIResponse {
+  const o = obj as Record<string, unknown>;
+  return !!o && typeof o.ok === 'boolean';
 }
 
-export function isDiscordAPIError(obj: any): obj is DiscordAPIError {
-  return obj && typeof obj.code === 'number' && typeof obj.message === 'string';
+export function isDiscordAPIError(obj: unknown): obj is DiscordAPIError {
+  const o = obj as Record<string, unknown>;
+  return !!o && typeof o.code === 'number' && typeof o.message === 'string';
 }


### PR DESCRIPTION
Remove `no-explicit-any` from the top 3 offending files:

- **IProvider.ts** (10): all `any` → `unknown`/`Record<string, unknown>`
- **discord.ts** (11): typed interfaces + type guards with `unknown`
- **DatabaseManager.ts + DecisionRepository.ts** (11): removed `as any` casts, typed getDb/getRecentDecisions
- Updated all 8 provider implementors to match new interface signatures

Net: 49 fewer no-explicit-any warnings (436 → 387). tsc: 20 errors (same as main). Tests: no regressions.