### PR TITLE
chore(ci): fix CI-fast lint errors and clear moderate audit findings

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "debug": "^4.4.3",
     "discord-api-types": "^0.37.67",
     "discord.js": "^14.14.1",
-    "dompurify": "^3.3.1",
+    "dompurify": "^3.4.0",
     "dotenv": "^16.6.1",
     "express": "^4.21.2",
     "express-handlebars": "^8.0.3",
@@ -160,7 +160,7 @@
     "form-data": "^4.0.4",
     "framer-motion": "12.34.3",
     "gpt-tokenizer": "^2.1.2",
-    "hono": "^4.12.12",
+    "hono": "^4.12.14",
     "html-entities": "^2.5.2",
     "inquirer": "^12.9.4",
     "ioredis": "^5.8.2",
@@ -337,7 +337,9 @@
       "minimatch": "^10.2.3",
       "serialize-javascript": "^7.0.3",
       "follow-redirects": "^1.16.0",
-      "smol-toml": "^1.3.0"
+      "smol-toml": "^1.6.1",
+      "basic-ftp": "^5.3.0",
+      "ajv": "^8.18.0"
     },
     "onlyBuiltDependencies": [
       "better-sqlite3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,9 @@ overrides:
   minimatch: ^10.2.3
   serialize-javascript: ^7.0.3
   follow-redirects: ^1.16.0
-  smol-toml: ^1.3.0
+  smol-toml: ^1.6.1
+  basic-ftp: ^5.3.0
+  ajv: ^8.18.0
 
 importers:
 
@@ -184,8 +186,8 @@ importers:
         specifier: ^14.14.1
         version: 14.26.2
       dompurify:
-        specifier: ^3.3.1
-        version: 3.3.3
+        specifier: ^3.4.0
+        version: 3.4.0
       dotenv:
         specifier: ^16.6.1
         version: 16.6.1
@@ -223,8 +225,8 @@ importers:
         specifier: ^2.1.2
         version: 2.9.0
       hono:
-        specifier: ^4.12.12
-        version: 4.12.12
+        specifier: ^4.12.14
+        version: 4.12.14
       html-entities:
         specifier: ^2.5.2
         version: 2.6.0
@@ -939,8 +941,8 @@ importers:
         specifier: ^5.1.25
         version: 5.5.19
       dompurify:
-        specifier: ^3.3.1
-        version: 3.3.3
+        specifier: ^3.4.0
+        version: 3.4.0
       framer-motion:
         specifier: ^12.34.3
         version: 12.34.3(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -4265,19 +4267,13 @@ packages:
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
-      ajv: ^8.0.0
+      ajv: ^8.18.0
     peerDependenciesMeta:
       ajv:
         optional: true
 
-  ajv@6.14.0:
-    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
-
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
-
-  ajv@8.6.3:
-    resolution: {integrity: sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -4556,8 +4552,8 @@ packages:
     resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
     engines: {node: '>= 0.8'}
 
-  basic-ftp@5.2.2:
-    resolution: {integrity: sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==}
+  basic-ftp@5.3.0:
+    resolution: {integrity: sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==}
     engines: {node: '>=10.0.0'}
 
   bcrypt@6.0.0:
@@ -5237,8 +5233,8 @@ packages:
     engines: {node: '>=12'}
     deprecated: Use your platform's native DOMException instead
 
-  dompurify@3.3.3:
-    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+  dompurify@3.4.0:
+    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -6034,8 +6030,8 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.12.12:
-    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@2.8.9:
@@ -6615,9 +6611,6 @@ packages:
 
   json-schema-to-ts@1.6.4:
     resolution: {integrity: sha512-pR4yQ9DHz6itqswtHCm26mw45FSNfQ9rEQjosaZErhn5J3J2sIViQiz8rDaezjKAhFGpmsoczYVBgGHzFw/stA==}
-
-  json-schema-traverse@0.4.1:
-    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -8259,8 +8252,8 @@ packages:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
 
-  smol-toml@1.5.2:
-    resolution: {integrity: sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==}
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
 
   socket.io-adapter@2.5.6:
@@ -8871,9 +8864,6 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
-
-  uri-js@4.4.1:
-    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
@@ -10892,7 +10882,7 @@ snapshots:
 
   '@eslint/eslintrc@3.3.5':
     dependencies:
-      ajv: 6.14.0
+      ajv: 8.18.0
       debug: 4.4.3(supports-color@8.1.1)
       espree: 10.4.0
       globals: 14.0.0
@@ -10921,9 +10911,9 @@ snapshots:
     dependencies:
       react: 19.2.5
 
-  '@hono/node-server@1.19.13(hono@4.12.12)':
+  '@hono/node-server@1.19.13(hono@4.12.14)':
     dependencies:
-      hono: 4.12.12
+      hono: 4.12.14
 
   '@hookform/resolvers@5.2.2(react-hook-form@7.72.1(react@19.2.5))':
     dependencies:
@@ -11403,7 +11393,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.12)
+      '@hono/node-server': 1.19.13(hono@4.12.14)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -11413,7 +11403,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.12
+      hono: 4.12.14
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -12088,7 +12078,7 @@ snapshots:
 
   '@types/dompurify@3.2.0':
     dependencies:
-      dompurify: 3.3.3
+      dompurify: 3.4.0
 
   '@types/dotenv@6.1.1':
     dependencies:
@@ -12507,12 +12497,12 @@ snapshots:
       fs-extra: 11.1.1
       js-yaml: 4.1.1
       minimatch: 10.2.5
-      smol-toml: 1.5.2
+      smol-toml: 1.6.1
       zod: 3.22.4
 
   '@vercel/static-config@3.2.0':
     dependencies:
-      ajv: 8.6.3
+      ajv: 8.18.0
       json-schema-to-ts: 1.6.4
       ts-morph: 12.0.0
 
@@ -12653,26 +12643,12 @@ snapshots:
     optionalDependencies:
       ajv: 8.18.0
 
-  ajv@6.14.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-json-stable-stringify: 2.1.0
-      json-schema-traverse: 0.4.1
-      uri-js: 4.4.1
-
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
-
-  ajv@8.6.3:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
-      uri-js: 4.4.1
 
   ansi-colors@4.1.3: {}
 
@@ -12968,7 +12944,7 @@ snapshots:
     dependencies:
       safe-buffer: 5.1.2
 
-  basic-ftp@5.2.2: {}
+  basic-ftp@5.3.0: {}
 
   bcrypt@6.0.0:
     dependencies:
@@ -13629,7 +13605,7 @@ snapshots:
     dependencies:
       webidl-conversions: 7.0.0
 
-  dompurify@3.3.3:
+  dompurify@3.4.0:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -14031,7 +14007,7 @@ snapshots:
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
-      ajv: 6.14.0
+      ajv: 8.18.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3(supports-color@8.1.1)
@@ -14542,7 +14518,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.2.2
+      basic-ftp: 5.3.0
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -14681,7 +14657,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.12.12: {}
+  hono@4.12.14: {}
 
   hosted-git-info@2.8.9: {}
 
@@ -15508,8 +15484,6 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
       ts-toolbelt: 6.15.5
-
-  json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
 
@@ -16805,7 +16779,7 @@ snapshots:
       css-mediaquery: 0.1.2
       csstype: 3.2.3
       diacritic: 0.0.2
-      dompurify: 3.3.3
+      dompurify: 3.4.0
       inflection: 3.0.2
       jsonexport: 3.2.0
       lodash: 4.18.1
@@ -17465,7 +17439,7 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
-  smol-toml@1.5.2: {}
+  smol-toml@1.6.1: {}
 
   socket.io-adapter@2.5.6:
     dependencies:
@@ -18138,10 +18112,6 @@ snapshots:
       browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
-
-  uri-js@4.4.1:
-    dependencies:
-      punycode: 2.3.1
 
   url-parse@1.5.10:
     dependencies:

--- a/src/auth/middleware.ts
+++ b/src/auth/middleware.ts
@@ -304,7 +304,11 @@ export const requirePermission = (
   return middleware.requirePermission(permission);
 };
 
-export const requireAdmin: (req: Request, res: Response, next: NextFunction) => void = (() => {
+export const requireAdmin: (req: Request, res: Response, next: NextFunction) => void = ((): ((
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => void) => {
   const middleware = new AuthMiddleware();
   return middleware.requireAdmin;
 })();

--- a/src/cli/handlers/BotCommandHandler.ts
+++ b/src/cli/handlers/BotCommandHandler.ts
@@ -5,6 +5,13 @@ import { BotConfigurationManager } from '@config/BotConfigurationManager';
 import { DatabaseManager } from '../../database/DatabaseManager';
 import { type CommandHandler } from './CommandHandler';
 
+interface AddBotOptions {
+  name?: string;
+  provider?: string;
+  llm?: string;
+  token?: string;
+}
+
 export class BotCommandHandler implements CommandHandler {
   private configManager: BotConfigurationManager;
   private dbManager: DatabaseManager;
@@ -90,7 +97,7 @@ export class BotCommandHandler implements CommandHandler {
       });
   }
 
-  private async addBot(options: any): Promise<void> {
+  private async addBot(options: AddBotOptions): Promise<void> {
     console.log(chalk.blue('Adding new bot...'));
 
     if (!options.name || !options.provider || !options.llm) {
@@ -111,7 +118,7 @@ export class BotCommandHandler implements CommandHandler {
         type: 'input',
         name: 'name',
         message: 'Bot name:',
-        validate: (input: string) => input.trim().length > 0 || 'Name is required',
+        validate: (input: string): true | string => input.trim().length > 0 || 'Name is required',
       },
       {
         type: 'list',
@@ -152,7 +159,8 @@ export class BotCommandHandler implements CommandHandler {
 
       if (verbose) {
         console.log(`   Enabled: ${bot.enabled ? chalk.green('Yes') : chalk.red('No')}`);
-        console.log(`   Created: ${(bot as any).createdAt || 'Unknown'}`);
+        const createdAt = typeof bot.createdAt === 'string' ? bot.createdAt : 'Unknown';
+        console.log(`   Created: ${createdAt}`);
       }
       console.log();
     });

--- a/src/cli/handlers/ServerCommandHandler.ts
+++ b/src/cli/handlers/ServerCommandHandler.ts
@@ -2,6 +2,12 @@ import chalk from 'chalk';
 import { type Command } from 'commander';
 import { type CommandHandler } from './CommandHandler';
 
+interface StartServerOptions {
+  port: string;
+  config?: string;
+  daemon?: boolean;
+}
+
 export class ServerCommandHandler implements CommandHandler {
   public setup(program: Command): void {
     program
@@ -48,7 +54,7 @@ export class ServerCommandHandler implements CommandHandler {
       });
   }
 
-  private async startServer(options: any): Promise<void> {
+  private async startServer(options: StartServerOptions): Promise<void> {
     console.log(chalk.blue(`Starting Hivemind server on port ${options.port}...`));
 
     if (options.daemon) {

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -24,7 +24,7 @@
     "@types/react-redux": "^7.1.34",
     "classnames": "^2.5.1",
     "daisyui": "^5.1.25",
-    "dompurify": "^3.3.1",
+    "dompurify": "^3.4.0",
     "framer-motion": "^12.34.3",
     "lucide-react": "^0.460.0",
     "prop-types": "^15.8.1",

--- a/src/common/ErrorUtils.ts
+++ b/src/common/ErrorUtils.ts
@@ -6,7 +6,7 @@ export interface HivemindError {
   code?: string;
   statusCode?: number;
   originalError?: Error;
-  context?: Record<string, any>;
+  context?: Record<string, unknown>;
 }
 
 export const ErrorClassification = {
@@ -50,12 +50,17 @@ export class ErrorUtils {
    * @param context - Additional context information.
    * @returns A standardized HivemindError object.
    */
-  public static toHivemindError(error: unknown, context?: Record<string, any>): HivemindError {
+  public static toHivemindError(error: unknown, context?: Record<string, unknown>): HivemindError {
     if (error instanceof Error) {
+      const typedError = error as Error & {
+        code?: string;
+        statusCode?: number;
+        status?: number;
+      };
       return {
         message: error.message,
-        code: (error as any).code,
-        statusCode: (error as any).statusCode || (error as any).status,
+        code: typedError.code,
+        statusCode: typedError.statusCode || typedError.status,
         originalError: error,
         context,
       };


### PR DESCRIPTION
Summary:
- fix lint/type errors that were failing CI Fast
- remove any usage in touched files and add explicit function return typing
- bump vulnerable dependencies and overrides (dompurify, hono, basic-ftp, ajv, smol-toml)
- refresh lockfile

Validation:
- pnpm run lint (0 errors)
- pnpm audit --audit-level=moderate (no moderate/high/critical; 2 low remain)
