### PR TITLE
chore(ci): add concurrency cancellation and workflow linting

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,6 +7,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: ci-cd-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -7,6 +7,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: ci-fast-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   code-quality:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,10 @@ on:
     types: [opened, synchronize]
   workflow_dispatch:
 
+concurrency:
+  group: deploy-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,6 +7,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: integration-tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   integration-api:
     runs-on: ubuntu-latest

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: playwright-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,6 +7,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: unit-tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests-core:
     runs-on: ubuntu-latest

--- a/.github/workflows/websocket-tests.yml
+++ b/.github/workflows/websocket-tests.yml
@@ -7,6 +7,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: websocket-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   websocket-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,26 @@
+name: Workflow Lint
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - ".github/workflows/**"
+  push:
+    branches: [ main ]
+    paths:
+      - ".github/workflows/**"
+  workflow_dispatch:
+
+concurrency:
+  group: workflow-lint-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1

--- a/docs/reference/ci-hardening.md
+++ b/docs/reference/ci-hardening.md
@@ -27,3 +27,8 @@
 
 - PR fast CI runs `pnpm run test:changed`.
 - This selects and runs related tests for changed files to shorten feedback loops.
+
+## Extra Hardening
+
+- Key workflows use `concurrency` with `cancel-in-progress: true` to avoid redundant runs.
+- Workflow linting runs via `.github/workflows/workflow-lint.yml` using `actionlint`.


### PR DESCRIPTION
Summary:
- add workflow-level concurrency with cancel-in-progress for core CI pipelines
- add workflow-lint workflow using actionlint for .github/workflows changes
- update CI hardening docs with these extra safeguards

Why:
- reduces redundant/queued CI runs on rapid pushes
- catches workflow syntax/logic mistakes earlier
