### PR TITLE
chore(ci): add dashboard triage docs, flaky expiry policy, and weekly health report

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -53,6 +53,10 @@ jobs:
         if: github.event_name == 'push'
         run: pnpm audit --audit-level=high --production
 
+      - name: Enforce flaky quarantine policy
+        if: github.event_name == 'pull_request'
+        run: pnpm run test:flaky:policy
+
       - name: Run quarantined flaky tests (non-blocking)
         if: github.event_name == 'pull_request'
         continue-on-error: true

--- a/.github/workflows/ci-health-weekly.yml
+++ b/.github/workflows/ci-health-weekly.yml
@@ -1,0 +1,130 @@
+name: CI Health Weekly Report
+
+on:
+  schedule:
+    - cron: "30 2 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ci-health-weekly-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build weekly CI health report
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueTitle = 'CI Health Weekly Report';
+            const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+            const sinceDate = since.toISOString().slice(0, 10);
+
+            const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+              owner,
+              repo,
+              per_page: 100,
+              created: `>=${sinceDate}`
+            });
+
+            const mainRuns = runs.filter((run) => run.head_branch === 'main');
+            const total = mainRuns.length;
+
+            const counts = {
+              success: 0,
+              failure: 0,
+              cancelled: 0,
+              neutral: 0,
+              skipped: 0,
+              timed_out: 0,
+              action_required: 0
+            };
+
+            const failingByWorkflow = new Map();
+            const durations = [];
+
+            for (const run of mainRuns) {
+              const conclusion = run.conclusion || 'neutral';
+              counts[conclusion] = (counts[conclusion] || 0) + 1;
+
+              if (conclusion === 'failure' || conclusion === 'timed_out') {
+                const name = run.name || 'unknown';
+                failingByWorkflow.set(name, (failingByWorkflow.get(name) || 0) + 1);
+              }
+
+              const start = run.run_started_at || run.created_at;
+              const end = run.updated_at || run.created_at;
+              const ms = new Date(end).getTime() - new Date(start).getTime();
+              if (Number.isFinite(ms) && ms > 0) durations.push(ms);
+            }
+
+            const successRate = total > 0 ? ((counts.success / total) * 100).toFixed(1) : '0.0';
+            durations.sort((a, b) => a - b);
+            const medianMs =
+              durations.length === 0
+                ? 0
+                : durations[Math.floor(durations.length / 2)];
+            const medianMin = (medianMs / 60000).toFixed(1);
+
+            const topFailing = [...failingByWorkflow.entries()]
+              .sort((a, b) => b[1] - a[1])
+              .slice(0, 5);
+
+            const topFailingText =
+              topFailing.length === 0
+                ? '- none'
+                : topFailing.map(([name, count]) => `- ${name}: ${count}`).join('\n');
+
+            const reportBody = [
+              `## Weekly CI Health (${sinceDate} to ${new Date().toISOString().slice(0, 10)})`,
+              '',
+              `- Total runs on \`main\`: ${total}`,
+              `- Success rate: ${successRate}%`,
+              `- Median duration: ${medianMin} min`,
+              '',
+              '### Outcome Breakdown',
+              `- success: ${counts.success || 0}`,
+              `- failure: ${counts.failure || 0}`,
+              `- timed_out: ${counts.timed_out || 0}`,
+              `- cancelled: ${counts.cancelled || 0}`,
+              `- skipped: ${counts.skipped || 0}`,
+              '',
+              '### Top Failing Workflows',
+              topFailingText,
+              '',
+              `Actions: https://github.com/${owner}/${repo}/actions`
+            ].join('\n');
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100
+            });
+
+            let issue = issues.find((i) => i.title === issueTitle);
+            if (!issue) {
+              issue = (
+                await github.rest.issues.create({
+                  owner,
+                  repo,
+                  title: issueTitle,
+                  body: 'Automated weekly CI health reports.'
+                })
+              ).data;
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: issue.number,
+              body: reportBody
+            });

--- a/docs/reference/ci-hardening.md
+++ b/docs/reference/ci-hardening.md
@@ -1,5 +1,22 @@
 # CI Hardening Notes
 
+## CI Dashboard
+
+Workflow links:
+- [Workflow Lint](../../.github/workflows/workflow-lint.yml)
+- [CI Fast (Build & Quality)](../../.github/workflows/ci-fast.yml)
+- [Unit Tests](../../.github/workflows/unit-tests.yml)
+- [Integration Tests](../../.github/workflows/integration-tests.yml)
+- [Playwright Tests](../../.github/workflows/playwright.yml)
+- [CI Health Weekly Report](../../.github/workflows/ci-health-weekly.yml)
+
+Triage order:
+1. `workflow-lint`
+2. `ci-fast`
+3. `unit-tests`
+4. `integration-tests`
+5. `playwright`
+
 ## Lint Warning Baseline
 
 - CI uses `pnpm run lint:gate` to fail only on _new_ ESLint warnings.
@@ -21,7 +38,11 @@
 
 - Quarantined list: `tests/flaky-tests.txt`
 - Runner: `pnpm run test:flaky:quarantine`
-- CI runs this in non-blocking mode and uploads a summary artifact.
+- Policy check: `pnpm run test:flaky:policy` (blocking on PRs)
+- CI runs quarantine tests in non-blocking mode and uploads a summary artifact.
+- Entry format:
+  - `testPath | owner=@team-or-user | expires=YYYY-MM-DD | reason=short note`
+- Expired entries fail CI and must be removed or extended with justification.
 
 ## Changed-File Test Selection
 
@@ -32,3 +53,4 @@
 
 - Key workflows use `concurrency` with `cancel-in-progress: true` to avoid redundant runs.
 - Workflow linting runs via `.github/workflows/workflow-lint.yml` using `actionlint`.
+- Weekly CI health reports are posted by `.github/workflows/ci-health-weekly.yml`.

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "test:only:backend": "npm run test",
     "test:only:frontend": "cd src/client && npx vitest run",
     "test:changed": "bash scripts/ci/run-changed-tests.sh",
-    "test:flaky:quarantine": "node scripts/ci/run-flaky-tests.js"
+    "test:flaky:quarantine": "node scripts/ci/run-flaky-tests.js",
+    "test:flaky:policy": "node scripts/ci/check-flaky-policy.js"
   },
   "_moduleAliases": {
     "@src": "dist/src",

--- a/scripts/ci/check-flaky-policy.js
+++ b/scripts/ci/check-flaky-policy.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+const fs = require('fs');
+
+const LIST_PATH = 'tests/flaky-tests.txt';
+
+function parseEntry(line) {
+  const parts = line.split('|').map((p) => p.trim()).filter(Boolean);
+  const testPath = parts[0] || '';
+  const metadata = {};
+  for (const part of parts.slice(1)) {
+    const idx = part.indexOf('=');
+    if (idx === -1) continue;
+    const key = part.slice(0, idx).trim();
+    const value = part.slice(idx + 1).trim();
+    metadata[key] = value;
+  }
+  return {
+    testPath,
+    owner: metadata.owner || '',
+    expires: metadata.expires || '',
+    reason: metadata.reason || '',
+  };
+}
+
+if (!fs.existsSync(LIST_PATH)) {
+  console.log(`${LIST_PATH} not found. Policy check skipped.`);
+  process.exit(0);
+}
+
+const lines = fs
+  .readFileSync(LIST_PATH, 'utf8')
+  .split('\n')
+  .map((line) => line.trim())
+  .filter((line) => line && !line.startsWith('#'));
+
+if (lines.length === 0) {
+  console.log('No flaky entries found. Policy check passed.');
+  process.exit(0);
+}
+
+const todayIso = new Date().toISOString().slice(0, 10);
+let violations = 0;
+
+for (const line of lines) {
+  const entry = parseEntry(line);
+  if (!entry.testPath) {
+    console.error(`Invalid flaky entry: ${line}`);
+    violations += 1;
+    continue;
+  }
+  if (!entry.owner) {
+    console.error(`Missing owner for flaky entry: ${entry.testPath}`);
+    violations += 1;
+  }
+  if (!entry.expires || !/^\d{4}-\d{2}-\d{2}$/.test(entry.expires)) {
+    console.error(`Missing/invalid expires (YYYY-MM-DD) for flaky entry: ${entry.testPath}`);
+    violations += 1;
+    continue;
+  }
+  if (entry.expires < todayIso) {
+    console.error(
+      `Expired flaky entry: ${entry.testPath} (owner=${entry.owner || 'unknown'}, expires=${entry.expires})`
+    );
+    violations += 1;
+  }
+}
+
+if (violations > 0) {
+  console.error(`Flaky policy check failed with ${violations} violation(s).`);
+  process.exit(1);
+}
+
+console.log('Flaky policy check passed.');

--- a/scripts/ci/run-flaky-tests.js
+++ b/scripts/ci/run-flaky-tests.js
@@ -6,18 +6,39 @@ const { spawnSync } = require('child_process');
 const LIST_PATH = 'tests/flaky-tests.txt';
 const MAX_RETRIES = Number(process.env.FLAKY_TEST_RETRIES || 2);
 
+function parseEntry(line) {
+  const parts = line.split('|').map((p) => p.trim()).filter(Boolean);
+  const testPath = parts[0] || '';
+  const metadata = {};
+  for (const part of parts.slice(1)) {
+    const idx = part.indexOf('=');
+    if (idx === -1) continue;
+    const key = part.slice(0, idx).trim();
+    const value = part.slice(idx + 1).trim();
+    metadata[key] = value;
+  }
+  return {
+    testPath,
+    owner: metadata.owner || '',
+    expires: metadata.expires || '',
+    reason: metadata.reason || '',
+  };
+}
+
 if (!fs.existsSync(LIST_PATH)) {
   console.log(`${LIST_PATH} not found. Nothing to run.`);
   process.exit(0);
 }
 
-const tests = fs
+const entries = fs
   .readFileSync(LIST_PATH, 'utf8')
   .split('\n')
   .map((line) => line.trim())
-  .filter((line) => line && !line.startsWith('#'));
+  .filter((line) => line && !line.startsWith('#'))
+  .map(parseEntry)
+  .filter((entry) => entry.testPath);
 
-if (tests.length === 0) {
+if (entries.length === 0) {
   console.log('No flaky tests listed. Nothing to run.');
   process.exit(0);
 }
@@ -25,7 +46,8 @@ if (tests.length === 0) {
 const summary = [];
 let failures = 0;
 
-for (const testPath of tests) {
+for (const entry of entries) {
+  const testPath = entry.testPath;
   let passed = false;
   let attempts = 0;
   for (let i = 0; i <= MAX_RETRIES; i += 1) {
@@ -53,7 +75,14 @@ for (const testPath of tests) {
     }
   }
 
-  summary.push({ testPath, passed, attempts });
+  summary.push({
+    testPath,
+    owner: entry.owner,
+    expires: entry.expires,
+    reason: entry.reason,
+    passed,
+    attempts,
+  });
   if (!passed) failures += 1;
 }
 

--- a/tests/flaky-tests.txt
+++ b/tests/flaky-tests.txt
@@ -1,4 +1,6 @@
 # Quarantined flaky tests (non-blocking).
 # Keep this list short and move tests out once stabilized.
+# Format:
+# testPath | owner=@team-or-user | expires=YYYY-MM-DD | reason=short note
 
-tests/integration/MonitoringPipeline.test.ts
+tests/integration/MonitoringPipeline.test.ts | owner=@platform-ci | expires=2026-05-15 | reason=intermittent timing variance under CI load


### PR DESCRIPTION
Summary:
- add CI dashboard/triage order section with key workflow links
- enforce flaky quarantine metadata policy (owner + expires) with blocking PR check
- keep flaky quarantine test execution non-blocking with richer summary metadata
- add weekly CI health report workflow that posts summary comments to a tracking issue

Validation:
- pnpm run test:flaky:policy
- pnpm run test:flaky:quarantine
