### PR TITLE
🎨 Palette: Add ARIA labels to dashboard widget move buttons

### DIFF
--- a/src/client/src/components/Dashboard.tsx
+++ b/src/client/src/components/Dashboard.tsx
@@ -254,8 +254,8 @@ const Dashboard: React.FC = () => {
   const renderWidget = (type: string, index: number) => {
     const controls = isCustomizing && (
       <div className="flex gap-1 mb-2">
-         <Button size="xs" variant="ghost" onClick={() => moveWidget(index, 'up')} disabled={index === 0}><ArrowUp className="w-3 h-3" /></Button>
-         <Button size="xs" variant="ghost" onClick={() => moveWidget(index, 'down')} disabled={index === layout.length - 1}><ArrowDown className="w-3 h-3" /></Button>
+         <Button size="xs" variant="ghost" aria-label={`Move ${type} widget up`} onClick={() => moveWidget(index, 'up')} disabled={index === 0}><ArrowUp className="w-3 h-3" /></Button>
+         <Button size="xs" variant="ghost" aria-label={`Move ${type} widget down`} onClick={() => moveWidget(index, 'down')} disabled={index === layout.length - 1}><ArrowDown className="w-3 h-3" /></Button>
       </div>
     );
 


### PR DESCRIPTION
🎨 Palette: [UX improvement]

💡 What: Added contextual `aria-label` attributes to the ArrowUp and ArrowDown buttons within the Dashboard component.
🎯 Why: To improve screen reader accessibility by providing specific context (e.g., "Move stats widget up") when reordering widgets, as the icon-only buttons lacked accessible names.
♿ Accessibility: Provides explicit, item-specific names for layout control buttons, allowing screen reader users to understand exactly which widget they are moving.

---
*PR created automatically by Jules for task [9591475445052588534](https://jules.google.com/task/9591475445052588534) started by @matthewhand*