### PR TITLE
fix(security): require strict schema on POST /api/webui/config

### DIFF
--- a/src/server/routes/webui.ts
+++ b/src/server/routes/webui.ts
@@ -4,6 +4,8 @@ import { Router } from 'express';
 import { MetricsCollector } from '../../monitoring/MetricsCollector';
 import { providerRegistry } from '../../registries/ProviderRegistry';
 import { webUIStorage } from '../../storage/webUIStorage';
+import { WebuiConfigUpdateSchema } from '../../validation/schemas/configSchema';
+import { validateRequest } from '../../validation/validateRequest';
 
 const router = Router();
 
@@ -17,11 +19,15 @@ router.get('/config', async (_req, res) => {
   }
 });
 
-// POST /config - Update the WebUI configuration
-router.post('/config', async (req, res) => {
+// POST /config - Update the WebUI configuration (dashboard layout / user preferences only)
+router.post('/config', validateRequest(WebuiConfigUpdateSchema), async (req, res) => {
   try {
+    const { layout } = req.body as { layout?: string[] };
     const currentConfig = await webUIStorage.loadConfig();
-    const newConfig = { ...currentConfig, ...req.body };
+    const newConfig = { ...currentConfig };
+    if (layout !== undefined) {
+      newConfig.layout = layout;
+    }
     await webUIStorage.saveConfig(newConfig);
     return res.json({ success: true, config: newConfig });
   } catch (_error) {

--- a/src/validation/schemas/configSchema.ts
+++ b/src/validation/schemas/configSchema.ts
@@ -11,6 +11,18 @@ export const ConfigUpdateSchema = z.object({
     .catchall(z.any()), // Allow additional properties for direct update format
 });
 
+// Schema for POST /api/webui/config — the dashboard layout / user-preference endpoint.
+// Only fields safe for any authenticated user are permitted. Provider/agent arrays
+// (agents, mcpServers, llmProviders, messengerProviders, personas, guards) are
+// intentionally excluded to prevent config poisoning. Unknown keys are rejected.
+export const WebuiConfigUpdateSchema = z.object({
+  body: z
+    .object({
+      layout: z.array(z.string().min(1).max(100)).max(50).optional(),
+    })
+    .strict(),
+});
+
 // Schema for restoring configuration from backup
 export const ConfigRestoreSchema = z.object({
   body: z.object({

--- a/tests/unit/routes/webui.test.ts
+++ b/tests/unit/routes/webui.test.ts
@@ -1,0 +1,114 @@
+import express from 'express';
+import request from 'supertest';
+import router from '../../../src/server/routes/webui';
+import { webUIStorage } from '../../../src/storage/webUIStorage';
+
+jest.mock('../../../src/storage/webUIStorage', () => ({
+  webUIStorage: {
+    loadConfig: jest.fn(),
+    saveConfig: jest.fn(),
+  },
+}));
+
+const mockedStorage = webUIStorage as jest.Mocked<typeof webUIStorage>;
+
+describe('POST /api/webui/config — privilege-escalation guard', () => {
+  let app: express.Application;
+
+  const baseConfig = {
+    agents: [{ id: 'existing-agent' }],
+    mcpServers: [{ name: 'existing-mcp' }],
+    llmProviders: [{ id: 'existing-llm' }],
+    messengerProviders: [],
+    personas: [],
+    guards: [],
+    layout: ['stats'],
+    lastUpdated: '2024-01-01T00:00:00.000Z',
+  };
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+    jest.clearAllMocks();
+    mockedStorage.loadConfig.mockResolvedValue({ ...baseConfig } as any);
+    mockedStorage.saveConfig.mockResolvedValue(undefined as any);
+  });
+
+  it('rejects requests that try to overwrite llmProviders with 400', async () => {
+    const res = await request(app)
+      .post('/config')
+      .send({ llmProviders: [{ id: 'attacker-llm', apiKey: 'pwned' }] });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error', 'Validation failed');
+    expect(mockedStorage.saveConfig).not.toHaveBeenCalled();
+  });
+
+  it('rejects requests that try to overwrite agents with 400', async () => {
+    const res = await request(app)
+      .post('/config')
+      .send({ agents: [{ id: 'attacker-agent' }] });
+
+    expect(res.status).toBe(400);
+    expect(mockedStorage.saveConfig).not.toHaveBeenCalled();
+  });
+
+  it('rejects requests that try to overwrite mcpServers with 400', async () => {
+    const res = await request(app)
+      .post('/config')
+      .send({ mcpServers: [{ name: 'attacker-mcp' }] });
+
+    expect(res.status).toBe(400);
+    expect(mockedStorage.saveConfig).not.toHaveBeenCalled();
+  });
+
+  it('rejects requests that smuggle layout alongside forbidden keys with 400', async () => {
+    const res = await request(app)
+      .post('/config')
+      .send({
+        layout: ['stats'],
+        llmProviders: [{ id: 'attacker-llm' }],
+      });
+
+    expect(res.status).toBe(400);
+    expect(mockedStorage.saveConfig).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown keys with 400', async () => {
+    const res = await request(app)
+      .post('/config')
+      .send({ somethingElse: 'evil' });
+
+    expect(res.status).toBe(400);
+    expect(mockedStorage.saveConfig).not.toHaveBeenCalled();
+  });
+
+  it('accepts a valid dashboard-layout request and persists only layout', async () => {
+    const res = await request(app)
+      .post('/config')
+      .send({ layout: ['stats', 'agents', 'command-stream'] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(mockedStorage.saveConfig).toHaveBeenCalledTimes(1);
+
+    const saved = mockedStorage.saveConfig.mock.calls[0][0] as any;
+    expect(saved.layout).toEqual(['stats', 'agents', 'command-stream']);
+    // Existing sensitive sections must be preserved, not overwritten
+    expect(saved.agents).toEqual(baseConfig.agents);
+    expect(saved.mcpServers).toEqual(baseConfig.mcpServers);
+    expect(saved.llmProviders).toEqual(baseConfig.llmProviders);
+  });
+
+  it('accepts an empty body and leaves config unchanged', async () => {
+    const res = await request(app).post('/config').send({});
+
+    expect(res.status).toBe(200);
+    expect(mockedStorage.saveConfig).toHaveBeenCalledTimes(1);
+    const saved = mockedStorage.saveConfig.mock.calls[0][0] as any;
+    expect(saved.agents).toEqual(baseConfig.agents);
+    expect(saved.llmProviders).toEqual(baseConfig.llmProviders);
+    expect(saved.layout).toEqual(baseConfig.layout);
+  });
+});


### PR DESCRIPTION
## Summary

- `POST /api/webui/config` previously spread `req.body` into the persisted config, letting any authenticated user overwrite `agents`, `mcpServers`, `llmProviders`, and other provider/agent sections — config poisoning / privilege escalation.
- Added a strict Zod schema (`WebuiConfigUpdateSchema`) that only permits the `layout` field and rejects unknown keys with 400.
- Handler now picks `layout` explicitly instead of spreading `req.body`.
- New test suite `tests/unit/routes/webui.test.ts` covers 7 scenarios including smuggled-key rejection and preservation of sensitive sections on valid requests.

## Test plan

- [x] Unit tests pass: `npm test -- tests/unit/routes/webui.test.ts`
- [ ] Manual smoke: `POST /api/webui/config` with `{ "layout": ["stats"] }` → 200; with `{ "llmProviders": [...] }` → 400