### PR TITLE
fix(security): surface encryption failures instead of silently storing plaintext

### DIFF
--- a/src/database/EncryptionService.ts
+++ b/src/database/EncryptionService.ts
@@ -28,19 +28,19 @@ export class EncryptionService {
 
   private initializeKey(): void {
     const configKey = databaseConfig.get('ENCRYPTION_KEY');
-    
+
     if (configKey) {
-      // Use env/config key (must be 32 bytes for AES-256, or we hash it)
       this.encryptionKey = crypto.createHash('sha256').update(configKey).digest();
       debug('Encryption key initialized from configuration');
     } else {
-      // Fallback to SecureConfigManager's .key file for consistency
       const keyPath = path.join(process.cwd(), 'config', '.key');
       if (fs.existsSync(keyPath)) {
         this.encryptionKey = fs.readFileSync(keyPath);
         debug('Encryption key initialized from .key file');
       } else {
-        debug('WARNING: No database encryption key found. Sensitive fields will be stored in PLAIN TEXT.');
+        console.warn(
+          '[SECURITY] DATABASE_ENCRYPTION_KEY not configured — sensitive fields will be stored in plaintext. Set DATABASE_ENCRYPTION_KEY to enable at-rest encryption.'
+        );
       }
     }
   }
@@ -56,20 +56,15 @@ export class EncryptionService {
   public encrypt(text: string): string {
     if (!this.encryptionKey) return text;
 
-    try {
-      const iv = crypto.randomBytes(16);
-      const cipher = crypto.createCipheriv(this.algorithm, this.encryptionKey, iv);
-      
-      let encrypted = cipher.update(text, 'utf8', 'hex');
-      encrypted += cipher.final('hex');
-      
-      const authTag = cipher.getAuthTag().toString('hex');
-      
-      return `enc:${iv.toString('hex')}:${authTag}:${encrypted}`;
-    } catch (error) {
-      debug('Encryption failed:', error);
-      return text;
-    }
+    const iv = crypto.randomBytes(16);
+    const cipher = crypto.createCipheriv(this.algorithm, this.encryptionKey, iv);
+
+    let encrypted = cipher.update(text, 'utf8', 'hex');
+    encrypted += cipher.final('hex');
+
+    const authTag = cipher.getAuthTag().toString('hex');
+
+    return `enc:${iv.toString('hex')}:${authTag}:${encrypted}`;
   }
 
   /**
@@ -78,27 +73,23 @@ export class EncryptionService {
   public decrypt(text: string): string {
     if (!this.encryptionKey || !text.startsWith('enc:')) return text;
 
-    try {
-      const parts = text.split(':');
-      if (parts.length !== 4) return text;
-
-      const [, ivHex, authTagHex, encryptedText] = parts;
-      
-      const iv = Buffer.from(ivHex, 'hex');
-      const authTag = Buffer.from(authTagHex, 'hex');
-      const decipher = crypto.createDecipheriv(this.algorithm, this.encryptionKey, iv);
-      
-      decipher.setAuthTag(authTag);
-      
-      let decrypted = decipher.update(encryptedText, 'hex', 'utf8');
-      decrypted += decipher.final('utf8');
-      
-      return decrypted;
-    } catch (error) {
-      debug('Decryption failed (check your key):', error);
-      // Return the original text if decryption fails (might be plain text or wrong key)
-      return text;
+    const parts = text.split(':');
+    if (parts.length !== 4) {
+      throw new Error('Malformed encrypted value: expected 4 colon-delimited segments');
     }
+
+    const [, ivHex, authTagHex, encryptedText] = parts;
+
+    const iv = Buffer.from(ivHex, 'hex');
+    const authTag = Buffer.from(authTagHex, 'hex');
+    const decipher = crypto.createDecipheriv(this.algorithm, this.encryptionKey, iv);
+
+    decipher.setAuthTag(authTag);
+
+    let decrypted = decipher.update(encryptedText, 'hex', 'utf8');
+    decrypted += decipher.final('utf8');
+
+    return decrypted;
   }
 }
 

--- a/tests/database/Encryption.test.ts
+++ b/tests/database/Encryption.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 import { BotConfigRepository } from '../../src/database/repositories/BotConfigRepository';
-import { encryptionService } from '../../src/database/EncryptionService';
+import { encryptionService, EncryptionService } from '../../src/database/EncryptionService';
 import { IDatabase } from '../../src/database/types';
 
 describe('Database At-Rest Encryption', () => {
@@ -39,7 +39,7 @@ describe('Database At-Rest Encryption', () => {
 
   it('should decrypt sensitive fields on retrieval', async () => {
     const encryptedData = encryptionService.encrypt(JSON.stringify({ apiKey: 'sk-secret' }));
-    
+
     const mockRow = {
       id: 1,
       name: 'SecureBot',
@@ -55,9 +55,9 @@ describe('Database At-Rest Encryption', () => {
     expect(result.openai).toEqual({ apiKey: 'sk-secret' });
   });
 
-  it('should handle legacy plain text data (graceful fallback)', async () => {
+  it('should pass through legacy plain text data (no enc: prefix)', async () => {
     const plainData = JSON.stringify({ apiKey: 'sk-legacy' });
-    
+
     const mockRow = {
       id: 2,
       name: 'LegacyBot',
@@ -71,5 +71,102 @@ describe('Database At-Rest Encryption', () => {
     const result = repository.mapRowToBotConfiguration(mockRow);
 
     expect(result.openai).toEqual({ apiKey: 'sk-legacy' });
+  });
+});
+
+describe('EncryptionService failure modes', () => {
+  const getInstance = (): EncryptionService => {
+    // @ts-ignore - reset singleton for isolated tests
+    EncryptionService.instance = undefined;
+    return EncryptionService.getInstance();
+  };
+
+  it('encrypt throws (does not silently return plaintext) when the cipher fails', () => {
+    const service = encryptionService;
+    // Sanity-check key is initialized from the test environment's .key file or env var.
+    // Force a failure by monkey-patching crypto.createCipheriv.
+    const crypto = require('crypto');
+    const originalCreateCipheriv = crypto.createCipheriv;
+    crypto.createCipheriv = () => {
+      throw new Error('forced cipher failure');
+    };
+
+    try {
+      if (service.isEnabled()) {
+        expect(() => service.encrypt('super-secret-api-key')).toThrow('forced cipher failure');
+      } else {
+        // When no key is configured, encrypt is a pass-through by design; skip.
+        expect(service.encrypt('x')).toBe('x');
+      }
+    } finally {
+      crypto.createCipheriv = originalCreateCipheriv;
+    }
+  });
+
+  it('decrypt throws when the ciphertext has been tampered with', () => {
+    const service = encryptionService;
+    if (!service.isEnabled()) {
+      // Without a key, decrypt is a pass-through; this test is only meaningful when encryption is enabled.
+      return;
+    }
+
+    const valid = service.encrypt('hello world');
+    // Flip one hex character in the encrypted payload segment to trigger GCM auth-tag failure.
+    const parts = valid.split(':');
+    const payload = parts[3];
+    const tamperedChar = payload[0] === '0' ? '1' : '0';
+    parts[3] = tamperedChar + payload.slice(1);
+    const tampered = parts.join(':');
+
+    expect(() => service.decrypt(tampered)).toThrow();
+  });
+
+  it('decrypt throws on a malformed enc: value (wrong segment count)', () => {
+    const service = encryptionService;
+    if (!service.isEnabled()) {
+      return;
+    }
+
+    expect(() => service.decrypt('enc:not-enough-parts')).toThrow(/Malformed encrypted value/);
+  });
+
+  it('logs a prominent console.warn at init when no encryption key is configured', () => {
+    const path = require('path');
+    const fs = require('fs');
+    const databaseConfig = require('../../src/config/databaseConfig').default;
+
+    const originalGet = databaseConfig.get.bind(databaseConfig);
+    const getSpy = jest.spyOn(databaseConfig, 'get').mockImplementation((...args: any[]) => {
+      if (args[0] === 'ENCRYPTION_KEY') return '';
+      return originalGet(...args);
+    });
+
+    const keyPath = path.join(process.cwd(), 'config', '.key');
+    const existsSpy = jest.spyOn(fs, 'existsSync').mockImplementation((p: any) => {
+      if (p === keyPath) return false;
+      // @ts-ignore
+      return jest.requireActual('fs').existsSync(p);
+    });
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      // @ts-ignore - reset singleton
+      EncryptionService.instance = undefined;
+      EncryptionService.getInstance();
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const msg = warnSpy.mock.calls[0][0];
+      expect(msg).toContain('[SECURITY]');
+      expect(msg).toContain('DATABASE_ENCRYPTION_KEY');
+      expect(msg).toContain('plaintext');
+    } finally {
+      warnSpy.mockRestore();
+      existsSpy.mockRestore();
+      getSpy.mockRestore();
+      // @ts-ignore - restore a fresh, normal singleton for other tests
+      EncryptionService.instance = undefined;
+      EncryptionService.getInstance();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- `EncryptionService.encrypt()` previously caught all cipher errors and returned plaintext, so a broken cipher config would silently persist API keys unencrypted on disk with zero signal to the operator.
- `EncryptionService.decrypt()` silently returned the raw text on GCM auth-tag mismatch, masking tampering and wrong-key scenarios.
- Missing `DATABASE_ENCRYPTION_KEY` only emitted a `debug()` log that most operators never see.

Changes:
- `encrypt()` no longer catches — errors propagate, write fails safely rather than silently landing plaintext.
- `decrypt()` throws on tampered ciphertext and malformed enc: values. Non-encrypted values still pass through for legacy migration.
- Init now emits `console.warn('[SECURITY] DATABASE_ENCRYPTION_KEY not configured — sensitive fields will be stored in plaintext...')` when no key is configured.

## Test plan

- [x] `encrypt` throws when cipher fails (monkey-patched `createCipheriv`)
- [x] `decrypt` throws on tampered GCM ciphertext
- [x] `decrypt` throws on malformed enc: value (wrong segment count)
- [x] Init logs a prominent `console.warn` when no key found
- [ ] Existing at-rest encryption round-trip tests still pass