### PR TITLE
fix: address review follow-ups from #2631/#2632/#2633

### DIFF
--- a/src/client/src/components/DaisyUI/DashboardWidgetSystem.tsx
+++ b/src/client/src/components/DaisyUI/DashboardWidgetSystem.tsx
@@ -373,23 +373,18 @@ const DashboardWidgetSystem: React.FC<DashboardWidgetSystemProps> = ({
     setWidgets(prev => prev.filter(w => w.id !== id));
   }, []);
 
-  const widgetPositionMap = useMemo(
-    () => new Map(widgets.map(w => [w.id, w.position])),
-    [widgets],
-  );
-
   const handleMouseDown = useCallback((e: React.MouseEvent, widgetId: string) => {
     if (!isEditing) {return;}
 
-    const position = widgetPositionMap.get(widgetId);
-    if (!position) {return;}
+    const widget = widgets.find(w => w.id === widgetId);
+    if (!widget) {return;}
 
     setDraggedWidget(widgetId);
     setDragOffset({
-      x: e.clientX - position.x,
-      y: e.clientY - position.y,
+      x: e.clientX - widget.position.x,
+      y: e.clientY - widget.position.y,
     });
-  }, [isEditing, widgetPositionMap]);
+  }, [isEditing, widgets]);
 
   const handleMouseMove = useCallback((e: MouseEvent) => {
     if (!draggedWidget || !isEditing) {return;}

--- a/src/database/repositories/BotConfigRepository.ts
+++ b/src/database/repositories/BotConfigRepository.ts
@@ -489,7 +489,15 @@ export class BotConfigRepository {
   }
 
   private mapRowToBotConfigurationAudit(row: Record<string, unknown>): BotConfigurationAudit {
-    const decryptVal = (val: any) => val ? encryptionService.decrypt(String(val)) : val;
+    const decryptVal = (val: any) => {
+      if (!val) return val;
+      try {
+        return encryptionService.decrypt(String(val));
+      } catch (error) {
+        debug('Failed to decrypt audit row field (id=%s): %O', row.id, error);
+        return null;
+      }
+    };
 
     return {
       id: row.id as number | undefined,

--- a/src/server/registerRoutes.ts
+++ b/src/server/registerRoutes.ts
@@ -146,7 +146,7 @@ export function registerRoutes(app: import('express').Application, ctx: RouteCon
   app.use('/api/templates', templatesRouter);
   app.use('/api/usage-tracking', usageTrackingRouter);
   app.use('/api/webhooks', webhooksRouter);
-  app.use('/api/webui', webuiRouter);
+  app.use('/api/webui', authenticateToken, webuiRouter);
   app.use('/api/demo', demoRouter);
   app.use('/api/docs', apiDocsRouter);
   app.use('/api/pluginSecurity', pluginSecurityRouter);


### PR DESCRIPTION
## Summary

Three small fixes surfaced by the post-merge reviews of the consolidation PRs.

### 1. auth: require `authenticateToken` on `/api/webui` mount

`#2631` strictified `POST /api/webui/config` but the entire `/api/webui` router mount at `src/server/registerRoutes.ts:149` had no authentication wrapper. Every sibling mount (`/api/guards`, `/api/specs`, `/api/monitoring`, `/api/import-export`, etc.) already requires `authenticateToken`. After this PR, `/api/webui` does too — closing the last gap.

### 2. audit: tolerate a single corrupted row in the audit log

`#2632` made `EncryptionService.decrypt()` throw on tampered/malformed ciphertext, which is the right posture for writes but means a single corrupted row in `bot_configuration_audit` would now 500 the whole audit list endpoint. `mapRowToBotConfigurationAudit` at `src/database/repositories/BotConfigRepository.ts:491` now wraps the per-field decrypt in a try/catch that logs the row id and returns `null` for that field — the rest of the audit remains readable.

### 3. perf: drop `widgetPositionMap`, revert to `Array.find`

`#2633` added a `useMemo`'d `Map` of widget positions to get O(1) lookup. Reviewer correctly flagged that the Map is rebuilt on every `widgets` change but is only consumed inside `handleMouseDown` — one lookup per drag-start (a rare event). Rebuilding a Map for a rare event is a net pessimization over `Array.find`. Reverted. `WIDGET_TYPE_MAP` (module-scope static) was the genuine win and stays.

## Test plan

- [ ] `POST /api/webui/config` without a valid token → 401 (previously reached the handler)
- [ ] Simulate a tampered audit row → list endpoint returns the other rows cleanly with the tampered field as `null`
- [ ] Dashboard drag/drop still works