### PR TITLE
fix(security): require authentication on /api/activity router mount

### DIFF
--- a/src/server/registerRoutes.ts
+++ b/src/server/registerRoutes.ts
@@ -122,7 +122,7 @@ export function registerRoutes(app: import('express').Application, ctx: RouteCon
   app.use('/api/import-export', authenticateToken, importExportRouter);
 
   // 3. Resource routers (specific paths, no catch-all conflict)
-  app.use('/api/activity', activityRouter);
+  app.use('/api/activity', authenticateToken, activityRouter);
   app.use('/api/agents', agentsRouter);
   app.use('/api/dashboard', dashboardRouter);
   app.use('/api/config', webuiConfigRouter);

--- a/tests/unit/server/activity-api-auth.test.ts
+++ b/tests/unit/server/activity-api-auth.test.ts
@@ -1,0 +1,44 @@
+import express from 'express';
+import request from 'supertest';
+import { authenticateToken } from '../../../src/server/middleware/auth';
+
+// Minimal router stub so we don't depend on the real activity implementation
+const activityRouter = express.Router();
+activityRouter.get('/messages', (_req, res) => res.json({ ok: true, messages: [] }));
+activityRouter.get('/summary', (_req, res) => res.json({ ok: true }));
+activityRouter.post('/log', express.json(), (_req, res) => res.json({ ok: true }));
+
+describe('POST/GET /api/activity requires authentication', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    // Replicate registerRoutes.ts line 125 shape
+    app.use('/api/activity', authenticateToken, activityRouter);
+  });
+
+  it('returns 401 on GET /messages without a token', async () => {
+    const res = await request(app).get('/api/activity/messages');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 on GET /summary without a token', async () => {
+    const res = await request(app).get('/api/activity/summary');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 on POST /log without a token', async () => {
+    const res = await request(app)
+      .post('/api/activity/log')
+      .send({ event: 'test' });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 on GET /messages with an obviously invalid token', async () => {
+    const res = await request(app)
+      .get('/api/activity/messages')
+      .set('Authorization', 'Bearer not-a-real-jwt');
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary

\`/api/activity\` was mounted at \`src/server/registerRoutes.ts:125\` with no auth middleware, while every sibling mount in the same file (\`/api/guards\`, \`/api/specs\`, \`/api/import-export\`, \`/api/monitoring\`) requires \`authenticateToken\`.

As a result, the following endpoints were reachable by anyone who passed the optional IP whitelist (disabled entirely when \`HTTP_ALLOW_ALL_IPS=true\`):
- \`GET /api/activity/messages\`
- \`GET /api/activity/summary\`
- \`GET /api/activity/agents\`
- \`POST /api/activity/log\`
- and the rest of that router

Fix: wrap the mount in the same \`authenticateToken\` used by every other protected mount in the same file. No new middleware pattern introduced.

## Supersedes

\`#2611\` — closed. The original was \`CONFLICTING/DIRTY\` after a long rebase gap, and picked session-based \`authenticate + requireAdmin\` from a different middleware stack, creating inconsistency with the surrounding mounts.

## Test plan

- [x] New test file \`tests/unit/server/activity-api-auth.test.ts\` asserts 401 on GET /messages, GET /summary, POST /log without a token, and on GET /messages with a bogus Bearer token
- [ ] Frontend still works — the UI uses \`/api/dashboard/api/activity\` (not \`/api/activity\`), so no UI regression

## Follow-up (not in this PR)

Reviewer audit surfaced other \`/api/*\` mounts in the same file that may also lack authentication — worth a follow-up sweep (\`agents\`, \`dashboard\`, \`config\`, \`bots\`, \`validation\`, \`hot-reload\`, \`ci\`, \`enterprise\`, \`secure-config\`, \`letta\`, \`mcp-tools\`, \`onboarding\`, \`personas\`, \`providers\`, \`usage-tracking\`, \`webhooks\`). Several self-protect via internal \`router.use(...)\` so they need case-by-case verification rather than blanket wrapping.