### PR TITLE
🎨 Palette: Add ARIA properties to toggle buttons

### DIFF
--- a/src/client/src/components/BotConfigViewer.tsx
+++ b/src/client/src/components/BotConfigViewer.tsx
@@ -172,12 +172,14 @@ const BotConfigViewer: React.FC<BotConfigViewerProps> = ({
                 <button 
                   className={`btn btn-xs ${viewMode === 'terminal' ? 'btn-active' : 'btn-ghost'}`}
                   onClick={() => setViewMode('terminal')}
+                  aria-pressed={viewMode === 'terminal'}
                 >
                   Terminal
                 </button>
                 <button 
                   className={`btn btn-xs ${viewMode === 'json' ? 'btn-active' : 'btn-ghost'}`}
                   onClick={() => setViewMode('json')}
+                  aria-pressed={viewMode === 'json'}
                 >
                   JSON
                 </button>

--- a/src/client/src/components/Personas/AvatarPicker.tsx
+++ b/src/client/src/components/Personas/AvatarPicker.tsx
@@ -35,6 +35,8 @@ const AvatarPicker: React.FC<AvatarPickerProps> = ({
                 : 'border-transparent'
             }`}
             title={label}
+            aria-label={`Select ${label} avatar style`}
+            aria-pressed={selectedStyle === key}
           >
             <PersonaAvatar seed={effectiveSeed} style={key} size={36} />
             <span className="text-[10px] opacity-60 truncate w-full text-center">{label}</span>


### PR DESCRIPTION
💡 What: Added `aria-label` and `aria-pressed` states to avatar style buttons in the Persona creation modal and view mode buttons in the Bot Config viewer.
🎯 Why: Makes the state of these toggle-like buttons explicitly clear to screen readers, improving overall accessibility for users with disabilities.
📸 Before/After: Visuals remain unchanged, but the DOM now conveys rich accessibility info.
♿ Accessibility: Ensures that screen reader users can identify both the purpose (`aria-label`) and current state (`aria-pressed`) of these custom interactive elements.

---
*PR created automatically by Jules for task [5746882987699806783](https://jules.google.com/task/5746882987699806783) started by @matthewhand*