### PR TITLE
⚡ Bolt: Optimize O(N) array lookups in lists

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,3 +35,6 @@
 ## 2026-04-25 - Optimize MCPServers array lookup
 **Learning:** React component renders often contain hidden O(N^2) complexity when checking for array duplicates using `.find()` inside `.forEach()` or `.map()` loops.
 **Action:** Replace nested array `.find()` operations during bulk processing with a pre-computed `Set` to achieve O(1) membership testing and linear overall time complexity.
+## 2026-04-27 - Pre-compute Map lookups in rendering loops
+**Learning:** React component renders often contain hidden O(N^2) complexity when using array `.find()` inside `.map()` loops (e.g., `stats.componentUsage.find`, `recentlyUsed.find`).
+**Action:** Replace nested array `.find()` operations during rendering with a pre-computed `Map` wrapped in `useMemo` to achieve O(1) membership testing and linear overall time complexity.

--- a/src/client/src/components/BotManagement/PersonaSelector.tsx
+++ b/src/client/src/components/BotManagement/PersonaSelector.tsx
@@ -90,6 +90,11 @@ const PersonaSelector: React.FC<PersonaSelectorProps> = ({
 
   const selectedPersona = personas.find(p => p.id === selectedPersonaId) || DEFAULT_PERSONA;
 
+  // Performance optimization: Pre-compute category color map
+  const categoryColorMap = useMemo(() => {
+    return new Map(categories.map(c => [c.value, c.color]));
+  }, [categories]);
+
   const handlePersonaClick = (personaId: string) => {
     onPersonaSelect(personaId);
     if (size === 'compact') {
@@ -192,7 +197,7 @@ const PersonaSelector: React.FC<PersonaSelectorProps> = ({
                           <div
                             className={`
                               w-2 h-2 rounded-full
-                              ${getCategoryDotClass(categories.find(c => c.value === persona.category)?.color || 'neutral')}
+                              ${getCategoryDotClass(categoryColorMap.get(persona.category) || 'neutral')}
                             `}
                           />
                           <span className="font-medium text-sm">{persona.name}</span>
@@ -337,7 +342,7 @@ const PersonaSelector: React.FC<PersonaSelectorProps> = ({
                       <div
                         className={`
                           w-3 h-3 rounded-full
-                          ${getCategoryDotClass(categories.find(c => c.value === persona.category)?.color || 'neutral')}
+                          ${getCategoryDotClass(categoryColorMap.get(persona.category) || 'neutral')}
                         `}
                       />
                       <h4 className="font-semibold">{persona.name}</h4>

--- a/src/client/src/components/DaisyUIComponentTracker.tsx
+++ b/src/client/src/components/DaisyUIComponentTracker.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars */
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import type { DaisyUIComponentStats } from '../utils/DaisyUIComponentTracker';
 import { daisyUITracker } from '../utils/DaisyUIComponentTracker';
 import Button from './DaisyUI/Button';
@@ -54,6 +54,12 @@ const DaisyUIComponentTracker: React.FC<Props> = ({ isOpen = true, onClose }) =>
 
   const usagePercentage = Math.round((stats.usedComponents / stats.totalComponents) * 100);
   const suggestions = daisyUITracker.getSuggestions();
+
+  // Performance optimization: Pre-compute component usage lookup map
+  // to avoid O(N) array .find() operations inside rendering loops
+  const componentUsageMap = useMemo(() => {
+    return new Map(stats.componentUsage.map(usage => [usage.component, usage]));
+  }, [stats.componentUsage]);
 
   return (
     <div className={`${isOpen ? 'block' : 'hidden'}`}>
@@ -213,7 +219,7 @@ const DaisyUIComponentTracker: React.FC<Props> = ({ isOpen = true, onClose }) =>
                     <div className="space-y-2 mt-2">
                       {data.components.length > 0 ? (
                         data.components.map((component) => {
-                          const usage = stats.componentUsage.find((u) => u.component === component);
+                          const usage = componentUsageMap.get(component);
                           return (
                             <div
                               key={component}

--- a/src/client/src/components/mcp-tools/ToolRegistryPanel.tsx
+++ b/src/client/src/components/mcp-tools/ToolRegistryPanel.tsx
@@ -94,6 +94,12 @@ const ToolRegistryPanel: React.FC<ToolRegistryPanelProps> = ({
     return tools.filter(tool => favorites.includes(tool.id));
   }, [tools, favorites]);
 
+  // Performance optimization: Pre-compute recently used tools map
+  // to avoid O(N) array .find() operations when rendering tool cards
+  const recentlyUsedMap = useMemo(() => {
+    return new Map(recentlyUsed.map(r => [r.toolId, r]));
+  }, [recentlyUsed]);
+
   const shouldVirtualize = filteredTools.length > 50;
   const gridRowVirtualizer = useVirtualizer({
     count: Math.ceil(filteredTools.length / 3), // 3 columns
@@ -144,7 +150,7 @@ const ToolRegistryPanel: React.FC<ToolRegistryPanelProps> = ({
               <button
                 className="btn btn-xs btn-primary flex-1"
                 onClick={() => {
-                  const lastUsage = recentlyUsed.find(r => r.toolId === tool.id);
+                  const lastUsage = recentlyUsedMap.get(tool.id);
                   onRunTool(tool, lastUsage?.arguments);
                 }}
                 disabled={!tool.enabled}


### PR DESCRIPTION
💡 What: Replaced nested array `.find()` operations with O(1) `Map` lookups inside component render functions (`DaisyUIComponentTracker.tsx`, `ToolRegistryPanel.tsx`).
🎯 Why: Calling `.find()` inside a `.map()` callback creates an `O(N * M)` time complexity rendering bottleneck, which can cause frame drops and block the main thread for lists containing large amounts of entries.
📊 Impact: Reduces array lookup complexity from `O(N * M)` to `O(N + M)` during renders.
🔬 Measurement: Verify by rendering the DaisyUIComponentTracker or MCP Tool Registry panels with many components/tools and observing reduced flamegraph trace times for those specific render phases.

---
*PR created automatically by Jules for task [739818291418392684](https://jules.google.com/task/739818291418392684) started by @matthewhand*