### PR TITLE
feat(client): wire density settings to live CSS variables

### DIFF
--- a/src/client/src/index.css
+++ b/src/client/src/index.css
@@ -11,7 +11,17 @@
 /* Base styles - let DaisyUI handle theming */
 html {
   scroll-behavior: smooth;
+  /* Density scale — multiplied into card/main padding via calc().
+     Driven by <html data-density="..."> set by uiStore.setDensity,
+     and <html data-compact-density="true"> from setCompactDensity. */
+  --density-scale: 1;
 }
+
+html[data-density="compact"] { --density-scale: 0.7; }
+html[data-density="comfortable"] { --density-scale: 1; }
+html[data-density="spacious"] { --density-scale: 1.25; }
+
+html[data-compact-density="true"] { --density-scale: calc(var(--density-scale) * 0.85); }
 
 body {
   margin: 0;
@@ -78,7 +88,7 @@ textarea {
 }
 
 .card-body {
-  padding: 1.5rem;
+  padding: calc(1.5rem * var(--density-scale, 1));
 }
 
 .card-title {
@@ -97,7 +107,7 @@ textarea {
 
 /* Stat cards with gradient backgrounds */
 .stat {
-  padding: 1.25rem 1.5rem;
+  padding: calc(1.25rem * var(--density-scale, 1)) calc(1.5rem * var(--density-scale, 1));
   border-color: hsl(var(--bc) / 0.1);
   transition: all 0.2s ease;
 }

--- a/src/client/src/pages/BotsPage/BotConfigCard.tsx
+++ b/src/client/src/pages/BotsPage/BotConfigCard.tsx
@@ -60,7 +60,7 @@ const BotConfigCard: React.FC<BotConfigCardProps> = ({
         ${isSelected ? 'border-primary ring-2 ring-primary/20' : 'border-base-300 hover:shadow-2xl'}`}
       onClick={onPreview ? () => onPreview(bot) : undefined}
     >
-      <Card.Body className="p-6">
+      <Card.Body>
         {/* Header */}
         <div className="flex justify-between items-start mb-4">
           <div className="flex-1 min-w-0">

--- a/src/client/src/store/uiStore.ts
+++ b/src/client/src/store/uiStore.ts
@@ -299,6 +299,7 @@ export const useUIStore = create<UIState & UIActions>((set, get) => ({
   setCompactDensity: (compactDensity) => {
     set({ compactDensity });
     localStorage.setItem('compactDensity', compactDensity.toString());
+    document.documentElement.setAttribute('data-compact-density', compactDensity.toString());
   },
 
   setShowDescriptions: (showDescriptions) => {
@@ -412,6 +413,7 @@ export const useUIStore = create<UIState & UIActions>((set, get) => ({
     document.documentElement.setAttribute('data-theme', state.theme === 'auto' ? 'light' : (state.theme as string));
     document.documentElement.setAttribute('lang', state.language);
     document.documentElement.setAttribute('data-density', state.density);
+    document.documentElement.setAttribute('data-compact-density', state.compactDensity.toString());
   },
 
   handleResize: (viewport) => {


### PR DESCRIPTION
## Summary
- The density slider and compactDensity toggle in Settings persisted to `<html data-density="...">` but no CSS rule consumed them — toggling did nothing visible. `BotConfigCard` also forced `p-6` on `Card.Body`, defeating `.card-compact`.
- Added `--density-scale` CSS var on `<html>` driven by `[data-density]` (compact 0.7, comfortable 1, spacious 1.25) and stacked multiplicatively with `[data-compact-density="true"]` (× 0.85).
- Applied the var to `.card-body` and `.stat` padding via `calc()`. Removed redundant `p-6` from `BotConfigCard` so density now actually scales bot cards.
- `setCompactDensity` now writes `data-compact-density` to `<html>`; `initializeFromLocalStorage` applies it on boot.

## Test plan
- [x] Build: `npm run build` (backend tsc + frontend vite) — PASS, 14s
- [x] Tests: `vitest run src/store/slices/__tests__/uiSlice.test.ts` — 23/23 PASS
- [x] Dev server: `npm run dev` starts and prints "🎉 Open Hivemind Server startup complete!"
- [ ] Manual: open Settings → toggle density between compact/comfortable/spacious, observe cards reflow padding live
- [ ] Manual: toggle compactDensity, observe additional 0.85× tightening
- [ ] Manual: reload page, confirm setting persists and applies on first paint

Note: project ESLint runtime is broken on `main` (pre-existing `@eslint/eslintrc` ajv crash). Unrelated to this branch.