### PR TITLE
feat(client): mobile FAB for BotsPage primary actions

### DIFF
--- a/src/client/src/index.css
+++ b/src/client/src/index.css
@@ -1340,3 +1340,52 @@ body.robot-ui-enabled .btn-accent {
     transform: translate(0, 0);
   }
 }
+
+/* ============================================================
+ * Mobile floating action buttons (FABs)
+ * Reusable pattern for surfacing primary page actions on small
+ * viewports. Pages opt in by rendering a `.fab-mobile` element
+ * with `md:hidden` so the FAB never appears on desktop.
+ * ============================================================ */
+.fab-mobile {
+  position: fixed;
+  bottom: calc(1.5rem * var(--density-scale, 1));
+  width: calc(3.5rem * var(--density-scale, 1));
+  height: calc(3.5rem * var(--density-scale, 1));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  background-color: oklch(var(--b2));
+  border: 2px solid oklch(var(--p));
+  color: oklch(var(--bc));
+  box-shadow:
+    0 8px 24px oklch(var(--bc) / 0.25),
+    0 2px 8px oklch(var(--bc) / 0.15);
+  z-index: 40;
+  cursor: pointer;
+  transition: background-color 150ms ease, color 150ms ease, transform 150ms ease;
+}
+
+.fab-mobile:hover,
+.fab-mobile:active,
+.fab-mobile:focus-visible {
+  background-color: oklch(var(--p));
+  color: oklch(var(--pc));
+  transform: scale(1.06);
+  outline: none;
+}
+
+.fab-mobile:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.fab-mobile-left {
+  left: 3rem;
+}
+
+.fab-mobile-right {
+  right: 3rem;
+}

--- a/src/client/src/pages/BotsPage/index.tsx
+++ b/src/client/src/pages/BotsPage/index.tsx
@@ -471,6 +471,30 @@ const BotsPage: React.FC = () => {
         }}
       />
       </div>
+
+      {/* Mobile FABs — primary page actions for small viewports.
+          Desktop uses the inline header buttons; FABs are hidden via md:hidden. */}
+      {isMobile && (
+        <>
+          <button
+            type="button"
+            className="fab-mobile fab-mobile-left md:hidden"
+            onClick={() => setIsCreateModalOpen(true)}
+            aria-label="Create bot"
+          >
+            <Plus className="w-6 h-6" />
+          </button>
+          <button
+            type="button"
+            className="fab-mobile fab-mobile-right md:hidden"
+            onClick={fetchBots}
+            disabled={botsLoading}
+            aria-label="Refresh bots"
+          >
+            <RefreshCw className={`w-6 h-6 ${botsLoading ? 'animate-spin' : ''}`} />
+          </button>
+        </>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Adds a reusable `.fab-mobile` style block in `src/client/src/index.css` (with `.fab-mobile-left` / `.fab-mobile-right` modifiers) modeled on the slopfinity FAB pattern: oklch-themed, `--density-scale`-aware, hover/active scale and primary fill.
- Renders two bottom-fixed FABs on `BotsPage` only when `useIsBelowBreakpoint('md')` is true (also `md:hidden` defensively): left `Plus` opens the create-bot modal, right `RefreshCw` calls `fetchBots` with the existing spinner state.
- No duplicate logic — both FABs reuse the existing handlers, and the desktop header buttons are untouched.

## Test plan
- [ ] `npm run build` passes (verified locally).
- [ ] Visual check at <768px: both FABs render at `bottom: 1.5rem`, `left/right: 3rem`, `z-index: 40` and trigger the same actions as the desktop buttons.
- [ ] Visual check at >=768px: no FABs visible, layout unchanged.
- [ ] Refresh FAB shows spinning icon while `botsLoading` and is disabled.
- [ ] `aria-label`s present on each FAB for screen readers.

> Draft — do not merge.