### PR TITLE
fix(lint): restore working ESLint setup on main

### DIFF
--- a/package.json
+++ b/package.json
@@ -343,8 +343,7 @@
       "serialize-javascript": "^7.0.3",
       "follow-redirects": "^1.16.0",
       "smol-toml": "^1.6.1",
-      "basic-ftp": "^5.3.0",
-      "ajv": "^8.18.0"
+      "basic-ftp": "^5.3.0"
     },
     "onlyBuiltDependencies": [
       "better-sqlite3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,6 @@ overrides:
   follow-redirects: ^1.16.0
   smol-toml: ^1.6.1
   basic-ftp: ^5.3.0
-  ajv: ^8.18.0
 
 importers:
 
@@ -4305,7 +4304,7 @@ packages:
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
     peerDependencies:
-      ajv: ^8.18.0
+      ajv: ^8.5.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -4313,13 +4312,22 @@ packages:
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
-      ajv: ^8.18.0
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
 
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.13.0:
+    resolution: {integrity: sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==}
+
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  ajv@8.6.3:
+    resolution: {integrity: sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -6669,6 +6677,9 @@ packages:
   json-schema-to-ts@1.6.4:
     resolution: {integrity: sha512-pR4yQ9DHz6itqswtHCm26mw45FSNfQ9rEQjosaZErhn5J3J2sIViQiz8rDaezjKAhFGpmsoczYVBgGHzFw/stA==}
 
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -8989,6 +9000,9 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
@@ -11010,7 +11024,7 @@ snapshots:
 
   '@eslint/eslintrc@3.3.5':
     dependencies:
-      ajv: 8.18.0
+      ajv: 6.15.0
       debug: 4.4.3(supports-color@8.1.1)
       espree: 10.4.0
       globals: 14.0.0
@@ -11835,9 +11849,9 @@ snapshots:
 
   '@rushstack/node-core-library@5.13.0(@types/node@22.19.17)':
     dependencies:
-      ajv: 8.18.0
-      ajv-draft-04: 1.0.0(ajv@8.18.0)
-      ajv-formats: 3.0.1(ajv@8.18.0)
+      ajv: 8.13.0
+      ajv-draft-04: 1.0.0(ajv@8.13.0)
+      ajv-formats: 3.0.1(ajv@8.13.0)
       fs-extra: 11.3.4
       import-lazy: 4.0.0
       jju: 1.4.0
@@ -12667,7 +12681,7 @@ snapshots:
 
   '@vercel/static-config@3.2.0':
     dependencies:
-      ajv: 8.18.0
+      ajv: 8.6.3
       json-schema-to-ts: 1.6.4
       ts-morph: 12.0.0
 
@@ -12804,13 +12818,31 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
-  ajv-draft-04@1.0.0(ajv@8.18.0):
+  ajv-draft-04@1.0.0(ajv@8.13.0):
     optionalDependencies:
-      ajv: 8.18.0
+      ajv: 8.13.0
+
+  ajv-formats@3.0.1(ajv@8.13.0):
+    optionalDependencies:
+      ajv: 8.13.0
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ajv@8.13.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js: 4.4.1
 
   ajv@8.18.0:
     dependencies:
@@ -12818,6 +12850,13 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  ajv@8.6.3:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js: 4.4.1
 
   ansi-colors@4.1.3: {}
 
@@ -14176,7 +14215,7 @@ snapshots:
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
-      ajv: 8.18.0
+      ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3(supports-color@8.1.1)
@@ -15663,6 +15702,8 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
       ts-toolbelt: 6.15.5
+
+  json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
 
@@ -18356,6 +18397,10 @@ snapshots:
       browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   url-parse@1.5.10:
     dependencies:

--- a/src/client/eslint.config.js
+++ b/src/client/eslint.config.js
@@ -1,0 +1,23 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
+import { globalIgnores } from 'eslint/config';
+
+export default tseslint.config([
+  globalIgnores(['dist']),
+  {
+    files: ['**/*.{ts,tsx}'],
+    extends: [
+      js.configs.recommended,
+      tseslint.configs.recommended,
+      reactHooks.configs['recommended-latest'],
+      reactRefresh.configs.vite,
+    ],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+  },
+]);

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -6,7 +6,7 @@
     "dev": "vite --port 5173 --host",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "test": "npx vitest run",
     "test:watch": "npx vitest",
     "test:coverage": "npx vitest run --coverage"


### PR DESCRIPTION
## Summary

`npm run lint` on `main` crashed at startup with:

```
TypeError: Cannot set properties of undefined (setting 'defaultMeta')
    at ajvOrig (@eslint/eslintrc/dist/eslintrc-universal.cjs:385)
```

The project had effectively no lint coverage as a result.

## Root cause

`pnpm.overrides` in the root `package.json` forced `"ajv": "^8.18.0"` globally (added in #2616 alongside other audit-clearance bumps). That override applied to `@eslint/eslintrc`, which depends on `ajv@^6.14.0` and accesses the v6-only internal `ajv._opts.defaultMeta`. With ajv@8 substituted in, eslintrc blew up before reaching any source file.

There is no current advisory against ajv that requires this override; modern consumers already declare ajv@8 directly, and legacy consumers (eslint, eslintrc, typescript-eslint plugins) still need ajv@6. `pnpm audit` confirms ajv is no longer flagged.

## Fix

1. Remove the global `ajv` override from `pnpm.overrides`. Each consumer now resolves its declared range (eslint/eslintrc -> ajv@6, modern packages -> ajv@8).
2. Restore `src/client/eslint.config.js`, which was deleted as collateral in 64a480209 ("modularize Discord adapter"). Without it, the client workspace had no flat config under ESLint 9, so `eslint .` matched zero files.
3. Drop the deprecated `--ext ts,tsx` flag from the client lint script. ESLint 9 flat config infers extensions from the `files` glob; the flag now triggers a hard error.

## Verification

- Root `npm run lint`: runs to completion, **1161 problems (252 errors, 909 warnings)** — all pre-existing, out of scope per task.
- Client `npm run lint`: runs to completion, **940 problems (895 errors, 45 warnings)** — all pre-existing, out of scope.
- `npm run build`: succeeds (backend + frontend).

## Test plan

- [ ] CI lint job runs to completion (does not crash at startup).
- [ ] CI build job still passes.
- [ ] Reviewer confirms no new audit findings against ajv after override removal (`pnpm audit`).

## Out of scope

Fixing the ~1100 pre-existing lint errors surfaced now that ESLint actually runs. The runtime crash needs to land first so subsequent cleanup PRs have a working tool.