### PR TITLE
feat(client): expand --density-scale to modal, sidebar, and table

### DIFF
--- a/src/client/src/index.css
+++ b/src/client/src/index.css
@@ -215,6 +215,7 @@ textarea {
 .menu li>a,
 .menu li>button {
   transition: all 0.15s ease;
+  padding: calc(0.5rem * var(--density-scale, 1)) calc(1rem * var(--density-scale, 1));
 }
 
 .menu li>a:hover,
@@ -248,12 +249,12 @@ textarea {
   text-transform: uppercase;
   font-size: 0.75rem;
   color: hsl(var(--bc) / 0.8);
-  padding: 1rem 1.25rem;
+  padding: calc(1rem * var(--density-scale, 1)) calc(1.25rem * var(--density-scale, 1));
   border-bottom: 2px solid hsl(var(--bc) / 0.1);
 }
 
 .table td {
-  padding: 0.875rem 1.25rem;
+  padding: calc(0.875rem * var(--density-scale, 1)) calc(1.25rem * var(--density-scale, 1));
   border-bottom: 1px solid hsl(var(--bc) / 0.05);
 }
 
@@ -345,6 +346,7 @@ dialog.modal:not([open]) {
   box-shadow:
     0 25px 50px rgba(0, 0, 0, 0.4),
     0 0 1px rgba(255, 255, 255, 0.1);
+  padding: calc(1.5rem * var(--density-scale, 1));
 }
 
 @keyframes modalScale {


### PR DESCRIPTION
## Summary

PR #2659 introduced `--density-scale` driven by `[data-density]` / `[data-compact-density]` on `<html>`, but only `.card-body` and `.stat` consumed it — toggling the density slider barely registered visually outside cards. This PR wires the variable into three additional high-impact surfaces so the slider feels cohesive across the app.

## Surfaces updated

- `.modal-box` padding (added new rule, base `1.5rem`)
- `.menu li>a` / `.menu li>button` sidebar item padding (base `0.5rem` / `1rem`)
- `.table th` / `.table td` cell padding (bases `1rem`/`0.875rem` × `1.25rem`)

All values use `calc(... * var(--density-scale, 1))`. The `1` fallback guarantees that at the default density the rendered output is byte-identical to the previous state — zero visual regression.

## Why these three

Of the candidates listed, modal/sidebar/table are pure custom CSS in `index.css` (no Tailwind utility conflicts), have visible padding everywhere in the app, and changes are immediately apparent. Form-control padding and `.card + .card` gaps were skipped: form fields rely on DaisyUI/Tailwind defaults, and card spacing is driven by Tailwind grid `gap` utilities — fighting either would risk visual regressions.

## Test plan

- [ ] `npm run build` — PASS (verified locally)
- [ ] At default density (`comfortable` / `data-density` unset), modal/sidebar/table render identically to main
- [ ] Toggle density slider compact ↔ comfortable ↔ spacious — sidebar items, modals, and table rows visibly tighten/loosen alongside cards
- [ ] `data-compact-density="true"` further compounds the scale (× 0.85) — confirm no overlap with min sizes

## Status

DRAFT — DO NOT MERGE.