### PR TITLE
feat(client): density quick-toggle in global navbar

### DIFF
--- a/src/client/src/components/DaisyUI/NavbarWithSearch.tsx
+++ b/src/client/src/components/DaisyUI/NavbarWithSearch.tsx
@@ -27,7 +27,20 @@ import {
   Play,
   Square,
   SearchCode,
+  Rows2,
+  Rows3,
+  Rows4,
 } from 'lucide-react';
+
+type Density = 'compact' | 'comfortable' | 'spacious';
+
+const DENSITY_ORDER: Density[] = ['compact', 'comfortable', 'spacious'];
+
+const DENSITY_META: Record<Density, { label: string; icon: typeof Rows2; description: string }> = {
+  compact:    { label: 'Compact',    icon: Rows4, description: 'Tighter spacing, more content per screen' },
+  comfortable:{ label: 'Comfortable',icon: Rows3, description: 'Balanced spacing (default)' },
+  spacious:   { label: 'Spacious',   icon: Rows2, description: 'Generous spacing, easier to scan' },
+};
 
 interface NavItem {
   id: string;
@@ -271,6 +284,17 @@ const NavbarWithSearch: React.FC<NavbarWithSearchProps> = ({
 
   const uiTheme = useUIStore((s) => s.theme);
   const setUiTheme = useUIStore((s) => s.setTheme);
+
+  const density = useUIStore((s) => s.density);
+  const setDensity = useUIStore((s) => s.setDensity);
+
+  const densityMeta = DENSITY_META[density];
+  const DensityIcon = densityMeta.icon;
+  const cycleDensity = () => {
+    const idx = DENSITY_ORDER.indexOf(density);
+    const next = DENSITY_ORDER[(idx + 1) % DENSITY_ORDER.length];
+    setDensity(next);
+  };
 
   return (
     <>
@@ -516,6 +540,22 @@ const NavbarWithSearch: React.FC<NavbarWithSearchProps> = ({
         </div>
 
         <Divider vertical className="h-6 mx-0 hidden sm:flex" />
+
+        {/* Density Quick Toggle — cycles compact -> comfortable -> spacious. Same store as Settings page slider. */}
+        <Tooltip
+          content={`Density: ${densityMeta.label}. Click to cycle to ${DENSITY_META[DENSITY_ORDER[(DENSITY_ORDER.indexOf(density) + 1) % DENSITY_ORDER.length]].label}.`}
+          position="bottom"
+        >
+          <button
+            type="button"
+            className="btn btn-ghost btn-circle btn-sm hidden sm:inline-flex"
+            onClick={cycleDensity}
+            aria-label={`UI density: ${densityMeta.label}. Activate to switch density.`}
+            data-density={density}
+          >
+            <DensityIcon className="w-5 h-5" />
+          </button>
+        </Tooltip>
 
         {/* Improved Theme Switcher integration */}
         <div className="hidden sm:flex">


### PR DESCRIPTION
## Summary

- Adds a small icon button to `NavbarWithSearch` that cycles UI density `compact -> comfortable -> spacious -> compact` on click, placed next to the existing `AdvancedThemeSwitcher` for consistency with other appearance controls.
- Reads/writes the same `density` state in `useUIStore` that the Settings page slider (PR #2659) uses — single source of truth, no new global state, no duplication. The icon (Rows4 / Rows3 / Rows2 from lucide-react, already a dependency) reflects current density and the tooltip announces the next state.
- Hidden on `<sm` breakpoints via `hidden sm:inline-flex` to preserve mobile navbar space; the Settings page slider remains the canonical control everywhere.

## Why

Density currently lives ~line 291 of `Settings.tsx`. Most users won't drill that deep. Slopfinity-style apps surface density inline; this gives users a one-click way to find a layout that fits their screen without leaving whatever page they're on. Both controls write to the same store, so flipping in one place updates the other.

## UX

- Click the icon: cycles through the 3 density modes.
- Hover: tooltip "Density: <current>. Click to cycle to <next>."
- Screen readers: `aria-label="UI density: <current>. Activate to switch density."`
- Icon visually changes (Rows4 dense -> Rows3 medium -> Rows2 sparse) so the current state is obvious at a glance.

## Test plan

- [ ] Open the app, verify the density icon appears in the navbar to the left of the theme switcher on >= sm screens.
- [ ] Click the icon repeatedly: navbar/page spacing should change after each click; icon swaps between Rows4/Rows3/Rows2.
- [ ] Open Settings -> appearance and confirm the density slider mirrors the navbar state.
- [ ] Move the Settings slider; the navbar icon should update on next render.
- [ ] Reload the page; the chosen density should persist (uses existing `localStorage` write in `useUIStore.setDensity`).
- [ ] Resize to <sm; the toggle should be hidden, and Settings slider remains available.
- [ ] Tab to the button; aria-label should announce "UI density: <Compact|Comfortable|Spacious>. Activate to switch density."

## Notes

- DRAFT — do not merge. Spawned to validate the UX placement; pending product/design sign-off on whether to keep this as a cycle button or convert to a 3-option dropdown (RFC in PR #2659 thread).
- No new dependencies. No state changes outside of read/write to existing `useUIStore.density` / `setDensity`.
- Pre-existing missing import for `ShieldAlert` in this same file is **not** addressed here to keep the change scoped.