### PR TITLE
a11y(client): polish BotsPage view-mode dropdown trigger

### DIFF
--- a/src/client/src/pages/BotsPage/index.tsx
+++ b/src/client/src/pages/BotsPage/index.tsx
@@ -200,12 +200,12 @@ const BotsPage: React.FC = () => {
               color="ghost"
               size="sm"
               className="dropdown-end"
-              triggerClassName="btn-square focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none"
+              triggerClassName="btn-square focus-visible:ring-2 ring-base-content focus-visible:ring-offset-2 ring-offset-base-100 focus-visible:outline-none"
               contentClassName="shadow-lg w-44 z-20"
               hideArrow
               aria-label={`View mode: ${
                 viewMode === 'swarm3d' ? '3D Swarm' : viewMode === 'compact' ? 'Compact' : 'Grid'
-              } (click to change)`}
+              }`}
             >
               {([
                 { value: 'default', label: 'Grid', icon: <LayoutGrid className="w-4 h-4" aria-hidden="true" /> },
@@ -217,7 +217,7 @@ const BotsPage: React.FC = () => {
                   <li key={opt.value}>
                     <a
                       onClick={(e) => { e.stopPropagation(); setViewMode(opt.value); }}
-                      className={`flex items-center gap-2 ${isActive ? 'active font-semibold bg-base-200' : ''}`}
+                      className={`flex items-center gap-2 ${isActive ? 'active font-semibold bg-base-200 border-l-2 border-primary pl-2' : ''}`}
                       role="menuitemradio"
                       aria-checked={isActive}
                     >


### PR DESCRIPTION
## Summary

Follow-up to #2664 addressing Wave C QA review nits on the BotsPage view-mode dropdown. **Do not merge until #2664 lands first.**

Three accessibility polish items, all scoped to `src/client/src/pages/BotsPage/index.tsx` (Dropdown component untouched):

- **Trigger aria-label**: drop the trailing `(click to change)` — that wording excludes keyboard users, and APG conventions say `role="button"` + `aria-haspopup="menu"` + `aria-expanded` (already wired in `Dropdown.tsx:103-104`) convey the affordance. New label: `View mode: <Mode>`.
- **Focus ring contrast**: swap `ring-primary` for `ring-base-content` with `ring-offset-base-100`. `--bc` is guaranteed >=3:1 against `--b1` in every DaisyUI theme; `ring-primary` was at risk in cupcake / emerald / aqua / nord.
- **Active item indicator**: `bg-base-200` alone is ~1.05-1.2:1 vs `bg-base-100` in light themes (fails WCAG SC 1.4.11). Added a non-color cue `border-l-2 border-primary pl-2` to the active `menuitemradio`, alongside the existing background and Check icon.

Behavior preserved: URL `view` param, view rendering, keyboard activation, all unchanged.

## Test plan

- [ ] Verify trigger announces `"View mode: Grid / Compact / 3D Swarm, menu, collapsed"` in NVDA/VoiceOver
- [ ] Tab to trigger across cupcake, emerald, aqua, nord themes — focus ring visible and meets 3:1
- [ ] Open menu in light theme — active item shows left border in addition to background tint
- [ ] Switch view via mouse and via keyboard (Enter/Space) — URL `?view=` updates correctly
- [ ] `npm run build` passes (verified locally)