### PR TITLE
feat(client): add WCAG AAA touch-target floor at compact density

### DIFF
--- a/src/client/src/index.css
+++ b/src/client/src/index.css
@@ -216,6 +216,11 @@ textarea {
 .menu li>button {
   transition: all 0.15s ease;
   padding: calc(0.5rem * var(--density-scale, 1)) calc(1rem * var(--density-scale, 1));
+  /* WCAG AAA touch-target floor (44px). At default density (scale=1) the
+     natural height already exceeds this, so the floor is a no-op; it only
+     activates under compact × compactDensity (scale=0.595) where items
+     would otherwise shrink to ~25.5px. */
+  min-height: 2.75rem;
 }
 
 .menu li>a:hover,


### PR DESCRIPTION
## Summary

Follow-up to #2665 addressing a Wave C QA nit. At combined `compact x compactDensity` (scale=0.595), `.menu li>a/button` items shrank to ~25.5px tap height — clears WCAG AA (24px) but fails AAA (44px).

Adds `min-height: 2.75rem` (44px = WCAG AAA target) to `.menu li>a` and `.menu li>button`. At default density (scale=1) the natural height already exceeds 44px, so the floor is a no-op there; it only kicks in under compact density to keep touch targets usable.

- Single-file edit: `src/client/src/index.css`
- No `.btn` rule currently references `--density-scale`, so none updated (per spec).
- Modal box and table cells intentionally excluded.

**DO NOT MERGE** — draft for review.

## Test plan

- [ ] Verify default density appearance unchanged
- [ ] Verify compact x compactDensity menu items now >=44px tall
- [ ] `npm run build` passes (verified locally)