### PR TITLE
test(client): add unit tests for MobileFAB component

### DIFF
--- a/src/client/src/components/__tests__/MobileFAB.test.tsx
+++ b/src/client/src/components/__tests__/MobileFAB.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import MobileFAB from '../MobileFAB';
+
+describe('MobileFAB', () => {
+  it('applies .fab-mobile and .fab-mobile-left when position="left"', () => {
+    render(
+      <MobileFAB position="left" icon={<span>i</span>} onClick={() => {}} ariaLabel="left-fab" />
+    );
+    const btn = screen.getByRole('button', { name: 'left-fab' });
+    expect(btn).toHaveClass('fab-mobile');
+    expect(btn).toHaveClass('fab-mobile-left');
+  });
+
+  it('applies .fab-mobile-right when position="right"', () => {
+    render(
+      <MobileFAB position="right" icon={<span>i</span>} onClick={() => {}} ariaLabel="right-fab" />
+    );
+    expect(screen.getByRole('button', { name: 'right-fab' })).toHaveClass('fab-mobile-right');
+  });
+
+  it('renders the passed icon ReactNode when loading is false', () => {
+    render(
+      <MobileFAB
+        position="left"
+        icon={<span data-testid="custom-icon">CUSTOM</span>}
+        onClick={() => {}}
+        ariaLabel="fab"
+      />
+    );
+    expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+    expect(screen.getByText('CUSTOM')).toBeInTheDocument();
+  });
+
+  it('renders an animate-spin spinner instead of the icon when loading is true', () => {
+    const { container } = render(
+      <MobileFAB
+        position="left"
+        icon={<span data-testid="custom-icon">CUSTOM</span>}
+        onClick={() => {}}
+        ariaLabel="fab"
+        loading
+      />
+    );
+    expect(screen.queryByTestId('custom-icon')).not.toBeInTheDocument();
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+  });
+
+  it('calls onClick exactly once when clicked', () => {
+    const onClick = vi.fn();
+    render(<MobileFAB position="left" icon={<span>i</span>} onClick={onClick} ariaLabel="fab" />);
+    fireEvent.click(screen.getByRole('button', { name: 'fab' }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets the disabled attribute and does not invoke onClick when disabled', () => {
+    const onClick = vi.fn();
+    render(
+      <MobileFAB position="left" icon={<span>i</span>} onClick={onClick} ariaLabel="fab" disabled />
+    );
+    const btn = screen.getByRole('button', { name: 'fab' });
+    expect(btn).toBeDisabled();
+    fireEvent.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('exposes aria-label matching the prop value', () => {
+    render(
+      <MobileFAB position="right" icon={<span>i</span>} onClick={() => {}} ariaLabel="open menu" />
+    );
+    expect(screen.getByRole('button', { name: 'open menu' })).toHaveAttribute('aria-label', 'open menu');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 7 unit tests for `<MobileFAB>` in `src/client/src/components/__tests__/MobileFAB.test.tsx`
- Uses existing vitest + @testing-library/react stack — no new dependencies
- Addresses Wave C QA nit on PR #2663 (missing tests)

## Dependency: blocked on #2663

This PR is branched off main (`14ec22e31`) and does **not** include PR #2663's commits. The test file imports `../MobileFAB`, which only exists on PR #2663's branch (`refactor/extract-mobile-fab-component`).

**Until #2663 merges, this PR's tests will fail to import the component.** Tests were verified to pass locally against the PR #2663 branch — all 7 pass.

Merge order:
1. Merge #2663 first
2. Then merge this PR

## Tests added
1. Applies `.fab-mobile` + `.fab-mobile-left` for `position="left"`
2. Applies `.fab-mobile-right` for `position="right"`
3. Renders the passed `icon` ReactNode when `loading` is false
4. Renders `RefreshCw` with `animate-spin` class when `loading` is true
5. Calls `onClick` exactly once on click
6. Sets `disabled` attribute and suppresses `onClick` when `disabled={true}`
7. Exposes `aria-label` matching the prop value

## Test plan
- [ ] Wait for #2663 to merge
- [ ] Rebase this PR onto updated main
- [ ] Verify CI: `cd src/client && npx vitest run src/components/__tests__/MobileFAB.test.tsx`
- [ ] DO NOT MERGE until #2663 lands

DRAFT — DO NOT MERGE.