### PR TITLE
feat(client): smooth density-driven padding transitions

### DIFF
--- a/src/client/src/index.css
+++ b/src/client/src/index.css
@@ -23,6 +23,30 @@ html[data-density="spacious"] { --density-scale: 1.25; }
 
 html[data-compact-density="true"] { --density-scale: calc(var(--density-scale) * 0.85); }
 
+/* Smooth out density-driven padding/min-height changes so toggling
+   the slider or navbar density button doesn't snap-jump. Wrapped in
+   prefers-reduced-motion: no-preference so vestibular-sensitive users
+   keep the instant snap behavior. Rules already using `transition: all`
+   (.stat, .menu li > a/button) are intentionally omitted to avoid
+   duplicate declarations. */
+@media (prefers-reduced-motion: no-preference) {
+  .card-body,
+  .modal-box,
+  .table th,
+  .table td {
+    transition: padding 180ms ease, min-height 180ms ease;
+  }
+
+  .fab-mobile {
+    transition:
+      background-color 150ms ease,
+      color 150ms ease,
+      transform 150ms ease,
+      padding 180ms ease,
+      min-height 180ms ease;
+  }
+}
+
 body {
   margin: 0;
   min-height: 100vh;


### PR DESCRIPTION
## Summary

Adds a 180ms ease transition on `padding` and `min-height` for the rules whose dimensions flex with `--density-scale`, so toggling the density slider or the navbar density button (#2666) glides instead of snap-jumping.

Wrapped in `@media (prefers-reduced-motion: no-preference)` so vestibular-sensitive users keep the instant snap behavior.

**Edits limited to `src/client/src/index.css` only.** No JS/TSX changes.

## Rules touched

Added `transition: padding 180ms ease, min-height 180ms ease`:
- `.card-body`
- `.modal-box`
- `.table th`
- `.table td`

Extended existing transition (merged padding/min-height into the property list):
- `.fab-mobile` (kept its existing `background-color`/`color`/`transform` 150ms transitions)

Skipped (already use `transition: all`, which already covers `padding`):
- `.stat` -> `transition: all 0.2s ease`
- `.menu li > a`, `.menu li > button` -> `transition: all 0.15s ease`

## Test plan

- [x] `npm run build` passes
- [ ] Toggle density slider in Settings -> Appearance -> verify card/table padding glides over ~180ms
- [ ] Cycle density via the navbar button -> verify no snap-jump
- [ ] Enable OS-level "reduce motion" -> verify density changes still snap instantly (no transition)
- [ ] Verify `.fab-mobile` hover/active animations still work as before on mobile

## Status

DRAFT - DO NOT MERGE.