### PR TITLE
test(client): density-settings regression suite (PR #2659 guard)

### DIFF
--- a/src/client/src/__tests__/density-css-smoke.test.ts
+++ b/src/client/src/__tests__/density-css-smoke.test.ts
@@ -1,0 +1,59 @@
+/**
+ * CSS structural smoke test — regression coverage for PR #2659.
+ *
+ * The density settings (`data-density`, `data-compact-density`) are wired up
+ * by uiStore via `<html>` data attributes. The CSS contract that turns those
+ * attributes into a visible effect lives in `src/client/src/index.css` and is
+ * keyed off the `--density-scale` custom property.
+ *
+ * The JSDOM-based store tests cover the JS->DOM half of the contract. This
+ * file covers the other half: that the CSS rules which give meaning to those
+ * attributes still exist. Without it, a refactor could silently delete the
+ * density rules and the JSDOM tests would still pass while the feature dies
+ * in production — exactly the bug class PR #2659 fixed.
+ *
+ * Regexes use \s* and accept either single or double quotes so trivial
+ * formatting changes don't trigger spurious failures.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const cssPath = join(__dirname, '../index.css');
+const css = readFileSync(cssPath, 'utf8');
+
+describe('density CSS contract (PR #2659 regression)', () => {
+  it('defines the --density-scale custom property', () => {
+    expect(css).toContain('--density-scale');
+  });
+
+  it('declares html[data-density="compact"] selector', () => {
+    expect(css).toMatch(/html\s*\[\s*data-density\s*=\s*["']compact["']\s*\]/);
+  });
+
+  it('declares html[data-density="comfortable"] selector', () => {
+    expect(css).toMatch(/html\s*\[\s*data-density\s*=\s*["']comfortable["']\s*\]/);
+  });
+
+  it('declares html[data-density="spacious"] selector', () => {
+    expect(css).toMatch(/html\s*\[\s*data-density\s*=\s*["']spacious["']\s*\]/);
+  });
+
+  it('declares html[data-compact-density="true"] selector', () => {
+    expect(css).toMatch(/html\s*\[\s*data-compact-density\s*=\s*["']true["']\s*\]/);
+  });
+
+  it('binds .card-body padding to var(--density-scale)', () => {
+    // Match the .card-body rule body and assert it references --density-scale.
+    // Keep the regex permissive on whitespace so reformatting doesn't break it.
+    const cardBodyMatch = css.match(/\.card-body\s*\{[^}]*\}/);
+    expect(cardBodyMatch, '.card-body rule must exist in index.css').not.toBeNull();
+    expect(cardBodyMatch![0]).toMatch(/var\s*\(\s*--density-scale/);
+  });
+
+  it('each density value sets a distinct --density-scale value', () => {
+    expect(css).toMatch(/html\s*\[\s*data-density\s*=\s*["']compact["']\s*\][^{]*\{[^}]*--density-scale\s*:/);
+    expect(css).toMatch(/html\s*\[\s*data-density\s*=\s*["']comfortable["']\s*\][^{]*\{[^}]*--density-scale\s*:/);
+    expect(css).toMatch(/html\s*\[\s*data-density\s*=\s*["']spacious["']\s*\][^{]*\{[^}]*--density-scale\s*:/);
+  });
+});

--- a/src/client/src/store/slices/__tests__/uiSlice.test.ts
+++ b/src/client/src/store/slices/__tests__/uiSlice.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for uiStore (Zustand) — migrated from the old Redux uiSlice tests.
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useUIStore } from '../../uiStore';
 
 // Reset Zustand store state between tests
@@ -179,6 +179,64 @@ describe('uiStore', () => {
     it('should set active section', () => {
       useUIStore.getState().setActiveSection('dashboard');
       expect(useUIStore.getState().activeSection).toBe('dashboard');
+    });
+  });
+
+  /**
+   * Regression coverage for PR #2659 — density settings used to be "dead":
+   * the JS state was set, but no DOM/CSS effect happened. These tests lock
+   * in the contract that setDensity / setCompactDensity / initializeFromLocalStorage
+   * each apply data-* attributes to <html>, which CSS variables key off of.
+   */
+  describe('density DOM side effects (PR #2659 regression)', () => {
+    afterEach(() => {
+      document.documentElement.removeAttribute('data-density');
+      document.documentElement.removeAttribute('data-compact-density');
+    });
+
+    it('setDensity("compact") writes data-density="compact" to <html>', () => {
+      useUIStore.getState().setDensity('compact');
+      expect(document.documentElement.getAttribute('data-density')).toBe('compact');
+    });
+
+    it('setDensity("comfortable") writes data-density="comfortable" to <html>', () => {
+      useUIStore.getState().setDensity('comfortable');
+      expect(document.documentElement.getAttribute('data-density')).toBe('comfortable');
+    });
+
+    it('setDensity("spacious") writes data-density="spacious" to <html>', () => {
+      useUIStore.getState().setDensity('spacious');
+      expect(document.documentElement.getAttribute('data-density')).toBe('spacious');
+    });
+
+    it('setCompactDensity(true) writes data-compact-density="true" to <html>', () => {
+      useUIStore.getState().setCompactDensity(true);
+      expect(document.documentElement.getAttribute('data-compact-density')).toBe('true');
+    });
+
+    it('setCompactDensity(false) writes data-compact-density="false" to <html>', () => {
+      useUIStore.getState().setCompactDensity(true);
+      useUIStore.getState().setCompactDensity(false);
+      expect(document.documentElement.getAttribute('data-compact-density')).toBe('false');
+    });
+
+    it('initializeFromLocalStorage applies persisted density and compactDensity to <html>', () => {
+      // setupTests.ts replaces localStorage with vi.fn() mocks, so we drive
+      // getItem directly. This still exercises the real initializeFromLocalStorage
+      // path (string-vs-bool parsing + setAttribute calls).
+      const getItemSpy = vi.spyOn(localStorage, 'getItem').mockImplementation((key: string) => {
+        if (key === 'density') return 'spacious';
+        if (key === 'compactDensity') return 'true';
+        return null;
+      });
+
+      try {
+        useUIStore.getState().initializeFromLocalStorage();
+        expect(document.documentElement.getAttribute('data-density')).toBe('spacious');
+        expect(document.documentElement.getAttribute('data-compact-density')).toBe('true');
+      } finally {
+        getItemSpy.mockRestore();
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

Locks in [PR #2659](https://github.com/matthewhand/open-hivemind/pull/2659)'s fix that wired up `density` and `compactDensity` settings to live CSS variables. Both settings had previously been dead — JS state was set, but no DOM or CSS effect happened.

This PR adds two complementary regression layers so the bug class (a setting whose UI control toggles state without any visible effect) cannot silently come back.

## What's added

**Layer 1 — `src/client/src/store/slices/__tests__/uiSlice.test.ts` (extended)**

Six new JSDOM tests under a new `density DOM side effects` describe block:

| Test | Guards |
| --- | --- |
| `setDensity('compact')` writes `data-density="compact"` | JS-to-DOM wiring for compact |
| `setDensity('comfortable')` writes `data-density="comfortable"` | JS-to-DOM wiring for comfortable |
| `setDensity('spacious')` writes `data-density="spacious"` | JS-to-DOM wiring for spacious |
| `setCompactDensity(true)` writes `data-compact-density="true"` | compactDensity ON path |
| `setCompactDensity(false)` writes `data-compact-density="false"` | compactDensity OFF path |
| `initializeFromLocalStorage()` re-applies persisted values to `<html>` | Boot-time hydration |

`afterEach` clears the `data-*` attributes from `<html>` so state cannot leak between tests.

**Layer 2 — `src/client/src/__tests__/density-css-smoke.test.ts` (new)**

Seven structural assertions against `src/client/src/index.css` (read with built-in `fs`/`path`):

| Assertion | Guards |
| --- | --- |
| File contains `--density-scale` | The custom property still exists |
| `html[data-density="compact"]` selector present | CSS half of compact wiring |
| `html[data-density="comfortable"]` selector present | CSS half of comfortable wiring |
| `html[data-density="spacious"]` selector present | CSS half of spacious wiring |
| `html[data-compact-density="true"]` selector present | CSS half of compact-density override |
| `.card-body` rule references `var(--density-scale)` | Consumer side actually uses the variable |
| Each `data-density` rule body contains a `--density-scale:` declaration | Each density value sets the variable |

Regexes use `\s*` and accept either single or double quotes so trivial reformatting doesn't trigger spurious failures. This layer catches the class of failure JSDOM-only tests miss (no real layout engine computes styles in JSDOM) — e.g. someone refactors the CSS and accidentally deletes the density rules.

## Constraints honored

- Pure additive change. No production code, store, or CSS modified.
- No new dependencies (uses built-in `fs`/`path`).
- All 36 vitest tests in the touched files pass; full `npm run build` passes.

## Test plan
- [x] `npx vitest run src/store/slices/__tests__/uiSlice.test.ts src/__tests__/density-css-smoke.test.ts` from `src/client/` — 36/36 pass
- [x] `npm run build` from repo root — succeeds
- [ ] CI green on this branch

## Do not merge

Opened as draft per request. Intent is to gate-keep against silent regressions of the dead-settings bug class; merge timing is up to the maintainer.