### PR TITLE
🧹 Janitor: Fix bit-rot in Encryption.test.ts

### DIFF
--- a/tests/database/Encryption.test.ts
+++ b/tests/database/Encryption.test.ts
@@ -6,6 +6,16 @@ import { IDatabase } from '../../src/database/types';
 describe('Database At-Rest Encryption', () => {
   let repository: BotConfigRepository;
   let mockDb: jest.Mocked<IDatabase>;
+  let originalKey: any;
+
+  beforeAll(() => {
+    originalKey = (encryptionService as any).encryptionKey;
+    (encryptionService as any).encryptionKey = Buffer.alloc(32, 'a');
+  });
+
+  afterAll(() => {
+    (encryptionService as any).encryptionKey = originalKey;
+  });
 
   beforeEach(() => {
     mockDb = {


### PR DESCRIPTION
🧹 Janitor: Fix bit-rot in Encryption.test.ts
💡 What: Added explicit mock setup and teardown for `encryptionService.encryptionKey` in `Encryption.test.ts`.
🎯 Why: The global test suite runs with `DISABLE_ENCRYPTION=true`, which disabled the encryption logic and broke the test expecting the `enc:` prefix. Setting a mock key allows the test to correctly pass in isolation.
🚦 Status: Fix verified and passes locally. Ready for merge.

---
*PR created automatically by Jules for task [7735822975516937763](https://jules.google.com/task/7735822975516937763) started by @matthewhand*