### PR TITLE
⚡ Bolt: Optimize component tracking usage lookup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,7 +35,3 @@
 ## 2026-04-25 - Optimize MCPServers array lookup
 **Learning:** React component renders often contain hidden O(N^2) complexity when checking for array duplicates using `.find()` inside `.forEach()` or `.map()` loops.
 **Action:** Replace nested array `.find()` operations during bulk processing with a pre-computed `Set` to achieve O(1) membership testing and linear overall time complexity.
-
-## 2026-04-30 - Optimizing nested list component tracking
-**Learning:** In `DaisyUIComponentTracker`, performing a `.find()` inside a `.map()` to correlate usage stats creates an O(N*M) lookup that scales poorly as the number of tracked components increases. This is a common React anti-pattern when rendering stats or complex lists.
-**Action:** Use `useMemo` to pre-calculate a lookup Map (e.g., `new Map(items.map(i => [i.key, i]))`) before the mapping loop, bringing the complexity down to O(N + M). This ensures O(1) lookups during the render cycle.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,3 +35,7 @@
 ## 2026-04-25 - Optimize MCPServers array lookup
 **Learning:** React component renders often contain hidden O(N^2) complexity when checking for array duplicates using `.find()` inside `.forEach()` or `.map()` loops.
 **Action:** Replace nested array `.find()` operations during bulk processing with a pre-computed `Set` to achieve O(1) membership testing and linear overall time complexity.
+
+## 2026-04-30 - Optimizing nested list component tracking
+**Learning:** In `DaisyUIComponentTracker`, performing a `.find()` inside a `.map()` to correlate usage stats creates an O(N*M) lookup that scales poorly as the number of tracked components increases. This is a common React anti-pattern when rendering stats or complex lists.
+**Action:** Use `useMemo` to pre-calculate a lookup Map (e.g., `new Map(items.map(i => [i.key, i]))`) before the mapping loop, bringing the complexity down to O(N + M). This ensures O(1) lookups during the render cycle.

--- a/src/client/src/components/DaisyUIComponentTracker.tsx
+++ b/src/client/src/components/DaisyUIComponentTracker.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars */
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import type { DaisyUIComponentStats } from '../utils/DaisyUIComponentTracker';
 import { daisyUITracker } from '../utils/DaisyUIComponentTracker';
 import Button from './DaisyUI/Button';
@@ -54,6 +54,8 @@ const DaisyUIComponentTracker: React.FC<Props> = ({ isOpen = true, onClose }) =>
 
   const usagePercentage = Math.round((stats.usedComponents / stats.totalComponents) * 100);
   const suggestions = daisyUITracker.getSuggestions();
+  const componentUsageMap = useMemo(() => new Map(stats.componentUsage.map(u => [u.component, u])), [stats.componentUsage]);
+
 
   return (
     <div className={`${isOpen ? 'block' : 'hidden'}`}>
@@ -213,7 +215,7 @@ const DaisyUIComponentTracker: React.FC<Props> = ({ isOpen = true, onClose }) =>
                     <div className="space-y-2 mt-2">
                       {data.components.length > 0 ? (
                         data.components.map((component) => {
-                          const usage = stats.componentUsage.find((u) => u.component === component);
+                          const usage = componentUsageMap.get(component);
                           return (
                             <div
                               key={component}


### PR DESCRIPTION
💡 **What**: Added a `useMemo` hook to pre-calculate a `Map` of component usage statistics (`componentUsageMap`) instead of calling `.find()` iteratively inside the category component `.map()`.

🎯 **Why**: The tracker component maps over arrays of components and, for each one, used `.find()` on the `stats.componentUsage` array. This causes an O(N * M) lookup complexity on every render, which is a common frontend performance anti-pattern. Pre-calculating a Map yields O(1) lookups during the render phase.

📊 **Impact**: Reduces rendering time complexity in the "Categories" tab from O(N*M) to O(N+M), providing a snappier feel and reducing main thread blocking as the component library grows.

🔬 **Measurement**: 
- Verified logic by successfully running `pnpm run build` in the client directory.
- `vitest` tests pass with no new regressions.
- Recorded the specific learning in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [16366446047856089699](https://jules.google.com/task/16366446047856089699) started by @matthewhand*