### PR TITLE
feat(client): show density toggle on mobile breakpoints

### DIFF
--- a/src/client/src/components/DaisyUI/NavbarWithSearch.tsx
+++ b/src/client/src/components/DaisyUI/NavbarWithSearch.tsx
@@ -549,7 +549,7 @@ const NavbarWithSearch: React.FC<NavbarWithSearchProps> = ({
         >
           <button
             type="button"
-            className="btn btn-ghost btn-circle btn-sm hidden sm:inline-flex"
+            className="btn btn-ghost btn-circle btn-sm"
             onClick={cycleDensity}
             aria-label={`UI density: ${densityMeta.label}. Activate to switch density.`}
             data-density={density}


### PR DESCRIPTION
## Summary

The density quick-toggle in `NavbarWithSearch.tsx` was gated by `hidden sm:inline-flex`, hiding it on mobile viewports — but compact density is *most* valuable on small screens, where vertical space is at a premium. Removing the breakpoint gate so the control is available everywhere desktop users already have it.

## Change

One-line className edit in `src/client/src/components/DaisyUI/NavbarWithSearch.tsx` (line 552):

```diff
- className="btn btn-ghost btn-circle btn-sm hidden sm:inline-flex"
+ className="btn btn-ghost btn-circle btn-sm"
```

## Layout impact at mobile widths

The button is `btn-circle btn-sm` (~32px), wrapped in a `Tooltip`. Adjacent navbar items already render at mobile (ShieldAlert button, theme dropdown trigger, avatar), so adding one more `btn-sm` circle is well within the navbar's flex budget on iPhone-sized viewports. The preceding `Divider` retains its `hidden sm:flex` since it's purely cosmetic.

## Screenshots

Not captured in this PR — the worktree environment does not have `node_modules` installed and dependency installation was not permitted within the task budget. Reviewer can verify locally by toggling DevTools to iPhone viewport on `/admin/bots`: the compact-density button should appear in the navbar action cluster.

## Test plan

- [ ] Open `/admin/bots` at iPhone 14 Pro width (393px) — density toggle is visible in navbar
- [ ] Click cycles compact → comfortable → spacious
- [ ] Tooltip renders correctly on touch devices
- [ ] Desktop layout (>=640px) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)