### PR TITLE
fix(client): scale MobileFAB horizontal insets with density (1.5rem base)

### DIFF
--- a/src/client/src/index.css
+++ b/src/client/src/index.css
@@ -1414,9 +1414,9 @@ body.robot-ui-enabled .btn-accent {
 }
 
 .fab-mobile-left {
-  left: 3rem;
+  left: calc(1.5rem * var(--density-scale, 1));
 }
 
 .fab-mobile-right {
-  right: 3rem;
+  right: calc(1.5rem * var(--density-scale, 1));
 }


### PR DESCRIPTION
## Summary

`.fab-mobile-left` and `.fab-mobile-right` (in `src/client/src/index.css`, lines 1416–1422) hard-coded `left: 3rem` / `right: 3rem`, even though the rest of `.fab-mobile` (`bottom`, `width`, `height`) scales with `var(--density-scale, 1)`. At compact density the FAB shrinks and moves up — but its horizontal distance from the screen edge stays glued to `3rem`, producing a visibly asymmetric inset (lots of vertical compression, no horizontal compression).

This PR makes two adjustments:

- **Density-scale the horizontal inset** for parity with the existing scaled properties: `calc(1.5rem * var(--density-scale, 1))`.
- **Reduce the base inset from `3rem` to `1.5rem`**, which is closer to the standard FAB edge-inset convention (Material spec ~16px, Apple HIG ~20pt). `3rem` (48px) was unusually large for a FAB.

### Diff

```diff
 .fab-mobile-left {
-  left: 3rem;
+  left: calc(1.5rem * var(--density-scale, 1));
 }

 .fab-mobile-right {
-  right: 3rem;
+  right: calc(1.5rem * var(--density-scale, 1));
 }
```

## Test plan

- [ ] Load any page with `.fab-mobile` on a mobile viewport (e.g. iPhone 14 Pro emulation, 393×852).
- [ ] Toggle density between Comfortable and Compact — confirm the FAB now compresses horizontally in lockstep with its vertical/size compression (no asymmetry).
- [ ] Confirm the FAB no longer sits an awkward 48px from the edge at default density; it should rest ~24px from the edge, matching standard FAB conventions.
- [ ] Verify both `.fab-mobile-left` and `.fab-mobile-right` variants behave consistently.

> Screenshots intentionally omitted — opened as draft so a reviewer with a running dev server can attach the visual before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)