### PR TITLE
fix(client): respect iOS safe-area and use press-down scale on MobileFAB

### DIFF
--- a/src/client/src/index.css
+++ b/src/client/src/index.css
@@ -1380,7 +1380,10 @@ body.robot-ui-enabled .btn-accent {
  * ============================================================ */
 .fab-mobile {
   position: fixed;
-  bottom: calc(1.5rem * var(--density-scale, 1));
+  /* Add iOS safe-area inset so the FAB sits above the home-indicator
+   * gesture bar at compact density (where 1.5rem * scale collapses to
+   * ~14px and would otherwise overlap the indicator). */
+  bottom: calc(1.5rem * var(--density-scale, 1) + env(safe-area-inset-bottom, 0px));
   width: calc(3.5rem * var(--density-scale, 1));
   height: calc(3.5rem * var(--density-scale, 1));
   display: flex;
@@ -1399,12 +1402,30 @@ body.robot-ui-enabled .btn-accent {
 }
 
 .fab-mobile:hover,
-.fab-mobile:active,
 .fab-mobile:focus-visible {
   background-color: oklch(var(--p));
   color: oklch(var(--pc));
-  transform: scale(1.06);
   outline: none;
+}
+
+.fab-mobile:active {
+  background-color: oklch(var(--p));
+  color: oklch(var(--pc));
+  outline: none;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .fab-mobile:hover,
+  .fab-mobile:focus-visible {
+    transform: scale(1.06);
+  }
+
+  .fab-mobile:active {
+    /* Press-down feedback (HIG/Material convention) — previous rule
+     * applied scale(1.06) on :active, which grew the button under the
+     * finger instead of acknowledging the press. */
+    transform: scale(0.96);
+  }
 }
 
 .fab-mobile:disabled {


### PR DESCRIPTION
## Summary

Two CSS-only fixes to `.fab-mobile` in `src/client/src/index.css` that affect every iOS user.

### Fix 1 — iOS safe-area clip

`.fab-mobile` previously set `bottom: calc(1.5rem * var(--density-scale, 1))`. At **compact density** (`--density-scale` ~ 0.6), this collapses to roughly **14px** — well inside the iOS home-indicator gesture bar, where the FAB visually overlaps the indicator and competes with the system swipe-up gesture.

```diff
- bottom: calc(1.5rem * var(--density-scale, 1));
+ bottom: calc(1.5rem * var(--density-scale, 1) + env(safe-area-inset-bottom, 0px));
```

`env(safe-area-inset-bottom, 0px)` is a no-op on platforms without a safe-area inset (desktop, Android with no gesture bar, etc.), so the change is strictly additive on iPhones with a home indicator. Existing density scaling on `bottom`/`width`/`height` is preserved.

### Fix 2 — Inverted tap feedback

The previous rule applied `transform: scale(1.06)` on **`:hover`, `:active`, AND `:focus-visible`** simultaneously. On touch devices `:active` fires under the finger — so the button **grew** when pressed instead of acknowledging the press, the opposite of both Apple HIG and Material Design conventions.

The fix splits the selectors:

- `:hover, :focus-visible` → `scale(1.06)` (grow on cursor/keyboard focus, unchanged behaviour for those input modes)
- `:active` → `scale(0.96)` (press-down, the standard tactile feedback)

Both transforms are now wrapped in `@media (prefers-reduced-motion: no-preference)` so users who opt into reduced motion get only the colour change without any scaling.

Background/foreground colour swap on `:hover`/`:focus-visible`/`:active` is unchanged.

## Test plan

- [ ] On iPhone (Safari), open `/admin/bots` at compact density — verify the FAB sits clearly above the home-indicator gesture bar.
- [ ] On iPhone, tap the FAB — verify it briefly shrinks under the finger (was: grew).
- [ ] On desktop, hover the FAB with a mouse — verify it still grows to 1.06x on hover.
- [ ] Tab to the FAB with the keyboard — verify the focus ring + scale 1.06 still appears.
- [ ] Toggle macOS / iOS "Reduce Motion" — verify the colour swap still happens but the scale transform is suppressed.
- [ ] Existing `MobileFAB.test.tsx` (class-application checks) continues to pass — the changes are CSS-only and do not touch class names.

## Scope

Strictly two CSS rule edits in `src/client/src/index.css`. No JS, no markup, no other files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)