### PR TITLE
fix(client): scope WCAG touch-target floor to coarse pointer only

### DIFF
--- a/src/client/src/index.css
+++ b/src/client/src/index.css
@@ -240,11 +240,18 @@ textarea {
 .menu li>button {
   transition: all 0.15s ease;
   padding: calc(0.5rem * var(--density-scale, 1)) calc(1rem * var(--density-scale, 1));
-  /* WCAG AAA touch-target floor (44px). At default density (scale=1) the
-     natural height already exceeds this, so the floor is a no-op; it only
-     activates under compact × compactDensity (scale=0.595) where items
-     would otherwise shrink to ~25.5px. */
-  min-height: 2.75rem;
+}
+
+/* WCAG AAA touch-target floor (44px) — scoped to coarse-pointer (touch)
+   devices only. Applying it to fine-pointer (mouse) users would pin every
+   sidebar item at 44px regardless of the density setting, neutralizing
+   density on the largest density-affected surface. Touch users still get
+   AAA-compliant targets; mouse users see the density-scaled height. */
+@media (pointer: coarse) {
+  .menu li>a,
+  .menu li>button {
+    min-height: 2.75rem;
+  }
 }
 
 .menu li>a:hover,


### PR DESCRIPTION
## Summary

The `.menu li > a, .menu li > button` rule in `src/client/src/index.css` set a `min-height: 2.75rem` floor (44px, WCAG 2.1 AAA target size) for every pointer type. On fine-pointer (mouse) devices this pinned every sidebar item to 44px regardless of the user's density setting, neutralizing density on the largest density-affected surface in the app and making the slider feel broken.

This change wraps only the `min-height` declaration in `@media (pointer: coarse)`, so:

- Touch / coarse-pointer users still get AAA-compliant 44px hit targets.
- Fine-pointer (mouse) users now see the real, density-scaled height — the sidebar visibly compacts under `compact` × `compactDensity`.

The padding rule and transition stay on the unscoped selector since they're pointer-agnostic.

### Why a pointer media query (and not, say, `hover`)

WCAG 2.5.5 AAA Target Size's intent is to protect users who lack precise pointing. `pointer: coarse` is the standard CSS signal for that population (touch / stylus on most devices) and is widely supported across modern browsers. Mice and trackpads report `pointer: fine` and don't need the larger hit area — so scoping the floor to coarse pointers is the minimal, semantically correct fix.

### Diff

```css
.menu li>a,
.menu li>button {
  transition: all 0.15s ease;
  padding: calc(0.5rem * var(--density-scale, 1)) calc(1rem * var(--density-scale, 1));
}

@media (pointer: coarse) {
  .menu li>a,
  .menu li>button {
    min-height: 2.75rem;
  }
}
```

## Test plan

- [x] `density-css-smoke.test.ts` (vitest) still passes — 7/7 tests, no assertion changes needed.
- [ ] Manual: at fine-pointer desktop viewport, toggle density slider — sidebar items should visibly shrink under `compact` × `compactDensity` (no longer pinned at 44px).
- [ ] Manual: emulate mobile / touch device — sidebar items should remain >=44px tall regardless of density.
- [ ] Existing density E2E spec (PR #2676) should continue to pass.

## Notes

- Pure scope fix: the floor value (2.75rem) and selector (`.menu li > a, .menu li > button`) are unchanged — only the media context is narrowed.
- No other rules touched.