### PR TITLE
a11y(client): restore chevron on BotsPage view-mode dropdown trigger

### DIFF
--- a/src/client/src/pages/BotsPage/index.tsx
+++ b/src/client/src/pages/BotsPage/index.tsx
@@ -200,9 +200,8 @@ const BotsPage: React.FC = () => {
               color="ghost"
               size="sm"
               className="dropdown-end"
-              triggerClassName="btn-square focus-visible:ring-2 ring-base-content focus-visible:ring-offset-2 ring-offset-base-100 focus-visible:outline-none"
+              triggerClassName="gap-1 focus-visible:ring-2 ring-base-content focus-visible:ring-offset-2 ring-offset-base-100 focus-visible:outline-none"
               contentClassName="shadow-lg w-44 z-20"
-              hideArrow
               aria-label={`View mode: ${
                 viewMode === 'swarm3d' ? '3D Swarm' : viewMode === 'compact' ? 'Compact' : 'Grid'
               }`}


### PR DESCRIPTION
## Summary

The BotsPage view-mode dropdown trigger currently sets `hideArrow`, so it renders only the active mode icon inside a `btn-square` button. With no chevron, the trigger visually reads as a single-purpose icon button — exactly the cycle-button anti-pattern that PR #2660 set out to replace. This change drops `hideArrow` (and the `btn-square` constraint) so the shared `Dropdown` renders its standard `ChevronDown` next to the active-mode icon, giving users a clear menu affordance.

- Removes `hideArrow` from the view-mode `<Dropdown>` in `src/client/src/pages/BotsPage/index.tsx`.
- Swaps the `btn-square` trigger class for `gap-1` so the leading icon and chevron sit comfortably side-by-side.
- No prop or API changes; `Dropdown.tsx` already renders `ChevronDownIcon` whenever `hideArrow` is falsy.

## Before / After

Live screenshots were attempted but skipped due to sandbox restrictions on starting the dev server (cross-env not on PATH in this environment). The behavioural change is fully covered by the one-line diff: the standard `ChevronDownIcon` rendered by `Dropdown.tsx` (line 108) now appears alongside the active-mode icon, where previously it was suppressed.

## Test plan

- [ ] `pnpm dev`, navigate to `/admin/bots`, confirm the view-mode trigger now shows a chevron next to the mode icon.
- [ ] Click the trigger — menu opens; selecting an option still updates `viewMode` and the leading icon.
- [ ] Keyboard: Tab to trigger, Enter / Space opens the menu, Escape closes it, focus ring is visible.
- [ ] Trigger remains right-aligned within the toolbar (still uses `dropdown-end`).
- [ ] No regressions in screen-reader output — `aria-label` still reflects the active mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)