### PR TITLE
a11y(client): announce density changes; remove dead data-density attr

### DIFF
--- a/src/client/src/components/DaisyUI/NavbarWithSearch.tsx
+++ b/src/client/src/components/DaisyUI/NavbarWithSearch.tsx
@@ -552,11 +552,12 @@ const NavbarWithSearch: React.FC<NavbarWithSearchProps> = ({
             className="btn btn-ghost btn-circle btn-sm hidden sm:inline-flex"
             onClick={cycleDensity}
             aria-label={`UI density: ${densityMeta.label}. Activate to switch density.`}
-            data-density={density}
           >
             <DensityIcon className="w-5 h-5" />
           </button>
         </Tooltip>
+        {/* Polite live region: announces the new density value to screen readers when state changes. */}
+        <span aria-live="polite" aria-atomic="true" className="sr-only">{`Density: ${densityMeta.label}`}</span>
 
         {/* Improved Theme Switcher integration */}
         <div className="hidden sm:flex">


### PR DESCRIPTION
## Summary

Two small a11y/cleanup fixes on the navbar density toggle in `src/client/src/components/DaisyUI/NavbarWithSearch.tsx`:

1. **Remove dead `data-density` attribute on the toggle button.** The attribute had no CSS consumer.
2. **Add polite `aria-live` region** so screen readers announce the new density value when state changes (previously the `aria-label` updated silently and required re-focus to be re-announced).

## Fix 1: Dead `data-density` attribute

The button at `NavbarWithSearch.tsx:555` set:

```tsx
data-density={density}
```

`grep` confirms no CSS selector matches `button[data-density]` or `[data-density]` on anything other than `<html>`:

```
$ grep -rn 'data-density' src/client/src
src/client/src/index.css:15:     Driven by <html data-density="..."> set by uiStore.setDensity,
src/client/src/index.css:20:html[data-density="compact"] { --density-scale: 0.7; }
src/client/src/index.css:21:html[data-density="comfortable"] { --density-scale: 1; }
src/client/src/index.css:22:html[data-density="spacious"] { --density-scale: 1.25; }
src/client/src/store/uiStore.ts:329:    document.documentElement.setAttribute('data-density', density);
src/client/src/store/uiStore.ts:415:    document.documentElement.setAttribute('data-density', state.density);
src/client/src/components/DaisyUI/NavbarWithSearch.tsx:555:            data-density={density}
```

The CSS only targets `html[data-density="..."]`, which `uiStore` already sets on `document.documentElement`. The duplicate attribute on the button was unused.

## Fix 2: Live region for density changes

The toggle's `aria-label` is updated when density changes, but ARIA labels on a focused element are not re-announced when their text changes. Added a sibling `<span aria-live="polite" aria-atomic="true" className="sr-only">` (matching the pattern already used in `Pagination.tsx`) so the new density value is politely announced when state cycles.

## Test plan

- [ ] Click the density toggle in the navbar — verify visual cycle (compact → comfortable → spacious) still works.
- [ ] With a screen reader (VoiceOver / NVDA), click the toggle and confirm the new density label is announced.
- [ ] Inspect the DOM — confirm the toggle button no longer has a `data-density` attribute.
- [ ] Confirm `html[data-density="..."]` is still set by uiStore (CSS `--density-scale` should still respond to clicks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)