### PR TITLE
refactor(client): reduce view-mode dropdown active-state to 2 visual signals

### DIFF
--- a/src/client/src/pages/BotsPage/__tests__/index.test.tsx
+++ b/src/client/src/pages/BotsPage/__tests__/index.test.tsx
@@ -151,9 +151,10 @@ describe('BotsPage', () => {
     const active = items.find((el) => el.getAttribute('aria-checked') === 'true');
     expect(active).toBeTruthy();
     expect(active!.textContent).toContain('Compact');
-    expect(active!.className).toContain('bg-base-200');
     expect(active!.className).toContain('border-l-2');
     expect(active!.className).toContain('border-primary');
+    expect(active!.className).not.toContain('font-semibold');
+    expect(active!.className).not.toContain('bg-base-200');
   });
 
   it('renders the MobileFAB pair only when isMobile is true', () => {

--- a/src/client/src/pages/BotsPage/index.tsx
+++ b/src/client/src/pages/BotsPage/index.tsx
@@ -217,7 +217,7 @@ const BotsPage: React.FC = () => {
                   <li key={opt.value}>
                     <a
                       onClick={(e) => { e.stopPropagation(); setViewMode(opt.value); }}
-                      className={`flex items-center gap-2 ${isActive ? 'active font-semibold bg-base-200 border-l-2 border-primary pl-2' : ''}`}
+                      className={`flex items-center gap-2 ${isActive ? 'active border-l-2 border-primary pl-2' : ''}`}
                       role="menuitemradio"
                       aria-checked={isActive}
                     >


### PR DESCRIPTION
## Summary
- The view-mode dropdown items in `src/client/src/pages/BotsPage/index.tsx` previously stacked **five** simultaneous active-state indicators: `active` class, `font-semibold`, `bg-base-200`, `border-l-2 border-primary pl-2`, and a trailing `<Check />` icon. Visual noise from competing emphasis.
- Reduced to **two** discoverable, accessible signals (plus the underlying `aria-checked` semantic):
  - Left primary border (`border-l-2 border-primary pl-2`)
  - Trailing `<Check />` icon
- Dropped: `font-semibold` (font-weight shift) and `bg-base-200` (background fill).
- The DaisyUI `active` class is retained — it's the semantic hook the menu item uses; visual styling within it is now intentionally minimal.

## Before / After
Before: active item rendered with bold text + tinted background + left border + check + `aria-checked`.
After: active item rendered with left border + check + `aria-checked` only.

(Open-menu screenshots skipped — local dev server capture was out of budget; visual diff is fully captured in the one-line className change below.)

```diff
- className={`flex items-center gap-2 ${isActive ? 'active font-semibold bg-base-200 border-l-2 border-primary pl-2' : ''}`}
+ className={`flex items-center gap-2 ${isActive ? 'active border-l-2 border-primary pl-2' : ''}`}
```

## Test plan
- [x] Updated `src/client/src/pages/BotsPage/__tests__/index.test.tsx` assertion: dropped the `bg-base-200` expectation, added negative assertions for `font-semibold` and `bg-base-200`, kept `border-l-2` + `border-primary` checks.
- [ ] Reviewer: open the BotsPage view-mode dropdown and confirm the active row has only the left primary border and trailing check, with no bold text or tinted background.
- [ ] Reviewer: confirm `aria-checked="true"` still correctly identifies the active row (a11y unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)