### PR TITLE
fix(client): preserve caller's icon in MobileFAB loading state

### DIFF
--- a/src/client/src/components/MobileFAB.tsx
+++ b/src/client/src/components/MobileFAB.tsx
@@ -1,5 +1,5 @@
 import React, { memo, ReactNode } from 'react';
-import { RefreshCw } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 
 export interface MobileFABProps {
   /** Which side of the viewport to anchor the FAB to. */
@@ -7,9 +7,9 @@ export interface MobileFABProps {
   /**
    * Icon node rendered inside the FAB.
    *
-   * NOTE: When `loading` is `true`, this prop is **ignored** and replaced by a
-   * hardcoded `RefreshCw` spinner with `animate-spin`. The caller's `icon` is
-   * not preserved during the loading state.
+   * The caller's `icon` is always rendered. When `loading` is `true`, the icon
+   * is dimmed (via `opacity-30`) and a `Loader2` spinner is overlaid on top —
+   * so the FAB still visually communicates which action it represents.
    */
   icon: ReactNode;
   /** Click handler. */
@@ -19,9 +19,9 @@ export interface MobileFABProps {
   /** Disables the button. */
   disabled?: boolean;
   /**
-   * When `true`, the supplied `icon` is replaced by a hardcoded animated
-   * `RefreshCw` spinner. The caller's `icon` value is discarded for the
-   * duration of the loading state.
+   * When `true`, the caller's `icon` is rendered at reduced opacity with a
+   * `Loader2` spinner overlay. The button also receives `aria-busy="true"`
+   * and `aria-disabled="true"` for assistive tech.
    */
   loading?: boolean;
   /** Additional Tailwind classes (appended after the FAB classes). */
@@ -46,7 +46,7 @@ const MobileFAB: React.FC<MobileFABProps> = ({
   className = '',
 }) => {
   const positionClass = position === 'left' ? 'fab-mobile-left' : 'fab-mobile-right';
-  const composed = `fab-mobile ${positionClass} md:hidden${className ? ` ${className}` : ''}`;
+  const composed = `fab-mobile ${positionClass} md:hidden relative${className ? ` ${className}` : ''}`;
 
   return (
     <button
@@ -55,8 +55,16 @@ const MobileFAB: React.FC<MobileFABProps> = ({
       onClick={onClick}
       disabled={disabled}
       aria-label={ariaLabel}
+      aria-busy={loading}
+      aria-disabled={loading || disabled}
     >
-      {loading ? <RefreshCw className="w-6 h-6 animate-spin" /> : icon}
+      <span className={loading ? 'opacity-30' : undefined}>{icon}</span>
+      {loading && (
+        <Loader2
+          className="absolute inset-0 m-auto w-5 h-5 animate-spin"
+          aria-hidden="true"
+        />
+      )}
     </button>
   );
 };

--- a/src/client/src/components/__tests__/MobileFAB.test.tsx
+++ b/src/client/src/components/__tests__/MobileFAB.test.tsx
@@ -33,7 +33,7 @@ describe('MobileFAB', () => {
     expect(screen.getByText('CUSTOM')).toBeInTheDocument();
   });
 
-  it('renders an animate-spin spinner instead of the icon when loading is true', () => {
+  it('overlays an animate-spin spinner while preserving the caller icon when loading is true', () => {
     const { container } = render(
       <MobileFAB
         position="left"
@@ -43,8 +43,32 @@ describe('MobileFAB', () => {
         loading
       />
     );
-    expect(screen.queryByTestId('custom-icon')).not.toBeInTheDocument();
+    // Caller's icon must still be in the DOM so the FAB visually communicates the action.
+    expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+    // A spinner is overlaid on top.
     expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+  });
+
+  it('sets aria-busy="true" on the button while loading', () => {
+    render(
+      <MobileFAB
+        position="left"
+        icon={<span>i</span>}
+        onClick={() => {}}
+        ariaLabel="fab"
+        loading
+      />
+    );
+    const btn = screen.getByRole('button', { name: 'fab' });
+    expect(btn).toHaveAttribute('aria-busy', 'true');
+    expect(btn).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('sets aria-busy="false" when not loading', () => {
+    render(
+      <MobileFAB position="left" icon={<span>i</span>} onClick={() => {}} ariaLabel="fab" />
+    );
+    expect(screen.getByRole('button', { name: 'fab' })).toHaveAttribute('aria-busy', 'false');
   });
 
   it('calls onClick exactly once when clicked', () => {


### PR DESCRIPTION
## Summary

`MobileFAB` previously discarded the caller's `icon` prop whenever `loading={true}` and rendered a hardcoded `RefreshCw` spinner in its place. A Create FAB (or any non-refresh action) in loading state therefore showed a spinning refresh icon — visually claiming the wrong action and confusing users about what is in progress.

This change keeps the caller's `icon` rendered at all times and overlays a small `Loader2` spinner on top during loading, so the FAB still communicates which action is in flight.

- Always render the caller's `icon`; dim it via `opacity-30` while loading.
- Overlay a `Loader2` spinner (`absolute inset-0 m-auto w-5 h-5 animate-spin`) when loading.
- Make the button `relative` so the absolute overlay anchors to it.
- Set `aria-busy={loading}` and `aria-disabled={loading || disabled}` for assistive tech.
- Replace `RefreshCw` import with `Loader2` (generic spinner, no implied semantics).

## Test plan

- [x] `vitest run src/components/__tests__/MobileFAB.test.tsx` — 9 passed
- [x] New test: caller's `icon` remains in the DOM when `loading={true}`
- [x] New test: button has `aria-busy="true"` and `aria-disabled="true"` while loading
- [x] New test: button has `aria-busy="false"` when not loading
- [x] Updated existing loading test: now asserts overlay coexists with the caller icon
- [ ] Manual smoke: trigger loading state on a Create FAB and confirm the create icon still shows underneath the spinner
- [ ] Visual regression: confirm `opacity-30` dimming reads correctly across light/dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)