### PR TITLE
fix(security): require auth on 8 unprotected /api router mounts

### DIFF
--- a/src/server/registerRoutes.ts
+++ b/src/server/registerRoutes.ts
@@ -123,19 +123,19 @@ export function registerRoutes(app: import('express').Application, ctx: RouteCon
 
   // 3. Resource routers (specific paths, no catch-all conflict)
   app.use('/api/activity', authenticateToken, activityRouter);
-  app.use('/api/agents', agentsRouter);
-  app.use('/api/dashboard', dashboardRouter);
-  app.use('/api/config', webuiConfigRouter);
-  app.use('/api/bots', botsRouter);
+  app.use('/api/agents', authenticateToken, agentsRouter);
+  app.use('/api/dashboard', authenticateToken, dashboardRouter);
+  app.use('/api/config', authenticateToken, webuiConfigRouter);
+  app.use('/api/bots', authenticateToken, botsRouter);
   app.use('/api/bot-config', botConfigRouter);
   app.use('/api/validation', validationRouter);
-  app.use('/api/hot-reload', hotReloadRouter);
+  app.use('/api/hot-reload', authenticateToken, hotReloadRouter);
   app.use('/api/ci', ciRouter);
-  app.use('/api/enterprise', enterpriseRouter);
-  app.use('/api/secure-config', secureConfigRouter);
+  app.use('/api/enterprise', authenticateToken, enterpriseRouter);
+  app.use('/api/secure-config', authenticateToken, secureConfigRouter);
   app.use('/api/admin', adminApiRouter);
   app.use('/api/integrations', integrationsRouter);
-  app.use('/api/letta', lettaRouter);
+  app.use('/api/letta', authenticateToken, lettaRouter);
   app.use('/api/marketplace', marketplaceRouter);
   app.use('/api/mcp', mcpRouter);
   app.use('/api/mcp-tools', mcpToolsRouter);


### PR DESCRIPTION
## Summary

Audit of `src/server/registerRoutes.ts` following [PR #2637](https://github.com/matthewhand/open-hivemind/pull/2637) (which patched only `/api/activity`) found **8 additional resource routers** mounted without `authenticateToken` middleware:

- `/api/bots` (23 routes, zero auth references — read/write/delete/clone/test-chat all reachable)
- `/api/agents`
- `/api/dashboard`
- `/api/config`
- `/api/enterprise`
- `/api/secure-config`
- `/api/hot-reload`
- `/api/letta`

All were reachable by anyone passing the optional IP whitelist — and that whitelist disables entirely when `HTTP_ALLOW_ALL_IPS=true`. Bot configurations include the provider API keys that the recent at-rest encryption work (PRs #2629/#2632) just protected. Leaving the API itself unauthenticated effectively negates that defense.

## Why this PR

PR #2637 fixed `/api/activity` but not the rest of the `/api/*` mount table. The audit followed the same review process and applies the **same one-line pattern** (`authenticateToken` at the mount site) to the remaining unprotected routers. No new middleware introduced.

## What's NOT touched

Routers that already enforce auth internally via `router.use(authenticate, requireAdmin)` are intentionally left unchanged: `admin`, `bot-config`, `mcp`, `integrations`, `marketplace`, `templates`, `demo`, `pluginSecurity`. Adding mount-site auth there is defense-in-depth but not strictly needed.

The following routers are also currently unprotected and **should be reviewed in a follow-up** (intentionally out of scope for this PR to keep it small): `/api/onboarding`, `/api/personas`, `/api/providers`, `/api/usage-tracking`, `/api/webhooks`, `/api/mcp-tools`, `/api/validation`, `/api/ci`. Some may be intentional (read-only, public), but each needs an explicit decision.

## Test plan

- [ ] Manual: hit `GET /api/bots` without token → expect 401 (was 200 before)
- [ ] Manual: hit `GET /api/bots` with valid token → expect 200
- [ ] Repeat for the other 7 routers
- [ ] Existing CI green
- [ ] Add `tests/unit/server/api-auth-mounts.test.ts` asserting 401 on each of the 8 routers (recommend as separate follow-up — note that PR #2637's `tests/unit/server/activity-api-auth.test.ts` was deleted in commit `d2686d2e3` during a test cleanup sweep, so there's no precedent file to extend)

## Risks

- Any external script or integration calling these endpoints unauthenticated will start getting 401s. This is the **intended** behavior — those callers should never have been working without auth — but operators with custom integrations should be alerted via release notes.
- Internal service-to-service calls within the app should already use authenticated client sessions. If any do not, they will need fixing as part of this rollout.

## Related

- Original fix: PR #2637 (`/api/activity`)
- At-rest encryption: PRs #2629, #2632 (the credentials this PR protects)
- Test gap: commit `d2686d2e3` removed the auth-mount test file added by #2637

🤖 Generated with [Claude Code](https://claude.com/claude-code)