### PR TITLE
fix(client): remove hardcoded Active Bots/MCP Nodes mock values from navbar

### DIFF
--- a/src/client/src/components/DaisyUI/NavbarWithSearch.tsx
+++ b/src/client/src/components/DaisyUI/NavbarWithSearch.tsx
@@ -502,8 +502,6 @@ const NavbarWithSearch: React.FC<NavbarWithSearchProps> = ({
           <ul tabIndex={0} className="dropdown-content z-[40] menu p-3 shadow-2xl bg-base-100 rounded-box w-64 border border-base-200 mt-2">
             <li className="menu-title text-xs opacity-40 uppercase tracking-widest font-bold mb-2">Live Infrastructure</li>
             <li><a className="flex justify-between py-2 font-medium"><span>🟢 System Status</span> <Badge variant="success" size="xs">Healthy</Badge></a></li>
-            <li><a className="flex justify-between py-2"><span>🤖 Active Bots</span> <span className="font-mono text-xs">3</span></a></li>
-            <li><a className="flex justify-between py-2"><span>📡 MCP Nodes</span> <span className="font-mono text-xs">5</span></a></li>
             <Divider className="my-1" />
             <li><a href="/admin/monitoring" className="btn btn-xs btn-primary btn-outline mt-2">View Health Dashboard</a></li>
           </ul>


### PR DESCRIPTION
## Summary

The system status dropdown in \`NavbarWithSearch.tsx:505-506\` shipped two literal mock values to every user:

\`\`\`tsx
<li><a className="flex justify-between py-2"><span>🤖 Active Bots</span> <span className="font-mono text-xs">3</span></a></li>
<li><a className="flex justify-between py-2"><span>📡 MCP Nodes</span> <span className="font-mono text-xs">5</span></a></li>
\`\`\`

Real data wiring requires plumbing \`useStatus()\` / MCP-status hooks into the navbar and adding loading/error handling — out of scope for this hotfix. This PR just removes the mock lines.

The "View Health Dashboard" button below already gives users a path to real, accurate counts.

## Test plan
- [x] Visual: dropdown still has System Status + Healthy badge + Health Dashboard CTA
- [x] No new dependencies or data fetches introduced

## Follow-up
A separate PR can wire real \`apiService.getStatus()\` data with proper loading state if the items are still desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)