### PR TITLE
perf(database): set SQLite PRAGMAs at connection time (WAL, foreign_keys, etc.)

### DIFF
--- a/src/database/sqliteWrapper.ts
+++ b/src/database/sqliteWrapper.ts
@@ -37,6 +37,28 @@ export class SQLiteWrapper implements IDatabase {
     }
 
     this.db = new DBConstructor(filename);
+    this.applyPragmas();
+  }
+
+  private applyPragmas(): void {
+    try {
+      // WAL gives concurrent reads alongside a single writer.
+      this.db.pragma('journal_mode = WAL');
+      // synchronous=NORMAL is durable across crashes when paired with WAL and
+      // significantly faster than FULL.
+      this.db.pragma('synchronous = NORMAL');
+      // Without this every FOREIGN KEY constraint declared in migrations is inert.
+      this.db.pragma('foreign_keys = ON');
+      // Wait up to 5s for a competing writer instead of failing immediately.
+      this.db.pragma('busy_timeout = 5000');
+      // Keep temp tables/indexes in memory rather than spilling to disk.
+      this.db.pragma('temp_store = MEMORY');
+      // 64MB page cache (negative value = KB).
+      this.db.pragma('cache_size = -64000');
+      debug('Applied SQLite PRAGMAs: WAL, synchronous=NORMAL, foreign_keys=ON');
+    } catch (e) {
+      debug('Failed to apply one or more PRAGMAs (continuing):', e);
+    }
   }
 
   async run(sql: string, params: any[] = []): Promise<{ lastID: number; changes: number }> {


### PR DESCRIPTION
## Summary

The SQLite wrapper opened every connection with **default PRAGMAs**:
- \`journal_mode=DELETE\` — no concurrent reads during a write
- \`synchronous=FULL\` — extra fsyncs
- **\`foreign_keys=OFF\`** — every FOREIGN KEY constraint declared in migrations was silently inert!
- no \`busy_timeout\` — writer collisions fail immediately with SQLITE_BUSY
- \`temp_store=DEFAULT\` — spills temp work to disk
- \`cache_size=2000\` pages (~8MB)

This PR applies the standard recommended PRAGMAs at connection time.

## Changes

\`\`\`ts
private applyPragmas(): void {
  this.db.pragma('journal_mode = WAL');         // concurrent reads + single writer
  this.db.pragma('synchronous = NORMAL');        // crash-safe under WAL, faster than FULL
  this.db.pragma('foreign_keys = ON');           // activate FK constraints that already exist
  this.db.pragma('busy_timeout = 5000');         // wait 5s for competing writers
  this.db.pragma('temp_store = MEMORY');         //
  this.db.pragma('cache_size = -64000');         // 64MB page cache
}
\`\`\`

Wrapped in try/catch so a hostile DB or driver mismatch does not break boot.

## Why this matters

The \`foreign_keys=ON\` change is the most impactful: the migration files declare FK constraints (e.g. \`bot_configuration_audit.botConfigurationId\`) which were previously **silently ignored** by SQLite. After this PR they're actually enforced — which means:
- Cascading deletes work as the schema intends
- Orphan rows can no longer be created via direct INSERT

If any code currently relies on FK violations being silently allowed, those bugs will surface as constraint errors. Better to find them now.

## Test plan
- [x] \`npm test -- tests/database\` — Encryption, MigrationManager, ConnectionManager, PostgresWrapper all pass; 20 pre-existing DatabaseManager failures are unrelated (umzug missing locally)
- [x] No PRAGMA changes for the Postgres path (postgresWrapper.ts unchanged)

## Risks
- Code that previously created orphan rows via direct INSERT/UPDATE will now get \`SQLITE_CONSTRAINT_FOREIGNKEY\`. If discovered, the right fix is the offending caller, not reverting the PRAGMA.
- WAL creates two extra files (\`*.db-wal\`, \`*.db-shm\`) alongside the DB file — backup/copy scripts must include them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)