### PR TITLE
⚡ Bolt: Replace O(N) array search with O(1) map lookup in PersonaSelector render loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,3 +35,7 @@
 ## 2026-04-25 - Optimize MCPServers array lookup
 **Learning:** React component renders often contain hidden O(N^2) complexity when checking for array duplicates using `.find()` inside `.forEach()` or `.map()` loops.
 **Action:** Replace nested array `.find()` operations during bulk processing with a pre-computed `Set` to achieve O(1) membership testing and linear overall time complexity.
+
+## 2025-05-01 - Replace O(N) array search with O(1) map lookup in PersonaSelector render loop
+**Learning:** In React components like `PersonaSelector`, performing array `.find()` lookups inside `.map()` render loops (to match categories/attributes with items) degrades rendering performance to O(N * M), which is especially noticeable when lists grow long or are filtered frequently.
+**Action:** Always pre-compute a lookup map using `useMemo` (e.g., `Object.fromEntries(categories.map(c => [c.value, c.color]))`) and use O(1) object key lookups (`categoryColorMap[persona.category]`) inside render loops instead of array searches. Make sure static data referenced by useMemo is moved outside the component or the optimization is defeated.

--- a/src/client/src/components/BotManagement/PersonaSelector.tsx
+++ b/src/client/src/components/BotManagement/PersonaSelector.tsx
@@ -14,6 +14,17 @@ import {
 } from 'lucide-react';
 import PersonaChip from './PersonaChip';
 
+const categories: Array<{ value: PersonaCategory | 'all'; label: string; color: string }> = [
+  { value: 'all', label: 'All Personas', color: 'neutral' },
+  { value: 'general', label: 'General', color: 'neutral' },
+  { value: 'customer_service', label: 'Customer Service', color: 'primary' },
+  { value: 'creative', label: 'Creative', color: 'secondary' },
+  { value: 'technical', label: 'Technical', color: 'accent' },
+  { value: 'educational', label: 'Educational', color: 'info' },
+  { value: 'entertainment', label: 'Entertainment', color: 'warning' },
+  { value: 'professional', label: 'Professional', color: 'success' },
+];
+
 interface PersonaSelectorProps {
   personas: Persona[];
   selectedPersonaId?: string;
@@ -39,16 +50,10 @@ const PersonaSelector: React.FC<PersonaSelectorProps> = ({
   const [selectedCategory, setSelectedCategory] = useState<PersonaCategory | 'all'>('all');
   const [isExpanded, setIsExpanded] = useState(false);
 
-  const categories: Array<{ value: PersonaCategory | 'all'; label: string; color: string }> = [
-    { value: 'all', label: 'All Personas', color: 'neutral' },
-    { value: 'general', label: 'General', color: 'neutral' },
-    { value: 'customer_service', label: 'Customer Service', color: 'primary' },
-    { value: 'creative', label: 'Creative', color: 'secondary' },
-    { value: 'technical', label: 'Technical', color: 'accent' },
-    { value: 'educational', label: 'Educational', color: 'info' },
-    { value: 'entertainment', label: 'Entertainment', color: 'warning' },
-    { value: 'professional', label: 'Professional', color: 'success' },
-  ];
+  // Performance optimization: pre-compute map for O(1) category color lookups instead of calling .find() inside .map() loops
+  const categoryColorMap = useMemo(() => {
+    return Object.fromEntries(categories.map(c => [c.value, c.color]));
+  }, []);
 
   // Static class lookup maps (Tailwind JIT-safe — avoids dynamic `bg-${color}` anti-pattern)
   const COLOR_BTN_CLASSES: Record<string, { active: string; dot: string }> = {
@@ -192,7 +197,7 @@ const PersonaSelector: React.FC<PersonaSelectorProps> = ({
                           <div
                             className={`
                               w-2 h-2 rounded-full
-                              ${getCategoryDotClass(categories.find(c => c.value === persona.category)?.color || 'neutral')}
+                              ${getCategoryDotClass(categoryColorMap[persona.category] || 'neutral')}
                             `}
                           />
                           <span className="font-medium text-sm">{persona.name}</span>
@@ -337,7 +342,7 @@ const PersonaSelector: React.FC<PersonaSelectorProps> = ({
                       <div
                         className={`
                           w-3 h-3 rounded-full
-                          ${getCategoryDotClass(categories.find(c => c.value === persona.category)?.color || 'neutral')}
+                          ${getCategoryDotClass(categoryColorMap[persona.category] || 'neutral')}
                         `}
                       />
                       <h4 className="font-semibold">{persona.name}</h4>


### PR DESCRIPTION
💡 **What:** Moved the static `categories` array outside the component and pre-computed a `categoryColorMap` using `useMemo` for category color lookups. Replaced the `categories.find()` array search inside the map loop with an O(1) object property lookup.
🎯 **Why:** Calling an O(N) array search inside an O(M) `map` render loop degrades rendering performance to O(N * M). The `PersonaSelector` component was running `.find()` for every single persona rendered.
📊 **Impact:** Reduces category lookup time complexity from O(N * M) to O(N + M). Prevents unnecessary CPU overhead when the persona list is long or filtered frequently.
🔬 **Measurement:** Verify rendering performance by checking the list in `src/client`. The change has been validated by `pnpm run build` and `pnpm lint`.

---
*PR created automatically by Jules for task [5172740684893967506](https://jules.google.com/task/5172740684893967506) started by @matthewhand*