### PR TITLE
fix(security): refuse SKIP_AUTH / ALLOW_TEST_BYPASS in production

### DIFF
--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -27,6 +27,14 @@ export const authenticateToken = (req: Request, res: Response, next: NextFunctio
   // Activate by setting ALLOW_TEST_BYPASS=true (never in production).
   // When enabled, any request is treated as an authenticated admin request.
   if (process.env.ALLOW_TEST_BYPASS === 'true') {
+    if (process.env.NODE_ENV === 'production') {
+      // Defense-in-depth: should never happen because module-level guards
+      // exist elsewhere, but if a hostile env reaches us, refuse to bypass.
+      res.status(500).json({
+        error: 'Server misconfiguration: ALLOW_TEST_BYPASS cannot be used in production',
+      });
+      return;
+    }
     req.user = TEST_BYPASS_USER;
     return next();
   }

--- a/src/server/routes/admin/index.ts
+++ b/src/server/routes/admin/index.ts
@@ -25,9 +25,23 @@ const debug = Debug('app:webui:admin');
 const isTestEnv = process.env.NODE_ENV === 'test';
 const skipAuth = process.env.SKIP_AUTH === 'true';
 
+// Refuse to start in production with auth disabled — a misconfigured .env
+// would otherwise make every /api/admin/* endpoint public.
+if (skipAuth && process.env.NODE_ENV === 'production') {
+  throw new Error(
+    '[SECURITY] SKIP_AUTH=true is not permitted when NODE_ENV=production. ' +
+      'Remove SKIP_AUTH from production env or set NODE_ENV to a non-production value.'
+  );
+}
+
 // Apply authentication middleware to all admin routes (unless SKIP_AUTH is set)
 if (!skipAuth) {
   router.use(authenticate, requireAdmin);
+} else {
+  // eslint-disable-next-line no-console
+  console.warn(
+    '[SECURITY] SKIP_AUTH=true — /api/admin/* is unauthenticated. Never use in production.'
+  );
 }
 
 // Apply rate limiting to configuration endpoints


### PR DESCRIPTION
## Summary

Two existing test-only auth bypasses had **no production guard**:

1. **\`SKIP_AUTH=true\`** (\`src/server/routes/admin/index.ts:26\`) — skips \`authenticate, requireAdmin\` on every \`/api/admin/*\` route.
2. **\`ALLOW_TEST_BYPASS=true\`** (\`src/server/middleware/auth.ts:29\`) — treats every request as an authenticated admin. Affects everything using \`authenticateToken\` (now most of \`/api/*\` after PR #2693).

A misconfigured \`.env\` reaching production made these surfaces fully public.

## Changes

- **Module-load throw** in \`admin/index.ts\` when \`SKIP_AUTH=true && NODE_ENV=production\`. Server refuses to start.
- **Per-request 500** in \`auth.ts\` when \`ALLOW_TEST_BYPASS=true && NODE_ENV=production\` (defense-in-depth).
- **Boot warning** when \`SKIP_AUTH=true\` outside production so operators notice they're unauthenticated.

## Test plan
- [x] Set \`SKIP_AUTH=true NODE_ENV=production\` → server refuses to start with security message
- [x] Set \`SKIP_AUTH=true NODE_ENV=development\` → server starts with warning
- [x] Default config unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)