### PR TITLE
fix(security): allow-list updatable columns in BotConfigRepository to block SQL identifier injection

### DIFF
--- a/src/database/repositories/BotConfigRepository.ts
+++ b/src/database/repositories/BotConfigRepository.ts
@@ -231,6 +231,17 @@ export class BotConfigRepository {
     }
   }
 
+  // Allow-list of column names that may be UPDATE'd. Anything outside this
+  // list is dropped silently. Defense against SQL identifier injection from
+  // any caller that passes user-supplied keys via `Partial<BotConfiguration>`
+  // (e.g. ConfigImporter). The TypeScript type alone is not enough — `as any`
+  // casts elsewhere can smuggle arbitrary keys through.
+  private static readonly UPDATABLE_COLUMNS = new Set<string>([
+    'name', 'messageProvider', 'llmProvider', 'persona', 'systemInstruction',
+    'mcpServers', 'mcpGuard', 'discord', 'slack', 'mattermost', 'openai',
+    'flowise', 'openwebui', 'openswarm', 'isActive', 'updatedAt',
+  ]);
+
   async updateBotConfiguration(id: number, config: Partial<BotConfiguration>): Promise<void> {
     this.ensureConnected();
 
@@ -243,6 +254,10 @@ export class BotConfigRepository {
 
       Object.entries(config).forEach(([key, value]) => {
         if (key === 'id' || value === undefined) return;
+        if (!BotConfigRepository.UPDATABLE_COLUMNS.has(key)) {
+          debug(`updateBotConfiguration: dropping non-allowlisted column "${key}"`);
+          return;
+        }
 
         updateFields.push(`${key} = ?`);
         if (this.sensitiveFields.includes(key)) {


### PR DESCRIPTION
## Summary

\`BotConfigRepository.updateBotConfiguration\` (line 244-247) interpolated \`\${key}\` from \`Object.entries(config)\` directly into the UPDATE statement:

\`\`\`ts
Object.entries(config).forEach(([key, value]) => {
  if (key === 'id' || value === undefined) return;
  updateFields.push(\`\${key} = ?\`);  // <-- key is template-literalled into SQL
  // ...
});
\`\`\`

The \`Partial<BotConfiguration>\` type provides only compile-time safety. Runtime callers using \`as any\` (e.g. \`ConfigImporter\` passing user-supplied import payloads) can smuggle arbitrary keys through, opening a SQL identifier injection vector.

## Fix

Adds a static \`UPDATABLE_COLUMNS\` allow-list. Any key not in the set is silently dropped (with a \`debug\` log) before reaching the SQL builder.

## Test plan
- [x] All current callers (BotConfigService, ConfigurationVersionService, ConfigImporter) pass only legitimate \`BotConfiguration\` keys → no behavior change
- [ ] Add a focused test feeding \`{ name: "ok", "id; DROP TABLE bot_configurations": "x" }\` → expect drop, no SQL error (recommend as follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)