### PR TITLE
fix(security): close MCP guard bypass when botName is missing

### DIFF
--- a/src/mcp/MCPService.ts
+++ b/src/mcp/MCPService.ts
@@ -318,9 +318,12 @@ export class MCPService {
     }
   ): Promise<unknown> {
     try {
-      if (context?.botName) {
-        await this.assertGuardAllowsExecution(context);
-      }
+      // Guard MUST run on every execution. Previously this was gated on
+      // `context?.botName` being present, which let any caller skip the
+      // entire MCPGuard by simply omitting botName (e.g. /api/mcp tool
+      // playground requests). assertGuardAllowsExecution still throws on
+      // missing botName — that's the safe failure mode.
+      await this.assertGuardAllowsExecution(context ?? {});
 
       const client = this.clients.get(serverName);
       if (!client) {
@@ -392,7 +395,9 @@ export class MCPService {
     const { botName, messageProvider, forumId, forumOwnerId, userId } = context;
 
     if (!botName) {
-      return;
+      // Refuse instead of silently allowing — every execution path must
+      // identify the bot so guard config can be looked up.
+      throw new Error('MCP tool access denied: botName is required for guard evaluation.');
     }
 
     const manager = BotConfigurationManager.getInstance();


### PR DESCRIPTION
## Summary

\`MCPService.executeTool\` (line 321) only ran \`assertGuardAllowsExecution\` when \`context?.botName\` was present:

\`\`\`ts
if (context?.botName) {
  await this.assertGuardAllowsExecution(context);
}
\`\`\`

Any caller could skip the entire MCPGuard by simply omitting \`botName\`. The WebUI Tool Playground (\`POST /api/mcp/servers/:name/call-tool\`) does exactly this — it sends no \`botName\`/\`userId\`/\`forumId\`, so playground execution silently bypassed all guard configuration.

## Fix

Two parts:

1. **\`executeTool\` now always calls \`assertGuardAllowsExecution\`** (no botName gate).
2. **\`assertGuardAllowsExecution\` throws when \`botName\` is missing** instead of silently returning. "No bot identified" is no longer a free pass — it's a hard denial.

## Test plan
- [x] Existing callers (DiscordMessage, SlackMessage, etc.) already pass \`botName\` → no behavior change for legitimate tool execution
- [ ] (Reviewer) Verify no internal tooling relied on the old "no botName = bypass" behavior
- [ ] Follow-up: \`/api/mcp/servers/:name/call-tool\` route should plumb the authenticated operator's bot context

🤖 Generated with [Claude Code](https://claude.com/claude-code)