### PR TITLE
perf(client): fix BotsPage useMemo invalidation and MobileFAB memo defeat

### DIFF
--- a/src/client/src/pages/BotsPage/index.tsx
+++ b/src/client/src/pages/BotsPage/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Bot as BotIcon, Check, Download, LayoutGrid, List, Pause, Play, Plus, RefreshCw, Settings, Trash2, Upload as UploadIcon } from 'lucide-react';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import Tabs from '../../components/DaisyUI/Tabs';
 import BotSettingsTab from './BotSettingsTab';
@@ -37,6 +37,12 @@ import { useSavedStamp } from '../../contexts/SavedStampContext';
 import Select from '../../components/DaisyUI/Select';
 import { BotDetailContent } from './BotDetailContent';
 
+// Hoisted icon constants — passed as the `icon` prop to React.memo(MobileFAB).
+// Inlining `<Plus className="..." />` at the call site allocates a new React
+// element on every render, defeating MobileFAB's shallow-compare memoization.
+const PLUS_ICON = <Plus className="w-6 h-6" />;
+const REFRESH_ICON = <RefreshCw className="w-6 h-6" />;
+
 const BotsPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const { values: urlParams, setValue: setUrlParam } = useUrlParams({
@@ -45,11 +51,22 @@ const BotsPage: React.FC = () => {
     view: { type: 'string', default: 'default' },
   });
   const searchQuery = urlParams.search;
-  const setSearchQuery = (v: string) => setUrlParam('search', v);
+  // Wrap setters in useCallback so they're stable across renders. Without this,
+  // these inline arrow functions are recreated every render and would invalidate
+  // any downstream memoization (e.g. instancesContent useMemo) that depends on
+  // them. setUrlParam is stable (memoized inside useUrlParams), so [setUrlParam]
+  // is a sufficient dep list.
+  const setSearchQuery = useCallback((v: string) => setUrlParam('search', v), [setUrlParam]);
   const filterType = urlParams.status as 'all' | 'active' | 'inactive';
-  const setFilterType = (v: 'all' | 'active' | 'inactive') => setUrlParam('status', v);
+  const setFilterType = useCallback(
+    (v: 'all' | 'active' | 'inactive') => setUrlParam('status', v),
+    [setUrlParam],
+  );
   const viewMode = urlParams.view as 'default' | 'compact' | 'swarm3d';
-  const setViewMode = (v: 'default' | 'compact' | 'swarm3d') => setUrlParam('view', v);
+  const setViewMode = useCallback(
+    (v: 'default' | 'compact' | 'swarm3d') => setUrlParam('view', v),
+    [setUrlParam],
+  );
 
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [editingBot, setEditingBot] = useState<BotConfig | null>(null);
@@ -494,13 +511,13 @@ const BotsPage: React.FC = () => {
         <>
           <MobileFAB
             position="left"
-            icon={<Plus className="w-6 h-6" />}
+            icon={PLUS_ICON}
             onClick={() => setIsCreateModalOpen(true)}
             ariaLabel="Create bot"
           />
           <MobileFAB
             position="right"
-            icon={<RefreshCw className="w-6 h-6" />}
+            icon={REFRESH_ICON}
             onClick={fetchBots}
             disabled={botsLoading}
             loading={botsLoading}


### PR DESCRIPTION
## Summary

Two related performance no-ops on `BotsPage` where memoization was silently defeated by inline allocations. Both fixes are tightly scoped to `src/client/src/pages/BotsPage/index.tsx`.

### 1. `instancesContent` `useMemo` invalidated every render

The setter wrappers `setSearchQuery`, `setFilterType`, `setViewMode` (previously lines 48–52) were inline arrow functions over `setUrlParam`:

```ts
const setSearchQuery = (v: string) => setUrlParam('search', v);
```

These were recreated on every render, and they appear in the `instancesContent` `useMemo` dep list (lines 330–337). Result: the memo's deps were never referentially stable, so it recomputed on every parent render — i.e. `useMemo` was a no-op that just added overhead.

`useUrlParams`'s `setValue` is stable (memoized with `useCallback([setSearchParams])` in `src/client/src/hooks/useUrlParams.ts`), so wrapping each setter in `useCallback([setUrlParam])` is safe and gives the memo something stable to compare against.

### 2. `React.memo(MobileFAB)` defeated by inline icon JSX

```tsx
<MobileFAB icon={<Plus className="w-6 h-6" />} ... />
<MobileFAB icon={<RefreshCw className="w-6 h-6" />} ... />
```

Each render of `BotsPage` allocates a fresh React element for `icon`, breaking the shallow-prop comparison `React.memo` performs. So `MobileFAB` re-renders every parent render despite being wrapped in `memo()`.

Fixed by hoisting the icon JSX as module-level constants:

```tsx
const PLUS_ICON = <Plus className="w-6 h-6" />;
const REFRESH_ICON = <RefreshCw className="w-6 h-6" />;
```

The icon className is constant — there's no dynamic binding to lose by hoisting.

## The no-op chain

For Fix 1 specifically:
- `useMemo` exists to skip work when deps are unchanged
- → deps include setter wrappers
- → setter wrappers are inline arrows recreated each render
- → deps always change
- → memo never short-circuits
- → wasted reconciliation of the entire instances tab content

## Test plan

- [ ] `vitest run src/pages/BotsPage/__tests__/index.test.tsx` passes
- [ ] BotsPage renders correctly: search, status filter, view-mode dropdown still work
- [ ] Mobile FAB buttons (Create, Refresh) on small viewports still work and show correct icons
- [ ] No new console warnings (especially around hook deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)