### PR TITLE
a11y(client): make BotsPage view-mode dropdown keyboard-operable

### DIFF
--- a/src/client/src/components/DaisyUI/Dropdown.tsx
+++ b/src/client/src/components/DaisyUI/Dropdown.tsx
@@ -15,6 +15,15 @@ type DropdownProps = {
   disabled?: boolean;
   hideArrow?: boolean;
   'aria-label'?: string;
+  /**
+   * ARIA `aria-haspopup` value for the trigger. Defaults to `"true"` (legacy).
+   * Set to `"menu"` when children render with `role="menu"` items.
+   */
+  'aria-haspopup'?: 'true' | 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog';
+  /** Stable id for the popup `<ul>`; pair with `triggerAriaControls`. */
+  menuId?: string;
+  /** Value applied to the trigger's `aria-controls` attribute. */
+  triggerAriaControls?: string;
 };
 
 const Dropdown: React.FC<DropdownProps> = ({
@@ -31,6 +40,9 @@ const Dropdown: React.FC<DropdownProps> = ({
   disabled = false,
   hideArrow = false,
   'aria-label': ariaLabel,
+  'aria-haspopup': ariaHasPopup = 'true',
+  menuId,
+  triggerAriaControls,
 }) => {
   const [uncontrolledIsOpen, setUncontrolledIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -100,15 +112,16 @@ const Dropdown: React.FC<DropdownProps> = ({
         className={`btn ${sizeClasses[size]} ${colorClasses[color]} ${disabled ? 'btn-disabled opacity-50' : ''} ${triggerClassName}`}
         onClick={handleToggle}
         onKeyDown={handleKeyDown}
-        aria-haspopup="true"
+        aria-haspopup={ariaHasPopup}
         aria-expanded={isOpen}
         aria-label={ariaLabel}
+        aria-controls={triggerAriaControls}
       >
         {trigger}
         {!hideArrow && <ChevronDownIcon className="h-5 w-5" aria-hidden="true" />}
       </div>
       {isOpen && (
-        <ul tabIndex={0} className={`dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52 z-50 ${contentClassName}`} role="menu">
+        <ul id={menuId} tabIndex={0} className={`dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52 z-50 ${contentClassName}`} role="menu">
           {children}
         </ul>
       )}

--- a/src/client/src/pages/BotsPage/__tests__/index.test.tsx
+++ b/src/client/src/pages/BotsPage/__tests__/index.test.tsx
@@ -127,6 +127,41 @@ describe('BotsPage', () => {
     expect(trigger).toBeTruthy();
   });
 
+  it('exposes WAI-ARIA menu semantics on the trigger (haspopup=menu, aria-controls)', () => {
+    renderPage();
+    const trigger = screen.getByRole('button', { name: /^View mode:/ });
+    expect(trigger.getAttribute('aria-haspopup')).toBe('menu');
+    const controls = trigger.getAttribute('aria-controls');
+    expect(controls).toBeTruthy();
+    fireEvent.click(trigger);
+    const menu = document.getElementById(controls!);
+    expect(menu).toBeTruthy();
+    expect(menu!.getAttribute('role')).toBe('menu');
+  });
+
+  it('renders dropdown items as <button role="menuitemradio"> with roving tabindex', () => {
+    currentView = 'compact';
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /^View mode:/ }));
+    const items = screen.getAllByRole('menuitemradio');
+    // Every item must be a real <button> so Enter/Space activate it.
+    items.forEach((el) => expect(el.tagName).toBe('BUTTON'));
+    // Roving tabindex: exactly one item is in the tab sequence (the active one).
+    const tabbable = items.filter((el) => el.getAttribute('tabindex') === '0');
+    expect(tabbable).toHaveLength(1);
+    expect(tabbable[0].textContent).toContain('Compact');
+  });
+
+  it('moves focus to the next item on ArrowDown', () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /^View mode:/ }));
+    const items = screen.getAllByRole('menuitemradio') as HTMLButtonElement[];
+    items[0].focus();
+    expect(document.activeElement).toBe(items[0]);
+    fireEvent.keyDown(items[0], { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(items[1]);
+  });
+
   it('reflects the current viewMode in the trigger aria-label', () => {
     currentView = 'compact';
     renderPage();

--- a/src/client/src/pages/BotsPage/index.tsx
+++ b/src/client/src/pages/BotsPage/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Bot as BotIcon, Check, Download, LayoutGrid, List, Pause, Play, Plus, RefreshCw, Settings, Trash2, Upload as UploadIcon } from 'lucide-react';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import Tabs from '../../components/DaisyUI/Tabs';
 import BotSettingsTab from './BotSettingsTab';
@@ -66,6 +66,56 @@ const BotsPage: React.FC = () => {
   const setViewMode = useCallback(
     (v: 'default' | 'compact' | 'swarm3d') => setUrlParam('view', v),
     [setUrlParam],
+  );
+
+  // ---------------------------------------------------------------------------
+  // View-mode dropdown a11y: WAI-ARIA "menu" pattern keyboard support.
+  // Items are <button role="menuitemradio"> with roving tabindex; arrow keys,
+  // Home, End, and Escape behave per APG. The Dropdown wrapper handles
+  // open/close on Enter/Space/Esc on the trigger; this only handles
+  // focus-traversal once an item has focus. See:
+  // https://www.w3.org/WAI/ARIA/apg/patterns/menu/
+  // ---------------------------------------------------------------------------
+  const viewMenuId = useId();
+  const viewMenuItemsRef = useRef<Array<HTMLButtonElement | null>>([]);
+  const viewTriggerRef = useRef<HTMLDivElement | null>(null);
+  const handleViewMenuKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLButtonElement>, index: number, count: number) => {
+      const focusItem = (i: number) => {
+        const next = ((i % count) + count) % count;
+        viewMenuItemsRef.current[next]?.focus();
+      };
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          focusItem(index + 1);
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          focusItem(index - 1);
+          break;
+        case 'Home':
+          e.preventDefault();
+          focusItem(0);
+          break;
+        case 'End':
+          e.preventDefault();
+          focusItem(count - 1);
+          break;
+        case 'Escape': {
+          e.preventDefault();
+          // Closing is handled by Dropdown's outside-click + its own trigger Escape.
+          // Move focus back to the trigger button so the menu collapses on blur
+          // and the user lands somewhere predictable.
+          const triggerButton = viewTriggerRef.current?.querySelector<HTMLElement>('[role="button"]');
+          triggerButton?.focus();
+          break;
+        }
+        default:
+          break;
+      }
+    },
+    []
   );
 
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
@@ -203,48 +253,69 @@ const BotsPage: React.FC = () => {
               <option value="active">Active Only</option>
               <option value="inactive">Inactive Only</option>
             </Select>
-            <Dropdown
-              trigger={
-                viewMode === 'swarm3d' ? (
-                  <BotIcon className="w-4 h-4" aria-hidden="true" />
-                ) : viewMode === 'compact' ? (
-                  <List className="w-4 h-4" aria-hidden="true" />
-                ) : (
-                  <LayoutGrid className="w-4 h-4" aria-hidden="true" />
-                )
-              }
-              position="bottom"
-              color="ghost"
-              size="sm"
-              className="dropdown-end"
-              triggerClassName="gap-1 focus-visible:ring-2 ring-base-content focus-visible:ring-offset-2 ring-offset-base-100 focus-visible:outline-none"
-              contentClassName="shadow-lg w-44 z-20"
-              aria-label={`View mode: ${
-                viewMode === 'swarm3d' ? '3D Swarm' : viewMode === 'compact' ? 'Compact' : 'Grid'
-              }`}
-            >
-              {([
-                { value: 'default', label: 'Grid', icon: <LayoutGrid className="w-4 h-4" aria-hidden="true" /> },
-                { value: 'compact', label: 'Compact', icon: <List className="w-4 h-4" aria-hidden="true" /> },
-                { value: 'swarm3d', label: '3D Swarm', icon: <BotIcon className="w-4 h-4" aria-hidden="true" /> },
-              ] as const).map((opt) => {
-                const isActive = viewMode === opt.value;
-                return (
-                  <li key={opt.value}>
-                    <a
-                      onClick={(e) => { e.stopPropagation(); setViewMode(opt.value); }}
-                      className={`flex items-center gap-2 ${isActive ? 'active border-l-2 border-primary pl-2' : ''}`}
-                      role="menuitemradio"
-                      aria-checked={isActive}
-                    >
-                      {opt.icon}
-                      <span className="flex-1">{opt.label}</span>
-                      {isActive && <Check className="w-4 h-4 text-primary" aria-hidden="true" />}
-                    </a>
-                  </li>
-                );
-              })}
-            </Dropdown>
+            <div ref={viewTriggerRef} className="contents">
+              <Dropdown
+                trigger={
+                  viewMode === 'swarm3d' ? (
+                    <BotIcon className="w-4 h-4" aria-hidden="true" />
+                  ) : viewMode === 'compact' ? (
+                    <List className="w-4 h-4" aria-hidden="true" />
+                  ) : (
+                    <LayoutGrid className="w-4 h-4" aria-hidden="true" />
+                  )
+                }
+                position="bottom"
+                color="ghost"
+                size="sm"
+                className="dropdown-end"
+                triggerClassName="gap-1 focus-visible:ring-2 ring-base-content focus-visible:ring-offset-2 ring-offset-base-100 focus-visible:outline-none"
+                contentClassName="shadow-lg w-44 z-20"
+                aria-label={`View mode: ${
+                  viewMode === 'swarm3d' ? '3D Swarm' : viewMode === 'compact' ? 'Compact' : 'Grid'
+                }`}
+                aria-haspopup="menu"
+                menuId={viewMenuId}
+                triggerAriaControls={viewMenuId}
+              >
+                {(() => {
+                  const items = [
+                    { value: 'default', label: 'Grid', icon: <LayoutGrid className="w-4 h-4" aria-hidden="true" /> },
+                    { value: 'compact', label: 'Compact', icon: <List className="w-4 h-4" aria-hidden="true" /> },
+                    { value: 'swarm3d', label: '3D Swarm', icon: <BotIcon className="w-4 h-4" aria-hidden="true" /> },
+                  ] as const;
+                  // Reset the ref array each render so removed items don't linger.
+                  viewMenuItemsRef.current = [];
+                  return items.map((opt, idx) => {
+                    const isActive = viewMode === opt.value;
+                    return (
+                      <li key={opt.value}>
+                        <button
+                          type="button"
+                          ref={(el) => {
+                            viewMenuItemsRef.current[idx] = el;
+                          }}
+                          role="menuitemradio"
+                          aria-checked={isActive}
+                          tabIndex={isActive ? 0 : -1}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setViewMode(opt.value);
+                          }}
+                          onKeyDown={(e) => handleViewMenuKeyDown(e, idx, items.length)}
+                          className={`flex items-center gap-2 w-full text-left ${
+                            isActive ? 'active border-l-2 border-primary pl-2' : ''
+                          }`}
+                        >
+                          {opt.icon}
+                          <span className="flex-1">{opt.label}</span>
+                          {isActive && <Check className="w-4 h-4 text-primary" aria-hidden="true" />}
+                        </button>
+                      </li>
+                    );
+                  });
+                })()}
+              </Dropdown>
+            </div>
             <Tooltip content="Refresh list">
               <Button
                 variant="ghost"


### PR DESCRIPTION
## Problem

The view-mode dropdown in `src/client/src/pages/BotsPage/index.tsx` rendered its menu items as `<a onClick>` with **no `href`**. This made the control unusable from the keyboard:

- Enter / Space do not fire `onClick` on a focused `<a>` without `href`
- No arrow-key navigation between items
- Esc did nothing from item focus
- `aria-haspopup="true"` was incorrect (items declare `role="menuitemradio"`, so the popup is a `menu`)
- No `aria-controls` linking trigger to menu

## Fix

Implements the [WAI-ARIA Authoring Practices "menu" pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menu/) on the view-mode dropdown:

1. Items are now `<button type="button" role="menuitemradio">` so Enter and Space activate them natively.
2. `onKeyDown` handles `ArrowDown` / `ArrowUp` / `Home` / `End` / `Escape`. Escape returns focus to the trigger.
3. **Roving tabindex** — the active item gets `tabIndex={0}`; siblings get `tabIndex={-1}`. Tab leaves the menu cleanly; arrows traverse within.
4. Trigger now exposes `aria-haspopup="menu"` and `aria-controls={menuId}`.
5. The popup `<ul role="menu">` gets a stable `id` from `useId()`.

`Dropdown.tsx` is extended with three optional props (`aria-haspopup`, `menuId`, `triggerAriaControls`) — all backwards compatible. No other Dropdown callers are touched in this PR (a future PR can extract a shared `useRovingTabIndex` hook).

## WCAG criteria

- [WCAG 2.2 SC 2.1.1 Keyboard (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html)
- [WCAG 2.2 SC 4.1.2 Name, Role, Value (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)

## Reference

- WAI-ARIA APG, Menu and Menubar Pattern: https://www.w3.org/WAI/ARIA/apg/patterns/menu/

## Tests

`src/client/src/pages/BotsPage/__tests__/index.test.tsx` is extended with three new assertions:

- Trigger exposes `aria-haspopup="menu"` and a working `aria-controls` linking to a `role="menu"` element.
- All items render as `<button>` with `role="menuitemradio"`, with exactly one item in the tab sequence (roving tabindex).
- `ArrowDown` from the first item moves focus to the second.

All 9 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)