### PR TITLE
docs: add baseline READMEs to all 14 workspace packages

### DIFF
--- a/packages/llm-flowise/README.md
+++ b/packages/llm-flowise/README.md
@@ -1,0 +1,34 @@
+# @hivemind/llm-flowise
+
+LLM provider that talks to a [Flowise](https://flowiseai.com) chatflow over its REST API. Loaded by Open Hivemind's `PluginLoader` as an `llm`-type plugin.
+
+## Exports
+
+- `FlowiseProvider` — class implementing the LLM provider contract
+- `flowiseProvider` — default singleton (re-exported)
+- `schema` — UI/config schema descriptor
+- `manifest` — `{ displayName: 'Flowise', type: 'llm', ... }`
+- `create(config?)` — factory used by the PluginLoader
+
+## Environment variables
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `FLOWISE_BASE_URL` | yes | Base URL of the Flowise instance (e.g. `https://flowise.example.com`). |
+| `FLOWISE_API_KEY` | yes | API key issued by Flowise for the chatflow. |
+
+Configuration may also be supplied through the bot config object — fields in `config` take precedence over env.
+
+## Usage
+
+```ts
+import { create as createFlowise } from '@hivemind/llm-flowise';
+
+const provider = createFlowise();
+const reply = await provider.generateChatCompletion('Hello, world', []);
+console.log(reply);
+```
+
+## Tests
+
+`npm test` is a stub. Functional coverage lives in the main app's test suite under `tests/llm/flowise/`.

--- a/packages/llm-letta/README.md
+++ b/packages/llm-letta/README.md
@@ -1,0 +1,37 @@
+# @hivemind/llm-letta
+
+LLM provider for [Letta](https://letta.com) (formerly MemGPT) — stateful agents with persistent memory, accessed via the official `@letta-ai/letta-client` SDK. Works against both Letta Cloud and self-hosted servers.
+
+## Exports
+
+- `LettaProvider`, `LettaProviderConfig` — provider class plus its config interface (`agentId`, `systemPrompt`, `sessionMode`, `conversationId`)
+- `listAgents`, `getAgent`, `AgentSummary` — helpers in `agentBrowser` for picking an agent ID at config time
+- `schema` — UI/config schema descriptor
+- `manifest` — `{ displayName: 'Letta', type: 'llm', ... }`
+- `create(config?)` — factory returning the singleton instance
+
+## Environment variables
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `LETTA_SERVER_PASSWORD` | yes | API key for Letta Cloud (`sk-let-...`) or the server password for a self-hosted instance. Used as `apiKey` for the SDK in both modes. |
+| `LETTA_AGENT_ID` | optional | Default agent to talk to when no `agentId` is supplied via config or per-message metadata. |
+
+## Usage
+
+```ts
+import { create as createLetta } from '@hivemind/llm-letta';
+
+const provider = createLetta({
+  agentId: process.env.LETTA_AGENT_ID,
+  sessionMode: 'per-channel',
+});
+
+const reply = await provider.generateChatCompletion('What did we decide last week?', []);
+```
+
+`sessionMode` controls how conversations are scoped: `default`, `per-channel`, `per-user`, or `fixed` (uses `conversationId`).
+
+## Tests
+
+`npm test` is a stub. See `tests/llm/letta/` in the main app for integration coverage.

--- a/packages/llm-openai/README.md
+++ b/packages/llm-openai/README.md
@@ -1,0 +1,37 @@
+# @hivemind/llm-openai
+
+OpenAI LLM provider — wraps the official `openai` SDK to provide chat completions and embeddings to Open Hivemind. Works with the OpenAI API and any OpenAI-compatible endpoint (Azure-style proxies, local LLMs exposing the OpenAI shape, etc.).
+
+## Exports
+
+- `OpenAiProvider` — provider class
+- `openAiService`, `OpenAiService` — service wrapper
+- `schema` — UI/config schema descriptor
+- `manifest` — `{ displayName: 'OpenAI', type: 'llm', ... }`
+- `create(config?)` — factory used by the PluginLoader (accepts `apiKey`, `baseUrl`, `model`, `timeout`, `organization`, `temperature`, `maxTokens`)
+
+## Environment variables
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `OPENAI_API_KEY` | yes (unless passed via config) | Your OpenAI API key. |
+| `OPENAI_BASE_URL` | optional | Override the API base URL (default: OpenAI). |
+| `OPENAI_MODEL` | optional | Default model name (e.g. `gpt-4o-mini`). |
+
+Per-bot overrides via `config` always take precedence over env.
+
+## Usage
+
+```ts
+import { create as createOpenAi } from '@hivemind/llm-openai';
+
+const provider = createOpenAi({
+  apiKey: process.env.OPENAI_API_KEY!,
+  model: 'gpt-4o-mini',
+});
+const reply = await provider.generateChatCompletion('Summarise our last sprint', []);
+```
+
+## Tests
+
+`npm test` is a stub. Functional tests for this provider live in `tests/llm/openai/` in the main app.

--- a/packages/llm-openswarm/README.md
+++ b/packages/llm-openswarm/README.md
@@ -1,0 +1,32 @@
+# @hivemind/llm-openswarm
+
+LLM provider for [OpenSwarm](https://github.com/openai/swarm) — multi-agent orchestration accessed through an OpenAI-compatible REST endpoint exposed by an OpenSwarm WebUI / server.
+
+## Exports
+
+- `OpenSwarmProvider` — provider class
+- `SwarmInstaller` — helper that installs / launches the local OpenSwarm WebUI
+- `schema` — UI/config schema descriptor
+- `manifest` — `{ displayName: 'OpenSwarm', type: 'llm', ... }`
+- `create(_config?)` — factory used by the PluginLoader (config is currently ignored — env vars drive it)
+
+## Environment variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `OPENSWARM_BASE_URL` | `http://localhost:8000/v1` | Base URL of the OpenSwarm OpenAI-compatible API. |
+| `OPENSWARM_API_KEY` | `dummy-key` | API key sent to the server. Local installs typically don't need a real key. |
+| `OPENSWARM_WEBUI_URL` | `http://localhost:8002` | URL the `SwarmInstaller` opens / pings for the WebUI. |
+
+## Usage
+
+```ts
+import { create as createOpenSwarm } from '@hivemind/llm-openswarm';
+
+const provider = createOpenSwarm();
+const reply = await provider.generateChatCompletion('Plan a release for v2', []);
+```
+
+## Tests
+
+`npm test` is a stub. Integration coverage is in `tests/llm/openswarm/` in the main app.

--- a/packages/llm-openwebui/README.md
+++ b/packages/llm-openwebui/README.md
@@ -1,0 +1,40 @@
+# @hivemind/llm-openwebui
+
+LLM provider for a self-hosted [Open WebUI](https://openwebui.com) instance. Supports both API-key and password (session) authentication and is exposed as a stateless singleton.
+
+## Exports
+
+- `openWebUIProvider` — singleton `ILlmProvider`
+- `generateChatCompletion` — lower-level helper from `runInference`
+- `schema` — UI/config schema descriptor
+- `manifest` — `{ displayName: 'OpenWebUI', type: 'llm', ... }`
+- `create(_config?)` — factory; returns the singleton
+
+## Environment variables
+
+Configured via `convict` in `openWebUIConfig.ts`:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `OPEN_WEBUI_API_URL` | `http://host.docker.internal:3000/api/` | Base URL of the Open WebUI API. |
+| `OPEN_WEBUI_AUTH_METHOD` | `password` | `password` or `apiKey`. |
+| `OPEN_WEBUI_USERNAME` | `''` | Username (when `authMethod=password`). |
+| `OPEN_WEBUI_PASSWORD` | `''` | Password (when `authMethod=password`). |
+| `OPEN_WEBUI_API_KEY` | `''` | API key (when `authMethod=apiKey`). |
+| `OPEN_WEBUI_MODEL` | `llama3.2` | Default model. |
+| `OPEN_WEBUI_KNOWLEDGE_FILE` | `''` | Optional path to a knowledge file to upload at boot. |
+
+## Usage
+
+```ts
+import { openWebUIProvider } from '@hivemind/llm-openwebui';
+
+const reply = await openWebUIProvider.generateChatCompletion(
+  'Summarise the latest engineering update',
+  [],
+);
+```
+
+## Tests
+
+`npm test` is a stub. The provider is exercised in `tests/llm/openwebui/` in the main app.

--- a/packages/memory-mem0/README.md
+++ b/packages/memory-mem0/README.md
@@ -1,0 +1,35 @@
+# @hivemind/memory-mem0
+
+Memory provider that connects to the [Mem0](https://mem0.ai) REST API (or a self-hosted instance). Implements `IMemoryProvider` so bots can persist and search facts across conversations.
+
+## Exports
+
+- `Mem0Provider` — provider class
+- `Mem0Config` — configuration shape (`apiKey`, `baseUrl`, `userId`, `agentId`, `orgId`, `llmProvider`, `llmModel`, `embedderModel`, `vectorStoreProvider`, `historyDbPath`, `timeoutMs`, `maxRetries`, `circuitBreaker`)
+- Response types: `Mem0Memory`, `Mem0AddResponse`, `Mem0ListResponse`, `Mem0SearchResponse`, `Mem0GetResponse`, `Mem0UpdateResponse`
+- `Mem0ApiError` — thrown on non-2xx responses
+- `schema`, `manifest`
+- `create(config)` — factory used by the PluginLoader
+
+## Environment variables
+
+This package does **not** read `process.env` directly. The Mem0 API key and other settings are passed through `config` from the bot configuration UI / file. Set them there.
+
+## Usage
+
+```ts
+import { create as createMem0 } from '@hivemind/memory-mem0';
+
+const memory = createMem0({
+  apiKey: process.env.MEM0_API_KEY!,
+  baseUrl: 'https://api.mem0.ai/v1',
+  userId: 'alice',
+});
+
+await memory.addMemory('Prefers dark mode', { source: 'profile' }, { userId: 'alice' });
+const hits = await memory.searchMemory('display preferences', { userId: 'alice' });
+```
+
+## Tests
+
+`npm test` is a stub. End-to-end coverage lives in `tests/memory/mem0/` in the main app.

--- a/packages/memory-mem4ai/README.md
+++ b/packages/memory-mem4ai/README.md
@@ -1,0 +1,36 @@
+# @hivemind/memory-mem4ai
+
+Memory provider that connects to the [Mem4ai](https://mem4ai.com) REST API. LLM-friendly memory with adaptive personalization. Implements `IMemoryProvider` and includes a built-in `CircuitBreaker` for resiliency.
+
+## Exports
+
+- `Mem4aiProvider` — provider class
+- `Mem4aiConfig` — configuration shape (`apiUrl` required, `apiKey`, `organizationId`, `userId`, `agentId`, `embeddingProviderId`, `limit`, `timeout`, `maxRetries`, `circuitBreaker`)
+- Response types: `Mem4aiMemory`, `Mem4aiAddResponse`, `Mem4aiListResponse`, `Mem4aiSearchResponse`, `Mem4aiGetResponse`, `Mem4aiUpdateResponse`
+- `Mem4aiApiError` — thrown on non-2xx responses
+- `schema`, `manifest`
+- `create(config)` — factory used by the PluginLoader
+
+## Environment variables
+
+This package does **not** read `process.env` directly. All settings are passed via `config` from the bot configuration.
+
+## Usage
+
+```ts
+import { create as createMem4ai } from '@hivemind/memory-mem4ai';
+
+const memory = createMem4ai({
+  apiUrl: 'https://api.mem4ai.example.com',
+  apiKey: process.env.MEM4AI_API_KEY!,
+  userId: 'bob',
+  limit: 10,
+});
+
+await memory.addMemory('Standups at 9:30 AEST', undefined, { userId: 'bob' });
+const hits = await memory.searchMemory('what time are standups?', { userId: 'bob' });
+```
+
+## Tests
+
+`npm test` is a stub. The provider is exercised through the main app's memory test suite.

--- a/packages/memory-postgres/README.md
+++ b/packages/memory-postgres/README.md
@@ -1,0 +1,36 @@
+# @hivemind/memory-postgres
+
+Memory provider backed by the host application's Postgres `DatabaseManager` and a configured embedding-capable LLM provider. Stores vectors natively (no external memory service).
+
+## Exports
+
+This package re-exports everything from `PostgresMemoryProvider`:
+
+- `PostgresMemoryProvider` — class implementing `IMemoryProvider`
+- `PostgresMemoryConfig` — `{ embeddingProfile?: string }`
+
+There is no `manifest` / `create()` in this package — it is wired in directly by the main app rather than through the generic PluginLoader because it depends on the host's `DatabaseManager`.
+
+## Environment variables
+
+None read directly. Database connectivity is provided by the host app; the embedding profile is selected by the `embeddingProfile` config field, which must match the `name` of an LLM provider that exposes `generateEmbedding()`.
+
+## Usage
+
+```ts
+import { PostgresMemoryProvider } from '@hivemind/memory-postgres';
+import type { IServiceDependencies } from '@hivemind/shared-types';
+
+const memory = new PostgresMemoryProvider(
+  { embeddingProfile: 'openai-default' },
+  dependencies satisfies IServiceDependencies,
+);
+
+await memory.addMemory('Standup is at 09:30', undefined, { userId: 'alice' });
+```
+
+If `dependencies.getDatabaseManager()` or a provider with `generateEmbedding()` is missing, calls throw `Error('PostgresMemoryProvider: ...')`.
+
+## Tests
+
+No package-level tests. Integration tests live in `tests/memory/postgres/` in the main app.

--- a/packages/message-discord/README.md
+++ b/packages/message-discord/README.md
@@ -1,0 +1,38 @@
+# @hivemind/message-discord
+
+Discord adapter for Open Hivemind. Wraps `discord.js` (with voice support via `@discordjs/voice` + `ffmpeg-static` + `libsodium-wrappers`) and exposes the standard `IMessengerService` contract.
+
+## Exports
+
+- `DiscordService`, `Discord` — service class + namespace
+- `DiscordMessage` (default re-export of `./DiscordMessage`)
+- `DiscordMessageProvider` — message-provider variant used by the new pipeline
+- `testDiscordConnection` — connection probe used by the WebUI
+- `Bot` — type from `DiscordBotManager`
+- `schema` — UI/config schema descriptor
+- `adapterMetadata` — `{ name, version, platform: 'discord' }`
+- `manifest` — `{ displayName: 'Discord', type: 'message', ... }`
+- `createDiscordService` (also `create`, default export) — `IAdapterFactory`
+
+## Environment variables
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `DISCORD_BOT_TOKEN` | legacy / fallback | Single-bot token. Multi-bot setups should use the bot config UI instead, where each bot supplies its own token. |
+
+## Usage
+
+```ts
+import createDiscordService from '@hivemind/message-discord';
+import type { IAdapterConfig, IServiceDependencies } from '@hivemind/shared-types';
+
+const service = createDiscordService(
+  { botConfig: { name: 'mybot', discord: { token: process.env.DISCORD_BOT_TOKEN! } } } as IAdapterConfig,
+  dependencies satisfies IServiceDependencies,
+);
+await service.initialize();
+```
+
+## Tests
+
+`npm test` is a stub. The Discord adapter has substantial coverage in `tests/message/discord/` in the main app.

--- a/packages/message-mattermost/README.md
+++ b/packages/message-mattermost/README.md
@@ -1,0 +1,31 @@
+# @hivemind/message-mattermost
+
+Mattermost adapter for Open Hivemind. Talks to a self-hosted Mattermost server over its REST API using `axios`. Supports multiple bot instances driven by the host app's `BotConfigurationManager`.
+
+## Exports
+
+- `MattermostService` (also default export) — singleton service implementing `IMessengerService`
+- `MattermostClient` — thin REST client (default re-export of `./mattermostClient`)
+- `MattermostMessage`, `MattermostPost` — message wrapper + raw post type
+- `testMattermostConnection`, `MattermostConnectionTestResult` — connection probe used by the WebUI
+- `schema` — UI/config schema descriptor
+- `manifest` — `{ displayName: 'Mattermost', type: 'message', ... }`
+- `create(_config?)` — factory; returns the singleton
+
+## Environment variables
+
+This package does **not** read `process.env` directly. Per-bot Mattermost settings (`token`, server URL, etc.) come from the bot config (`bot.mattermost.token` is required for an instance to be initialised).
+
+## Usage
+
+```ts
+import { create as createMattermost } from '@hivemind/message-mattermost';
+
+const service = createMattermost();
+await service.initialize();
+const id = await service.sendMessageToChannel('town-square', 'Hello team', 'mybot');
+```
+
+## Tests
+
+`npm test` is a stub. Integration coverage lives in `tests/message/mattermost/` in the main app.

--- a/packages/message-slack/README.md
+++ b/packages/message-slack/README.md
@@ -1,0 +1,54 @@
+# @hivemind/message-slack
+
+Slack adapter for Open Hivemind. Built on `@slack/web-api`, `@slack/socket-mode`, `@slack/rtm-api`, and `@slack/webhook`. Supports multiple Slack workspaces and Block Kit interactivity.
+
+## Exports
+
+Core / loaders / routing / events / utils:
+
+- `SlackConfigurationLoader`, `SlackInstanceFactory`
+- `SlackRouteRegistry`
+- `SlackMessageHandler`, `SlackEventProcessor`, `SlackMessageProcessor`
+- `SlackChannelManager`
+
+Backwards-compatible classes:
+
+- `SlackService` (default + named), `SlackBotManager`, `SlackSignatureVerifier`
+- `SlackInteractiveHandler`, `SlackInteractiveActions`
+- `SlackWelcomeHandler`, `SlackMessage` (default), `SlackMessageProvider`
+- `testSlackConnection`
+
+Plus `schema`, `manifest` (`{ displayName: 'Slack', type: 'message', ... }`), and `create(_config?)` returning the singleton.
+
+## Environment variables
+
+| Variable | Purpose |
+|---|---|
+| `SLACK_BOT_TOKEN` | xoxb token. Used as a single-bot fallback when no instances are configured. |
+| `SLACK_SIGNING_SECRET` | Slack request signing secret. |
+| `SLACK_APP_TOKEN` | Socket Mode app-level token (xapp). |
+| `SLACK_DEFAULT_CHANNEL_ID` | Channel used when one isn't supplied (interactive fallback, etc.). |
+| `SLACK_JOIN_CHANNELS` | Comma-separated channels to join at boot. |
+| `SLACK_INCLUDE_HISTORY` | When `'true'`, include channel history in responses. |
+| `SLACK_FAKE_TYPING` | When `'false'`, disables the typing indicator simulation. |
+| `SLACK_ENABLE_STATUS_UPDATES` | When `'true'`, send periodic status updates. |
+| `SLACK_BUTTON_MAPPINGS` | JSON mapping of Block Kit button IDs to actions. |
+| `MESSAGE_USERNAME_OVERRIDE` | Display name override (default `SlackBot`). |
+| `INCLUDE_SLACK_METADATA` | When `'true'`, include Slack event metadata in messages. |
+| `SUPPRESS_CANVAS_CONTENT` | When `'true'`, drops canvas blocks from message text. |
+| `RESOURCE_URL`, `REPORT_ISSUE_URL` | Welcome-handler link targets. |
+| `NODE_CONFIG_DIR` | Where to load JSON bot configs from (default `config`). |
+
+## Usage
+
+```ts
+import { create as createSlack } from '@hivemind/message-slack';
+
+const service = createSlack();
+await service.initialize();
+await service.sendMessageToChannel('C12345', 'Deploy complete', 'CI');
+```
+
+## Tests
+
+`npm test` is a stub. Slack has extensive coverage in `tests/message/slack/` in the main app.

--- a/packages/message-webhook/README.md
+++ b/packages/message-webhook/README.md
@@ -1,0 +1,33 @@
+# @hivemind/message-webhook
+
+Generic webhook messenger adapter for Open Hivemind. Lets you wire up a custom platform that isn't natively supported by exposing a small HTTP-style integration point on the `IMessengerService` contract.
+
+## Exports
+
+- `WebhookService` — class implementing `IMessengerService` (`initialize`, `sendMessageToChannel`, `getMessagesFromChannel`, `sendPublicAnnouncement`, `getClientId`, `getDefaultChannel`, `shutdown`, `setMessageHandler`)
+- `schema` — UI/config schema descriptor
+- `manifest` — `{ displayName: 'Webhook', type: 'message', ... }`
+- `create(_config, dependencies)` — `IAdapterFactory` (also the default export)
+
+## Status
+
+This adapter is intentionally minimal. The current `WebhookService` exposes the right shape for the message pipeline but `sendMessageToChannel` does not yet POST anywhere — it returns a synthetic message ID. Wire up your own outbound HTTP in a wrapper or extend the class.
+
+## Environment variables
+
+None read directly.
+
+## Usage
+
+```ts
+import createWebhook from '@hivemind/message-webhook';
+import type { IServiceDependencies } from '@hivemind/shared-types';
+
+const service = createWebhook({}, dependencies satisfies IServiceDependencies);
+await service.initialize();
+service.setMessageHandler(async (msg, history, botConfig) => `echo: ${msg.getText()}`);
+```
+
+## Tests
+
+No package-level tests. The webhook surface is exercised through the main app's message routing tests.

--- a/packages/shared-types/README.md
+++ b/packages/shared-types/README.md
@@ -1,0 +1,45 @@
+# @hivemind/shared-types
+
+Shared TypeScript interfaces, base classes, and small runtime helpers that Open Hivemind adapters and providers compile against. Platform-agnostic — no I/O of its own beyond a tiny SSRF-aware HTTP client.
+
+## What's in here
+
+This package defines the contracts every adapter implements:
+
+- `IMessengerService`, `IMessage`, `IServiceDependencies`, `IAdapterFactory`, `IAdapterModule`, `IAdapterConfig`
+- `ILlmProvider`
+- `IMemoryProvider` (+ `MemoryEntry`, `MemorySearchResult`, `MemoryScopeOptions`)
+- `IToolProvider` (+ `ToolDefinition`, `ToolInputSchema`, `ToolResult`, `ToolExecutionContext`)
+- Bot/config accessor types: `IBotConfig`, `IConfigAccessor`, `GetBotConfigFn`, `GetAllBotConfigsFn`, `GetLlmProvidersFn`
+- Misc: `IWebSocketService`, `IMetricsCollector`, `IChannelRouter`, `ILogger`, `IStartupGreetingService`, `SwarmClaim`
+
+Plus a few runtime utilities that are small enough to live alongside the types:
+
+- `BaseError`, `ValidationError`, `NetworkError`, `ApiError`, `ConfigurationError`, `defaultErrorFactory`
+- `isSafeUrl`, `isPrivateIP` — SSRF guards used by every outbound HTTP call
+- `http`, `createHttpClient`, `HttpError`, `isHttpError` — the shared HTTP client
+- `randomId`, `randomUuid`, `cryptoJitter`
+
+## Environment variables
+
+Only the SSRF guard reads env directly:
+
+| Variable | Purpose |
+|---|---|
+| `ALLOW_LOCAL_NETWORK_ACCESS` | When `'true'`, lets `isSafeUrl` return private/localhost addresses. |
+| `MCP_INTERNAL_CIDR_ALLOWLIST` | Comma-separated CIDRs allowed even when private addresses are blocked. |
+
+## Usage
+
+```ts
+import type { ILlmProvider, IMessage } from '@hivemind/shared-types';
+import { http, isSafeUrl } from '@hivemind/shared-types';
+
+if (!isSafeUrl(url).safe) throw new Error('refusing private URL');
+const client = http.create('https://api.example.com');
+const data = await client.get<{ ok: boolean }>('/health');
+```
+
+## Tests
+
+`npm test` is a stub (`echo "No tests yet"`). The runtime helpers are exercised through the consuming adapters' test suites.

--- a/packages/tool-mcp/README.md
+++ b/packages/tool-mcp/README.md
@@ -1,0 +1,47 @@
+# @hivemind/tool-mcp
+
+[Model Context Protocol](https://modelcontextprotocol.io) tool provider for Open Hivemind. Connects to MCP servers over stdio, SSE, or streamable-HTTP and exposes their tools to bots through the `IToolProvider` contract.
+
+## Exports
+
+- `McpToolProvider` — class implementing `IToolProvider`
+- `McpToolProviderConfig`, `McpTransport` — config types
+- `McpToolsListResponse`, `McpToolCallResponse` — raw SDK response shapes
+- `manifest` — `{ displayName: 'MCP Tools', type: 'tool', ... }`
+- `create(config)` — factory used by the PluginLoader. Throws if `config` is missing.
+
+## Configuration (`McpToolProviderConfig`)
+
+| Field | Required | Purpose |
+|---|---|---|
+| `name` | yes | Human-readable provider instance name. |
+| `serverUrl` | yes | URL of the MCP server (used by `sse` and `streamable-http`). |
+| `transport` | yes | One of `'stdio' \| 'sse' \| 'streamable-http'`. |
+| `command` | stdio | Command to spawn the MCP server when `transport === 'stdio'`. |
+| `apiKey` | optional | Bearer token for authenticated servers. |
+| `timeout` | optional | Tool execution timeout in ms (default 30 000). |
+| `autoReconnect` | optional | Reconnect on disconnect (default `true`). |
+
+## Environment variables
+
+None read directly. SSRF guards in `@hivemind/shared-types` validate `serverUrl` — set `ALLOW_LOCAL_NETWORK_ACCESS=true` (or `MCP_INTERNAL_CIDR_ALLOWLIST`) if the server is on a private network.
+
+## Usage
+
+```ts
+import { create as createMcp } from '@hivemind/tool-mcp';
+
+const provider = createMcp({
+  name: 'my-mcp',
+  serverUrl: 'https://mcp.example.com/sse',
+  transport: 'sse',
+  apiKey: process.env.MCP_API_KEY,
+});
+
+const tools = await provider.listTools();
+const result = await provider.callTool(tools[0].name, { query: 'hello' });
+```
+
+## Tests
+
+`npm test` is a stub. End-to-end coverage lives in `tests/tools/mcp/` in the main app.


### PR DESCRIPTION
## Summary

None of the workspaces under `packages/` had a README, so any consumer had to read source to understand the package's surface. This adds a short, source-derived README to every package covering: public exports, required environment variables, a small usage snippet, and a note on tests.

Each README was written from the actual `src/index.ts`, `package.json`, provider classes, and `process.env` references in that package — no aspirational docs. Where the package is intentionally thin (e.g. `memory-postgres` has a 1-line `index.ts` re-export, `message-webhook`'s send is a stub), the README says so.

## Files added

- `packages/llm-flowise/README.md`
- `packages/llm-letta/README.md`
- `packages/llm-openai/README.md`
- `packages/llm-openswarm/README.md`
- `packages/llm-openwebui/README.md`
- `packages/memory-mem0/README.md`
- `packages/memory-mem4ai/README.md`
- `packages/memory-postgres/README.md`
- `packages/message-discord/README.md`
- `packages/message-mattermost/README.md`
- `packages/message-slack/README.md`
- `packages/message-webhook/README.md`
- `packages/shared-types/README.md`
- `packages/tool-mcp/README.md`

No source changes. Draft so maintainers can sanity-check the env-var lists and provider descriptions before merge.

## Test plan

- [ ] Spot-check that the env vars listed for each provider match `grep -rn "process.env" packages/<name>/src`
- [ ] Confirm the usage snippets compile against current types (no type changes here, but the snippets target the exported `create()` factories)
- [ ] Confirm screenshot-described behaviour (Letta cloud/self-hosted via `LETTA_SERVER_PASSWORD`, OpenWebUI as a profile-driven LLM provider) matches the new docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)