### PR TITLE
perf(client): replace transition: all and gate density transitions

### DIFF
--- a/src/client/src/index.css
+++ b/src/client/src/index.css
@@ -34,18 +34,31 @@ html[data-compact-density="true"] { --density-scale: calc(var(--density-base) * 
 /* Smooth out density-driven padding/min-height changes so toggling
    the slider or navbar density button doesn't snap-jump. Wrapped in
    prefers-reduced-motion: no-preference so vestibular-sensitive users
-   keep the instant snap behavior. Rules already using `transition: all`
-   (.stat, .menu li > a/button) are intentionally omitted to avoid
-   duplicate declarations. */
+   keep the instant snap behavior.
+
+   These transitions are gated behind html[data-density-transitioning]
+   so they only fire briefly while density is actually changing. Leaving
+   them permanently active (the previous behavior) caused unrelated
+   layout-changing operations on every card/cell to animate, producing
+   jank on dense pages (logs, providers, large tables). uiStore's
+   setDensity / setCompactDensity actions toggle the attribute on for
+   ~300ms after each change. */
 @media (prefers-reduced-motion: no-preference) {
-  .card-body,
-  .modal-box,
-  .table th,
-  .table td {
+  html[data-density-transitioning] .card-body,
+  html[data-density-transitioning] .modal-box,
+  html[data-density-transitioning] .table th,
+  html[data-density-transitioning] .table td {
     transition: padding 180ms ease, min-height 180ms ease;
   }
 
   .fab-mobile {
+    transition:
+      background-color 150ms ease,
+      color 150ms ease,
+      transform 150ms ease;
+  }
+
+  html[data-density-transitioning] .fab-mobile {
     transition:
       background-color 150ms ease,
       color 150ms ease,
@@ -141,7 +154,8 @@ textarea {
 .stat {
   padding: calc(1.25rem * var(--density-scale, 1)) calc(1.5rem * var(--density-scale, 1));
   border-color: hsl(var(--bc) / 0.1);
-  transition: all 0.2s ease;
+  /* Hover applies a background-image gradient. */
+  transition: background 0.2s ease, background-color 0.2s ease;
 }
 
 .stat:hover {
@@ -209,7 +223,8 @@ textarea {
    Button Enhancements
    ============================================ */
 .btn {
-  transition: all 0.2s ease;
+  /* Hover changes transform + box-shadow; active resets transform. */
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .btn:not(.btn-disabled):hover {
@@ -246,7 +261,10 @@ textarea {
    ============================================ */
 .menu li>a,
 .menu li>button {
-  transition: all 0.15s ease;
+  /* Hover animates padding-left; active state changes background +
+     border-left. Color/background-color also tween for state changes. */
+  transition: padding-left 0.15s ease, background 0.15s ease,
+    background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
   padding: calc(0.5rem * var(--density-scale, 1)) calc(1rem * var(--density-scale, 1));
 }
 
@@ -303,7 +321,8 @@ textarea {
 }
 
 .table tr {
-  transition: all 0.2s ease;
+  /* Hover applies a background gradient + horizontal translate. */
+  transition: background 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
 }
 
 .table tbody tr:hover {
@@ -321,7 +340,8 @@ textarea {
 .input,
 .textarea,
 .select {
-  transition: all 0.2s ease;
+  /* Hover/focus animate border-color, transform, and box-shadow. */
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
   border: 1px solid hsl(var(--bc) / 0.3);
 }
 
@@ -407,7 +427,8 @@ dialog.modal:not([open]) {
 
 /* Modal close button */
 .modal-box .btn-circle.btn-ghost {
-  transition: all 0.15s ease;
+  /* Hover changes background, color, and applies a 90deg rotate. */
+  transition: background 0.15s ease, background-color 0.15s ease, color 0.15s ease, transform 0.15s ease;
 }
 
 .modal-box .btn-circle.btn-ghost:hover {
@@ -428,7 +449,8 @@ dialog.modal:not([open]) {
 
 .tabs-boxed .tab {
   border-radius: 0.5rem;
-  transition: all 0.2s ease;
+  /* Hover/active swap background, color, and box-shadow. */
+  transition: background 0.2s ease, background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
   font-weight: 500;
 }
 
@@ -444,7 +466,8 @@ dialog.modal:not([open]) {
 
 /* Bordered/Lifted tabs */
 .tabs-lifted .tab {
-  transition: all 0.2s ease;
+  /* Hover/active swap border-bottom-color and color. */
+  transition: border-bottom-color 0.2s ease, color 0.2s ease;
   border-bottom: 2px solid transparent;
 }
 
@@ -467,7 +490,8 @@ dialog.modal:not([open]) {
   width: 0;
   height: 2px;
   background: hsl(var(--p));
-  transition: all 0.2s ease;
+  /* Hover/active grow the underline width. */
+  transition: width 0.2s ease;
   transform: translateX(-50%);
 }
 
@@ -680,7 +704,8 @@ dialog.modal:not([open]) {
 
 .dropdown-content li>a,
 .dropdown-content li>button {
-  transition: all 0.15s ease;
+  /* Hover applies a background gradient and padding-left shift. */
+  transition: background 0.15s ease, background-color 0.15s ease, padding-left 0.15s ease, color 0.15s ease;
   border-radius: 0.5rem;
   margin: 0.25rem;
 }
@@ -828,7 +853,9 @@ body.robot-ui-enabled {
       hsl(var(--bc) / 0.15) 0%,
       hsl(var(--bc) / 0.08) 50%,
       hsl(var(--bc) / 0.12) 100%);
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  /* Hover/active/open states change transform and box-shadow. */
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   isolation: isolate;
   display: flex;
   align-items: center;
@@ -881,7 +908,8 @@ body.robot-ui-enabled {
   height: 0.625rem;
   background: hsl(var(--bc) / 0.4);
   border-radius: 1px;
-  transition: all 0.3s ease;
+  /* Hover/open states change background and add a colored box-shadow. */
+  transition: background 0.3s ease, background-color 0.3s ease, box-shadow 0.3s ease;
 }
 
 .robot-hamburger-antenna-left {
@@ -901,7 +929,8 @@ body.robot-ui-enabled {
   background: transparent;
   border: 2px solid hsl(var(--bc) / 0.4);
   border-radius: 50%;
-  transition: all 0.3s ease;
+  /* Hover/open change border-color, background, and box-shadow. */
+  transition: border-color 0.3s ease, background 0.3s ease, background-color 0.3s ease, box-shadow 0.3s ease;
 }
 
 .robot-hamburger-antenna-tip-left {
@@ -930,7 +959,11 @@ body.robot-ui-enabled {
   height: 2px;
   background: hsl(var(--bc) / 0.8);
   border-radius: 1px;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  /* Hover changes background; open state animates transform + opacity. */
+  transition: background 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    background-color 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   transform-origin: center;
 }
 
@@ -943,7 +976,8 @@ body.robot-ui-enabled {
   height: 0.375rem;
   background: hsl(var(--bc) / 0.3);
   border-radius: 50%;
-  transition: all 0.3s ease;
+  /* Open state changes background and box-shadow (LED glow). */
+  transition: background 0.3s ease, background-color 0.3s ease, box-shadow 0.3s ease;
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.3);
 }
 
@@ -1241,8 +1275,13 @@ body.robot-ui-enabled {
 body.robot-ui-enabled .btn-primary,
 body.robot-ui-enabled .btn-secondary,
 body.robot-ui-enabled .btn-accent {
-  /* Smooth transition when switching themes */
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  /* Smooth transition when switching themes — only the theme-driven
+     properties need to animate, not every animatable property. */
+  transition: background 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    background-color 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    border-color 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    color 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 /* ============================================

--- a/src/client/src/store/uiStore.ts
+++ b/src/client/src/store/uiStore.ts
@@ -153,6 +153,26 @@ const getInitialState = (): UIState => ({
   },
 });
 
+/**
+ * Briefly mark <html data-density-transitioning="true"> so the CSS rules
+ * scoped behind that selector (.card-body / .modal-box / .table th td /
+ * .fab-mobile padding+min-height transitions) actually fire when density
+ * changes. The attribute is removed ~300ms later so unrelated layout
+ * changes on those surfaces remain instant — leaving the transitions
+ * permanently active was visibly janky on dense pages with many cards
+ * or table cells.
+ */
+function flashDensityTransition(): void {
+  if (typeof document === 'undefined' || typeof window === 'undefined') return;
+  const el = document.documentElement;
+  el.setAttribute('data-density-transitioning', 'true');
+  const t = (flashDensityTransition as any)._t;
+  if (t !== undefined) window.clearTimeout(t);
+  (flashDensityTransition as any)._t = window.setTimeout(() => {
+    el.removeAttribute('data-density-transitioning');
+  }, 300);
+}
+
 export const useUIStore = create<UIState & UIActions>((set, get) => ({
   ...getInitialState(),
 
@@ -297,6 +317,7 @@ export const useUIStore = create<UIState & UIActions>((set, get) => ({
   },
 
   setCompactDensity: (compactDensity) => {
+    flashDensityTransition();
     set({ compactDensity });
     localStorage.setItem('compactDensity', compactDensity.toString());
     document.documentElement.setAttribute('data-compact-density', compactDensity.toString());
@@ -324,6 +345,7 @@ export const useUIStore = create<UIState & UIActions>((set, get) => ({
   },
 
   setDensity: (density) => {
+    flashDensityTransition();
     set({ density });
     localStorage.setItem('density', density);
     document.documentElement.setAttribute('data-density', density);


### PR DESCRIPTION
## Summary

Two CSS performance fixes in `src/client/src/index.css` to reduce hover-time and layout-time transition work, especially on dense pages (logs, providers, large tables).

### 1. Replace `transition: all` with explicit property lists

`transition: all` causes the browser to interpolate every animatable property when *anything* changes (hover, focus, attribute toggle, theme swap). Combined with the recently added density `padding`/`min-height` transitions, hover interactions on dense pages were producing visible jank. Each rule below now lists only the properties that actually animate based on its hover/focus/active rules:

| Selector | New transition |
|---|---|
| `.stat` | `background, background-color` |
| `.btn` | `transform, box-shadow` |
| `.menu li > a/button` | `padding-left, background, background-color, border-color, color` |
| `.table tr` | `background, background-color, transform` |
| `.input, .textarea, .select` | `border-color, transform, box-shadow` |
| `.modal-box .btn-circle.btn-ghost` | `background, background-color, color, transform` |
| `.tabs-boxed .tab` | `background, background-color, color, box-shadow` |
| `.tabs-lifted .tab` | `border-bottom-color, color` |
| `.tab-bordered .tab::after` | `width` |
| `.dropdown-content li > a/button` | `background, background-color, padding-left, color` |
| `.robot-hamburger` | `transform, box-shadow` |
| `.robot-hamburger-antenna` | `background, background-color, box-shadow` |
| `.robot-hamburger-antenna-tip` | `border-color, background, background-color, box-shadow` |
| `.robot-hamburger-line` | `background, background-color, transform, opacity` |
| `.robot-hamburger-led` | `background, background-color, box-shadow` |
| `body.robot-ui-enabled .btn-primary/secondary/accent` | `background, background-color, border-color, color, box-shadow` |

### 2. Gate density transitions behind an attribute

The `transition: padding, min-height` rules on `.card-body`, `.modal-box`, `.table th/td`, and `.fab-mobile` were permanently active. They only need to fire briefly when density actually changes. Otherwise, any unrelated layout change to those surfaces (resize, content load, etc.) gets animated.

Solution:

- CSS rules are now scoped behind `html[data-density-transitioning] .card-body { ... }` (etc.).
- `uiStore.setDensity` and `setCompactDensity` call a new `flashDensityTransition()` helper that sets `<html data-density-transitioning="true">` and clears it 300ms later (clearing/replacing any pending timeout).
- Wrapped in `@media (prefers-reduced-motion: no-preference)` (already was), so vestibular-sensitive users keep the instant snap behavior.

## Test plan

- [ ] `cd src/client && pnpm exec vitest run src/__tests__/density-css-smoke.test.ts` — density CSS contract regression test still passes (the test asserts on `--density-base` / `--density-scale` plumbing and `.card-body` referencing `--density-scale`; none of those changed).
- [ ] `npm run dev` — open `/dashboard` and `/logs` (or any dense table page); confirm hover on rows/buttons/inputs feels snappier with no padding/min-height tween bleed-through.
- [ ] Toggle density slider in Settings — confirm `.card-body` / `.modal-box` / table cells still animate padding smoothly during the toggle (300ms window).
- [ ] Toggle density rapidly — confirm no lingering attribute (`document.documentElement.dataset.densityTransitioning` should clear within ~300ms of the last change).
- [ ] Toggle compact-density — same smooth animation.
- [ ] After density transition completes, resize a card or load new content — padding changes should be instant (no tween).
- [ ] With `prefers-reduced-motion: reduce`, density toggles still apply instantly with no animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)