### PR TITLE
a11y(client): restore full opacity on kill-switch trigger; distinguish trigger vs state icons

### DIFF
--- a/src/client/src/components/DaisyUI/NavbarWithSearch.tsx
+++ b/src/client/src/components/DaisyUI/NavbarWithSearch.tsx
@@ -31,6 +31,7 @@ import {
   Rows3,
   Rows4,
   ShieldAlert,
+  ShieldOff,
 } from 'lucide-react';
 
 type Density = 'compact' | 'comfortable' | 'spacious';
@@ -301,9 +302,9 @@ const NavbarWithSearch: React.FC<NavbarWithSearchProps> = ({
     <>
       {isPanicMode && (
         <div className="bg-error text-error-content px-4 py-2 text-center text-sm font-bold uppercase tracking-widest flex items-center justify-center gap-2 animate-pulse shadow-inner">
-          <ShieldAlert className="w-4 h-4" />
+          <ShieldOff className="w-4 h-4" />
           SYSTEM PANIC MODE ACTIVE: ALL BOT MESSAGES REJECTED
-          <ShieldAlert className="w-4 h-4" />
+          <ShieldOff className="w-4 h-4" />
         </div>
       )}
     <nav className="navbar bg-base-100 shadow-lg border-b border-base-200 px-4" aria-label="Main navigation">
@@ -472,7 +473,7 @@ const NavbarWithSearch: React.FC<NavbarWithSearchProps> = ({
         {/* Kill Switch */}
         <Tooltip content={isPanicMode ? "Deactivate Kill Switch" : "Global Kill Switch (PANIC)"} position="bottom">
           <button 
-            className={`btn btn-sm btn-circle ${isPanicMode ? 'btn-error animate-pulse shadow-[0_0_15px_rgba(220,38,38,0.8)]' : 'btn-ghost text-error/60 hover:bg-error hover:text-error-content'}`}
+            className={`btn btn-sm btn-circle ${isPanicMode ? 'btn-error animate-pulse shadow-[0_0_15px_rgba(220,38,38,0.8)]' : 'btn-ghost text-error hover:bg-error hover:text-error-content'}`}
             onClick={handleTogglePanicMode}
             aria-label="Toggle Global Kill Switch"
           >


### PR DESCRIPTION
## Summary

Two related accessibility/usability fixes to the global kill-switch in `NavbarWithSearch.tsx`.

### 1. WCAG 2.2 SC 1.4.11 contrast — kill-switch trigger

The resting-state kill-switch button used `text-error/60` (line 475). At 60% opacity, the icon's contrast against the navbar surface drops below the **3:1 minimum required by WCAG 2.2 SC 1.4.11 (Non-text Contrast)** in the light family of DaisyUI themes (`light`, `cupcake`, `corporate`, `emerald`). Worse, the dimmed appearance reads as a *disabled* control — the opposite of an "armed danger control" that the user can press to trip the kill switch.

**Fix:** drop the `/60` opacity modifier so the trigger renders at the full `text-error` color.

### 2. Icon-vocabulary disambiguation — trigger vs active state

Previously the same `ShieldAlert` icon was used both for the resting trigger button **and** for the active panic-mode banner. Reusing one icon for two semantically different states (a button you press vs a state currently in effect) muddies the visual language.

**Fix:** use `ShieldOff` in the active panic-mode banner (lines 305 and 307) and keep `ShieldAlert` on the trigger. The vocabulary now distinguishes "I trigger this danger" (alert / warn) from "this danger control is engaged" (off / blocked). `ShieldOff` is added to the lucide-react import.

## Test plan

- [ ] Visually verify the kill-switch icon in the navbar renders at full red opacity in `light`, `cupcake`, `corporate`, and `emerald` themes
- [ ] Activate panic mode and confirm the top banner shows `ShieldOff` icons on either side of the message
- [ ] Confirm the trigger button still shows `ShieldAlert` (warn) when not in panic mode
- [ ] Run an automated contrast check (e.g. axe / Lighthouse) on the navbar in a light theme — non-text contrast on the kill-switch should now meet 3:1