### PR TITLE
feat(client): add density controls to SystemSettings page

### DIFF
--- a/docs/density-system.md
+++ b/docs/density-system.md
@@ -86,20 +86,23 @@ Rules of thumb:
 
 ## UX entry points
 
-- The navbar quick-toggle (PR #2666) cycles
-  `compact → comfortable → spacious` from the global header. It writes to the
-  Zustand slice via `setDensity`. **This is currently the only working UI
-  control for density.**
-- `src/client/src/components/Settings.tsx` contains a `<select>` wired to
-  `setDensity`, but it is orphaned — the live `/admin/settings` route renders
-  `src/client/src/pages/SystemSettings.tsx` (see
-  `src/client/src/router/AppRouter.tsx`), which does not include the density
-  control. The orphan component is not mounted anywhere in the router.
-- `compactDensity` has **no UI control** at all today. It is currently
-  programmatic-only — the value is read by `src/client/src/components/DaisyUI/Card.tsx`
-  to apply `card-compact`, and `setCompactDensity` exists in the store but
-  no component invokes it. Toggling it requires editing `localStorage`
-  directly or wiring a new control.
+Two surfaces in the live app let users change density today, and they share the
+same Zustand actions (`setDensity`, `setCompactDensity`):
+
+- **Navbar quick-toggle** (PR #2666). Cycles
+  `compact → comfortable → spacious` from the global header. Best for fast
+  one-handed iteration; the icon and aria-label announce the next state.
+- **Settings page** — `/admin/settings` → *General* → *Display Density* card.
+  Renders a `<Select>` for the three-way density choice plus a `<Toggle>` for
+  the boolean `compactDensity` axis ("Extra-compact mode"). Implemented in
+  `src/client/src/components/Settings/SettingsGeneral.tsx`. This is the
+  discoverable home for both controls and the only place `compactDensity` can
+  be flipped from the UI.
+
+Historical note: an earlier orphan component at
+`src/client/src/components/Settings.tsx` held a density `<select>` that was
+never mounted in the router. It was removed in PR #2702. The Settings-page
+controls listed above replace it.
 
 ## Known constraints
 

--- a/src/client/src/components/Settings/SettingsGeneral.tsx
+++ b/src/client/src/components/Settings/SettingsGeneral.tsx
@@ -17,6 +17,14 @@ import { useSavedStamp } from '../../contexts/SavedStampContext';
 import Textarea from '../DaisyUI/Textarea';
 import { useToast } from '../DaisyUI/ToastNotification';
 import { useDemoModeWarning } from '../../hooks/useDemoModeWarning';
+import { useUIStore } from '../../store/uiStore';
+import type { UIState } from '../../store/uiStore';
+
+const DENSITY_OPTIONS: Array<{ value: UIState['density']; label: string; description: string }> = [
+  { value: 'compact', label: 'Compact', description: 'Tighter spacing, more content per screen' },
+  { value: 'comfortable', label: 'Comfortable', description: 'Balanced spacing (default)' },
+  { value: 'spacious', label: 'Spacious', description: 'Generous spacing, easier to scan' },
+];
 const debug = Debug('app:client:components:Settings:SettingsGeneral');
 
 const generalSettingsSchema = z.object({
@@ -80,6 +88,18 @@ const SettingsGeneral: React.FC = () => {
   const warnIfDemo = useDemoModeWarning(addToast as any);
 
   const enableHealthChecks = watch('enableHealthChecks');
+
+  // Density controls — match the canonical entry-point lost when the
+  // orphan Settings.tsx was deleted in PR #2702. Wires straight into the
+  // existing uiStore actions; no API round-trip needed because the values
+  // are persisted to localStorage and applied to <html data-density="..."> /
+  // <html data-compact-density="..."> by the store itself.
+  const density = useUIStore((s) => s.density);
+  const compactDensity = useUIStore((s) => s.compactDensity);
+  const setDensity = useUIStore((s) => s.setDensity);
+  const setCompactDensity = useUIStore((s) => s.setCompactDensity);
+  const densityDescription =
+    DENSITY_OPTIONS.find((opt) => opt.value === density)?.description ?? '';
 
   // Auto-save functions for individual settings (like LLMProvidersPage pattern)
   const saveGlobalSetting = async (patch: Record<string, any>) => {
@@ -323,6 +343,49 @@ const SettingsGeneral: React.FC = () => {
             />
             <p className="text-xs text-base-content/50 pl-1">
               When enabled, shows the Getting Started tab on the Overview page with setup guides and tips.
+            </p>
+          </div>
+        </Card>
+
+        {/* Display Density */}
+        <Card
+          className="bg-base-100 border border-base-300 shadow-sm p-4 h-full"
+          data-testid="settings-density-card"
+        >
+          <h6 className="text-md font-semibold mb-4 flex items-center gap-2">
+            <span className="w-2 h-2 bg-success rounded-full"></span>
+            Display Density
+          </h6>
+
+          <FormField label="UI Density">
+            <Select
+              size="sm"
+              value={density}
+              onChange={(e) => setDensity(e.target.value as UIState['density'])}
+              options={DENSITY_OPTIONS.map((opt) => ({
+                value: opt.value,
+                label: opt.label,
+              }))}
+              data-testid="settings-density-select"
+            />
+          </FormField>
+          <p className="text-xs text-base-content/50 pl-1 -mt-2 mb-3">
+            {densityDescription}
+          </p>
+
+          <div className="space-y-3">
+            <Toggle
+              label="Extra-compact mode"
+              checked={compactDensity}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setCompactDensity(e.target.checked)
+              }
+              size="sm"
+              data-testid="settings-compact-density-toggle"
+            />
+            <p className="text-xs text-base-content/50 pl-1">
+              Further tightens spacing on top of the selected density. Useful for
+              power users who want maximum information per screen.
             </p>
           </div>
         </Card>


### PR DESCRIPTION
## Summary

PR #2702 deleted the orphan `src/client/src/components/Settings.tsx` (it was never mounted in the router). That component was the home of the canonical density `<select>` UI, so its removal left the navbar cycle button as the **only** in-app density control — a UX downgrade for power users who expect a settings page entry-point. `compactDensity` had no UI control at all.

This restores a discoverable density section on the live `/admin/settings` page, integrated into the existing tab structure (no resurrection of the orphan).

## Changes

- `src/client/src/components/Settings/SettingsGeneral.tsx`
  - New "Display Density" card alongside the existing "Aesthetic Preferences" card
  - `<Select>` for `density` (Compact / Comfortable / Spacious) wired to `useUIStore.setDensity`
  - `<Toggle>` for `compactDensity` ("Extra-compact mode") wired to `useUIStore.setCompactDensity` — first UI surface for this flag
  - Live help text from the canonical density description strings
  - `data-testid` hooks: `settings-density-card`, `settings-density-select`, `settings-compact-density-toggle`
- `docs/density-system.md`
  - "UX entry points" section now lists BOTH the navbar quick-toggle AND the new Settings page section
  - Removed the "no UI exists" caveat for `compactDensity`
  - Replaced the orphan-component description with a historical note referencing PR #2702

## Why this layout

The new card sits inside the existing General tab grid (same `Card` + `FormField` patterns as siblings) so it shares spacing/responsive behaviour. No new sub-tab is introduced — density is a small enough surface that a dedicated tab would feel empty.

## Test plan

- [ ] `/admin/settings` (General tab) renders the "Display Density" card
- [ ] Changing the `<Select>` immediately updates `<html data-density="...">` and persists to `localStorage` `density`
- [ ] Toggling "Extra-compact mode" updates `<html data-compact-density="...">` and persists to `localStorage` `compactDensity`
- [ ] Navbar quick-toggle and the new Select stay in sync (both read/write the same Zustand slice)
- [ ] `cd src/client && ../../node_modules/.bin/vitest run` — sandbox blocked locally; please run in CI

## Notes

Draft PR. Local sandbox blocked test execution; relying on CI to run vitest. No screenshot captured (best-effort, sandbox-limited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)