### PR TITLE
fix(client): stabilize useInactivity.reset to break closure-over-isIdle loop

### DIFF
--- a/src/client/src/hooks/__tests__/useInactivity.test.ts
+++ b/src/client/src/hooks/__tests__/useInactivity.test.ts
@@ -5,18 +5,11 @@
  * timer management, cleanup, and custom configuration.
  *
  * Uses @testing-library/react's renderHook + act so the hook runs inside a
- * real React component context. Previously the test invoked the hook
- * directly, which threw "Cannot read properties of null (reading
- * 'useState')" because hooks must run inside a render.
+ * real React component context.
  *
- * Note: the hook re-registers its useEffect whenever `isIdle` changes (the
- * `reset` callback closes over `isIdle`). That means when the timer fires
- * and `setIsIdle(true)` runs, the resulting re-render synchronously calls
- * `reset()` again from the new effect, which flips `isIdle` back to false
- * before the next render is observed. We therefore use the `onIdle`/`onWake`
- * callbacks as the source of truth for transition-to-idle assertions, and
- * read `result.current` for properties that don't depend on that transient
- * state (initial state, `lastActive`, the `reset` function).
+ * Both `result.current.isIdle` (the rendered state) AND the `onIdle` /
+ * `onWake` callbacks are asserted on, so a regression that breaks either the
+ * external state or the callbacks will fail this suite.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
@@ -40,20 +33,22 @@ describe('useInactivity Hook', () => {
   it('should transition to idle after the specified timeout with no activity', () => {
     const timeoutMs = 5000;
     const onIdle = vi.fn();
-    renderHook(() => useInactivity({ timeoutMs, onIdle }));
+    const { result } = renderHook(() => useInactivity({ timeoutMs, onIdle }));
 
     expect(onIdle).not.toHaveBeenCalled();
+    expect(result.current.isIdle).toBe(false);
 
     act(() => {
       vi.advanceTimersByTime(timeoutMs);
     });
 
     expect(onIdle).toHaveBeenCalledTimes(1);
+    expect(result.current.isIdle).toBe(true);
   });
 
   it('should call onIdle callback when transitioning to idle', () => {
     const onIdle = vi.fn();
-    renderHook(() => useInactivity({ timeoutMs: 3000, onIdle }));
+    const { result } = renderHook(() => useInactivity({ timeoutMs: 3000, onIdle }));
 
     expect(onIdle).not.toHaveBeenCalled();
 
@@ -62,18 +57,20 @@ describe('useInactivity Hook', () => {
     });
 
     expect(onIdle).toHaveBeenCalledTimes(1);
+    expect(result.current.isIdle).toBe(true);
   });
 
   it('should reset the idle timer on user activity (mouse movement)', () => {
     const timeoutMs = 2000;
     const onIdle = vi.fn();
-    renderHook(() => useInactivity({ timeoutMs, onIdle }));
+    const { result } = renderHook(() => useInactivity({ timeoutMs, onIdle }));
 
     // Advance partway to idle
     act(() => {
       vi.advanceTimersByTime(1500);
     });
     expect(onIdle).not.toHaveBeenCalled();
+    expect(result.current.isIdle).toBe(false);
 
     // Simulate mouse movement — resets the timer
     act(() => {
@@ -85,23 +82,26 @@ describe('useInactivity Hook', () => {
       vi.advanceTimersByTime(1500);
     });
     expect(onIdle).not.toHaveBeenCalled();
+    expect(result.current.isIdle).toBe(false);
 
     act(() => {
       vi.advanceTimersByTime(500);
     });
     expect(onIdle).toHaveBeenCalledTimes(1);
+    expect(result.current.isIdle).toBe(true);
   });
 
   it('should wake from idle state on user activity and call onWake', () => {
     const onIdle = vi.fn();
     const onWake = vi.fn();
-    renderHook(() => useInactivity({ timeoutMs: 1000, onIdle, onWake }));
+    const { result } = renderHook(() => useInactivity({ timeoutMs: 1000, onIdle, onWake }));
 
     // Go idle
     act(() => {
       vi.advanceTimersByTime(1000);
     });
     expect(onIdle).toHaveBeenCalledTimes(1);
+    expect(result.current.isIdle).toBe(true);
 
     // Simulate activity — listener fires synchronously and resets the timer
     act(() => {
@@ -109,13 +109,14 @@ describe('useInactivity Hook', () => {
     });
 
     expect(onWake).toHaveBeenCalled();
+    expect(result.current.isIdle).toBe(false);
   });
 
   it('should handle visibilitychange event when page becomes visible', () => {
     const timeoutMs = 2000;
     const onIdle = vi.fn();
     const onWake = vi.fn();
-    renderHook(() =>
+    const { result } = renderHook(() =>
       useInactivity({ timeoutMs, onIdle, onWake })
     );
 
@@ -124,6 +125,7 @@ describe('useInactivity Hook', () => {
       vi.advanceTimersByTime(timeoutMs);
     });
     expect(onIdle).toHaveBeenCalledTimes(1);
+    expect(result.current.isIdle).toBe(true);
 
     // Page becomes visible again — should wake
     Object.defineProperty(document, 'visibilityState', {
@@ -136,12 +138,13 @@ describe('useInactivity Hook', () => {
     });
 
     expect(onWake).toHaveBeenCalled();
+    expect(result.current.isIdle).toBe(false);
   });
 
   it('should NOT reset timer when visibilitychange fires with hidden state', () => {
     const timeoutMs = 2000;
     const onIdle = vi.fn();
-    renderHook(() => useInactivity({ timeoutMs, onIdle }));
+    const { result } = renderHook(() => useInactivity({ timeoutMs, onIdle }));
 
     // Page hidden — should not affect timer
     Object.defineProperty(document, 'visibilityState', {
@@ -158,6 +161,7 @@ describe('useInactivity Hook', () => {
       vi.advanceTimersByTime(timeoutMs);
     });
     expect(onIdle).toHaveBeenCalledTimes(1);
+    expect(result.current.isIdle).toBe(true);
   });
 
   it('should clean up event listeners and timers on unmount', () => {
@@ -189,17 +193,20 @@ describe('useInactivity Hook', () => {
       vi.advanceTimersByTime(1000);
     });
     expect(onIdle).toHaveBeenCalledTimes(1);
+    expect(result.current.isIdle).toBe(true);
 
-    // Manually reset — should restart the timer
+    // Manually reset — should restart the timer and clear idle state
     act(() => {
       result.current.reset();
     });
+    expect(result.current.isIdle).toBe(false);
 
     // Should fire onIdle again after another full timeout
     act(() => {
       vi.advanceTimersByTime(1000);
     });
     expect(onIdle).toHaveBeenCalledTimes(2);
+    expect(result.current.isIdle).toBe(true);
   });
 
   it('should report lastActive timestamp that updates on activity', () => {

--- a/src/client/src/hooks/useInactivity.ts
+++ b/src/client/src/hooks/useInactivity.ts
@@ -24,27 +24,43 @@ export function useInactivity({
   const timerRef = useRef<number | null>(null);
   const lastActiveRef = useRef<number>(Date.now());
 
-  const clearTimer = () => {
+  // Mirror state and callbacks in refs so `reset` does not need them in its
+  // dep list. Previously `reset` closed over `isIdle` and was in
+  // `useEffect`'s deps; when the timer fired `setIsIdle(true)`, the resulting
+  // re-render produced a new `reset` identity, which re-ran the effect, which
+  // immediately called the new `reset()` — flipping `isIdle` back to false
+  // before any consumer could observe `true`. PR #2704 worked around this by
+  // weakening the tests; this restores the actual behavior.
+  const isIdleRef = useRef(isIdle);
+  isIdleRef.current = isIdle;
+  const onIdleRef = useRef(onIdle);
+  onIdleRef.current = onIdle;
+  const onWakeRef = useRef(onWake);
+  onWakeRef.current = onWake;
+  const timeoutMsRef = useRef(timeoutMs);
+  timeoutMsRef.current = timeoutMs;
+
+  const clearTimer = useCallback(() => {
     if (timerRef.current) {
       window.clearTimeout(timerRef.current);
       timerRef.current = null;
     }
-  };
+  }, []);
 
   const goIdle = useCallback(() => {
     setIsIdle(true);
-    onIdle?.();
-  }, [onIdle]);
+    onIdleRef.current?.();
+  }, []);
 
   const reset = useCallback(() => {
     lastActiveRef.current = Date.now();
-    if (isIdle) {
+    if (isIdleRef.current) {
       setIsIdle(false);
-      onWake?.();
+      onWakeRef.current?.();
     }
     clearTimer();
-    timerRef.current = window.setTimeout(goIdle, timeoutMs);
-  }, [goIdle, isIdle, onWake, timeoutMs]);
+    timerRef.current = window.setTimeout(goIdle, timeoutMsRef.current);
+  }, [clearTimer, goIdle]);
 
   useEffect(() => {
     // Initialize timer
@@ -65,7 +81,7 @@ export function useInactivity({
       clearTimer();
       events.forEach(evt => window.removeEventListener(evt, handleEvent));
     };
-  }, [events, reset]);
+  }, [events, reset, clearTimer]);
 
   return { isIdle, reset, lastActive: lastActiveRef.current };
 }


### PR DESCRIPTION
## Summary

Fixes a real source bug in \`src/client/src/hooks/useInactivity.ts\` and restores the test assertions that PR #2704 had to weaken to ship green.

## The bug

The hook's \`reset\` callback closed over \`isIdle\` and was listed in \`useEffect\`'s dep array:

\`\`\`ts
const reset = useCallback(() => {
  // ...
  if (isIdle) { setIsIdle(false); onWake?.(); }
  // ...
}, [goIdle, isIdle, onWake, timeoutMs]);

useEffect(() => {
  reset();
  // ...register listeners...
}, [events, reset]);
\`\`\`

Sequence on idle:
1. Timer fires → \`setIsIdle(true)\`
2. Component re-renders
3. \`reset\` gets a new identity (because \`isIdle\` changed)
4. \`useEffect\` re-runs (because \`reset\` is in deps)
5. The new effect immediately calls \`reset()\`, which now sees \`isIdle === true\`
6. \`reset()\` calls \`setIsIdle(false)\` → \`isIdle\` flips back to \`false\` before any consumer ever observes \`true\`

The \`onIdle\` and \`onWake\` callbacks fire correctly during the transient flip, so they're a misleading proxy for the actual rendered state.

## The fix

Stabilize \`reset\` (and \`goIdle\`/\`clearTimer\`) so they have stable identities across renders:

- Mirror \`isIdle\`, \`onIdle\`, \`onWake\`, and \`timeoutMs\` in refs that are updated on every render.
- \`reset\` reads \`isIdleRef.current\` instead of closing over the \`isIdle\` state.
- \`reset\`'s deps are now \`[clearTimer, goIdle]\` (both stable with empty deps), so its identity is stable.
- \`useEffect\` no longer re-registers listeners on idle transitions.

The functional contract is unchanged: timers, listeners, callbacks, and \`reset()\` all behave the same; only the spurious self-cancellation is removed.

## Why test changes too

PR #2704 (test-only) noted in its body that \`result.current.isIdle\` could not be observed as \`true\` and switched the affected assertions to \`onIdle\`/\`onWake\` callbacks, with a follow-up note that the source needed fixing. This PR is that follow-up — it restores \`expect(result.current.isIdle).toBe(true)\` (and \`...toBe(false)\` after wake) on every transition that previously had to be weakened.

The strict assertions FAIL against the unfixed hook (verified by reverting only \`useInactivity.ts\` and re-running the test file: 7 of 11 fail with \`expected true, received false\` exactly at the new \`result.current.isIdle\` checks). They PASS with the hook fix.

## Test plan

- [x] All 11 cases in \`src/client/src/hooks/__tests__/useInactivity.test.ts\` pass with the fix
- [x] Confirmed the new strict assertions fail against the pre-fix hook (7 failures, all at the restored \`result.current.isIdle\` checks)
- [ ] CI green
- [ ] Manual smoke: any consumer reading \`isIdle\` (e.g. inactivity-driven UI dimming) now sees the rendered idle state instead of always \`false\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)