### PR TITLE
test(client): lock in setUrlParam stability and CSS transition presence

### DIFF
--- a/src/client/src/__tests__/css-transitions-smoke.test.ts
+++ b/src/client/src/__tests__/css-transitions-smoke.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression guard for PR #2708 (perf(client): replace transition: all
+ * and gate density transitions).
+ *
+ * PR #2708 replaced 13 `transition: all` declarations in index.css with
+ * explicit property lists. The risk it introduced: if a future commit
+ * accidentally drops a `transition:` line entirely from one of those
+ * rules (during a refactor, a merge resolution, etc.), the hover/focus
+ * animations on that element silently vanish — no console error, no
+ * visual diff in static snapshots, just a subtle UX regression.
+ *
+ * This file is a deliberately simple string-presence smoke test:
+ *   1. Read index.css as raw text.
+ *   2. Locate each known selector's rule body.
+ *   3. Assert the rule body contains a `transition:` declaration.
+ *
+ * It does NOT parse CSS. That means it is intentionally brittle to
+ * extreme reformatting (e.g. moving the transition to a separate
+ * selector via cascade) — accepted tradeoff for a tiny test that
+ * catches the actual regression we care about: the transition line
+ * being removed entirely.
+ *
+ * The selector list is the set modified by PR #2708. If a selector is
+ * intentionally retired, remove it from this list AND record why in
+ * the commit message.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const cssPath = join(__dirname, '../index.css');
+const css = readFileSync(cssPath, 'utf8');
+
+/**
+ * Extract the body of the FIRST rule in `css` whose selector list
+ * contains `selector` as a complete entry (comma-delimited or alone).
+ * Returns null if no such rule exists.
+ *
+ * This is a string scan, not a CSS parser — it accepts any whitespace
+ * around `{` and assumes top-level rules (no @-rule nesting tricks).
+ */
+function findRuleBody(source: string, selector: string): string | null {
+  // Escape regex metacharacters in the selector, then allow flexible
+  // whitespace between tokens (so `.menu li>a` matches `.menu li > a`).
+  const escaped = selector
+    .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    .replace(/\s*>\s*/g, '\\s*>\\s*')
+    .replace(/\s+/g, '\\s+');
+
+  // Match the selector as a standalone entry in a comma-separated list,
+  // bounded by start-of-rule, comma, or whitespace before `{`.
+  const selectorPattern = new RegExp(
+    `(?:^|[},])\\s*(?:[^{},]*,\\s*)*${escaped}(?:\\s*,[^{]*)?\\s*\\{([^}]*)\\}`,
+    'm',
+  );
+  const match = source.match(selectorPattern);
+  return match ? match[1] : null;
+}
+
+/**
+ * Selectors PR #2708 modified. Each MUST retain at least one
+ * `transition:` declaration somewhere in its rule body.
+ */
+const SELECTORS_REQUIRING_TRANSITION: readonly string[] = [
+  '.stat',
+  '.btn',
+  '.menu li>a',
+  '.menu li>button',
+  '.table tr',
+  '.input',
+  '.textarea',
+  '.select',
+  '.tabs-boxed .tab',
+  '.tabs-lifted .tab',
+  '.dropdown-content li>a',
+  '.dropdown-content li>button',
+  '.modal-box .btn-circle.btn-ghost',
+];
+
+describe('CSS transition declarations (PR #2708 regression guard)', () => {
+  for (const selector of SELECTORS_REQUIRING_TRANSITION) {
+    it(`rule "${selector}" still declares a transition`, () => {
+      const body = findRuleBody(css, selector);
+      expect(
+        body,
+        `Could not locate rule for selector "${selector}" in index.css. ` +
+          `Either the selector was renamed (update this test) or the rule was ` +
+          `removed (likely a regression of PR #2708).`,
+      ).not.toBeNull();
+      expect(
+        body!,
+        `Rule "${selector}" exists but has no \`transition:\` declaration. ` +
+          `PR #2708 explicitly added one — silently dropping it removes ` +
+          `the hover/focus animation.`,
+      ).toMatch(/transition\s*:/);
+    });
+  }
+});

--- a/src/client/src/hooks/__tests__/useUrlParams.test.ts
+++ b/src/client/src/hooks/__tests__/useUrlParams.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression guard for PR #2705 (perf(client): fix BotsPage useMemo
+ * invalidation and MobileFAB memo defeat).
+ *
+ * BotsPage now wraps its URL setters in `useCallback([setUrlParam])` —
+ * that optimization only holds if `useUrlParams`'s `setValue` is itself
+ * a stable reference across renders. The hook achieves this by wrapping
+ * `setValue` in `useCallback([setSearchParams])` (where `setSearchParams`
+ * is itself stable from react-router).
+ *
+ * If a future refactor breaks that stability (e.g. inlining the function,
+ * adding a non-stable dep, recreating it via `useMemo` keyed on `values`),
+ * BotsPage's `useCallback` deps would change every render, the downstream
+ * `useMemo`s would invalidate, and the perf regression that #2705 fixed
+ * would silently return — with no test failure to catch it.
+ *
+ * This test pins the contract by asserting object-identity equality of
+ * `result.current.setValue` across an explicit re-render.
+ */
+import { describe, expect, it } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
+import { useUrlParams } from '../useUrlParams';
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(MemoryRouter, null, children);
+
+describe('useUrlParams setValue reference stability (PR #2705 regression guard)', () => {
+  it('returns the same setValue reference across re-renders', () => {
+    const { result, rerender } = renderHook(
+      () =>
+        useUrlParams({
+          search: { type: 'string', default: '' },
+          page: { type: 'number', default: 1 },
+        }),
+      { wrapper },
+    );
+
+    const firstSetValue = result.current.setValue;
+    rerender();
+    const secondSetValue = result.current.setValue;
+
+    // Object identity — not just behavioral equality. Downstream
+    // useCallback([setUrlParam]) in consumers depends on this.
+    expect(secondSetValue).toBe(firstSetValue);
+  });
+
+  it('keeps setValue stable across multiple re-renders', () => {
+    const { result, rerender } = renderHook(
+      () =>
+        useUrlParams({
+          status: { type: 'string', default: 'all' },
+        }),
+      { wrapper },
+    );
+
+    const initial = result.current.setValue;
+    for (let i = 0; i < 5; i++) {
+      rerender();
+      expect(result.current.setValue).toBe(initial);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Two tiny regression-guard tests that pin assumptions made by the recent perf/CSS PRs. Test-only — no source changes.

### Test 1: `useUrlParams` `setValue` reference stability

Locks in the assumption made by **PR #2705** (`perf(client): fix BotsPage useMemo invalidation and MobileFAB memo defeat`). That PR wrapped BotsPage's URL setters in `useCallback([setUrlParam])`. The optimization only holds if `useUrlParams`'s `setValue` is itself a stable reference across renders (currently achieved via `useCallback([setSearchParams])`).

If a future refactor breaks that stability (inlines the function, recreates it per-render, adds a non-stable dep), the `useCallback` deps in BotsPage would invalidate every render, the downstream `useMemo`s would thrash, and the perf regression #2705 fixed would silently return — with no test failure.

The test uses `renderHook`, captures `result.current.setValue`, calls `rerender()`, and asserts object identity.

File: `src/client/src/hooks/__tests__/useUrlParams.test.ts` (new).

### Test 2: CSS `transition:` presence smoke test

Locks in **PR #2708** (`perf(client): replace transition: all and gate density transitions`). That PR replaced 13 `transition: all` declarations with explicit property lists. The risk it introduced: if a future commit accidentally drops a `transition:` line entirely from one of those rules (during a refactor, a merge, an over-aggressive cleanup), the hover/focus animations silently vanish.

The test reads `index.css` as a raw string and, for each of the selectors PR #2708 touched, asserts the rule body contains a `transition:` declaration. It is a deliberately simple **string-presence** test — not a CSS parser. The file documents that tradeoff: it's brittle to extreme reformatting (e.g. moving the transition to a separate selector via cascade) but reliably catches the regression we actually care about.

Selectors covered: `.stat`, `.btn`, `.menu li>a`, `.menu li>button`, `.table tr`, `.input`, `.textarea`, `.select`, `.tabs-boxed .tab`, `.tabs-lifted .tab`, `.dropdown-content li>a`, `.dropdown-content li>button`, `.modal-box .btn-circle.btn-ghost`.

File: `src/client/src/__tests__/css-transitions-smoke.test.ts` (new).

## Test plan

- [x] `vitest run src/hooks/__tests__/useUrlParams.test.ts src/__tests__/css-transitions-smoke.test.ts` — 2 files, 15 tests, all pass locally.
- [ ] CI runs the existing client test suite and picks up both new files via the default discovery globs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)