### PR TITLE
fix(security): add Zod schema to POST /api/enterprise/compliance/check

### DIFF
--- a/src/server/routes/enterprise.ts
+++ b/src/server/routes/enterprise.ts
@@ -4,6 +4,7 @@ import { ApiResponse } from '@src/server/utils/apiResponse';
 import { AuditLogger } from '../../common/auditLogger';
 import { HTTP_STATUS } from '../../types/constants';
 import {
+  ComplianceCheckSchema,
   CreateCloudProviderSchema,
   CreateEnterpriseIntegrationSchema,
   PerformanceOptimizeSchema,
@@ -337,7 +338,7 @@ router.get('/performance', (req, res) => {
 });
 
 // Run compliance check
-router.post('/compliance/check', (req, res) => {
+router.post('/compliance/check', validateRequest(ComplianceCheckSchema), (req, res) => {
   try {
     // In a real implementation, this would run compliance checks
     // For now, simulate compliance check

--- a/src/validation/schemas/enterpriseSchema.ts
+++ b/src/validation/schemas/enterpriseSchema.ts
@@ -26,3 +26,13 @@ export const PerformanceOptimizeSchema = z.object({
     type: z.string().optional(),
   }),
 });
+
+/** Schema for POST /api/enterprise/compliance/check */
+export const ComplianceCheckSchema = z.object({
+  body: z
+    .object({
+      framework: z.enum(['soc2', 'hipaa', 'gdpr', 'iso27001']).optional(),
+      scope: z.array(z.string()).optional(),
+    })
+    .strict(),
+});


### PR DESCRIPTION
Three of four POSTs in `enterprise.ts` validated with `validateRequest`; `/compliance/check` did not. Adds `ComplianceCheckSchema` (strict, optional `framework` + `scope`) and wires it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)