### PR TITLE
fix(memory): preserve type/isDefault/inUseBy in memory-profile round-trip

### DIFF
--- a/src/config/memoryProfiles.ts
+++ b/src/config/memoryProfiles.ts
@@ -63,13 +63,23 @@ const MemoryProfileConfigSchema = z.object({
  *  - `description` is optional
  *  - `config` holds provider-specific settings
  */
-export const MemoryProfileSchema = z.object({
-  key: z.string().min(1, 'Profile key is required'),
-  name: z.string().min(1, 'Profile name is required'),
-  description: z.string().optional(),
-  provider: z.string().min(1, 'Provider is required'),
-  config: MemoryProfileConfigSchema.default({}),
-});
+export const MemoryProfileSchema = z
+  .object({
+    key: z.string().min(1, 'Profile key is required'),
+    name: z.string().min(1, 'Profile name is required'),
+    description: z.string().optional(),
+    provider: z.string().min(1, 'Provider is required'),
+    /** Memory backend type (redis, pinecone, sqlite, …). Surfaced in UI. */
+    type: z.string().optional(),
+    /** Whether this profile is the default for new bots. */
+    isDefault: z.boolean().optional(),
+    /** Cross-reference: bots currently using this profile (read-only echo). */
+    inUseBy: z.array(z.string()).optional(),
+    config: MemoryProfileConfigSchema.default({}),
+  })
+  // Forward-compat: tolerate fields added to the wire format before the
+  // schema catches up, instead of silently stripping them on round-trip.
+  .passthrough();
 
 export type MemoryProfile = z.infer<typeof MemoryProfileSchema>;
 

--- a/src/validation/schemas/configProfilesSchema.ts
+++ b/src/validation/schemas/configProfilesSchema.ts
@@ -74,11 +74,17 @@ export const MessageProfileKeyParamSchema = z.object({
 // ── Memory Profile Schemas ───────────────────────────────────────────────────
 
 export const CreateMemoryProfileSchema = z.object({
-  body: z.object({
-    key: profileKeyField,
-    name: profileNameField,
-    provider: profileProviderField,
-  }),
+  body: z
+    .object({
+      key: profileKeyField,
+      name: profileNameField,
+      provider: profileProviderField,
+      type: z.string().optional(),
+      description: z.string().optional(),
+      isDefault: z.boolean().optional(),
+      config: z.record(z.unknown()).optional(),
+    })
+    .passthrough(),
 });
 
 export const MemoryProfileKeyParamSchema = z.object({

--- a/tests/e2e/memory-profiles-crud-api.spec.ts
+++ b/tests/e2e/memory-profiles-crud-api.spec.ts
@@ -56,11 +56,9 @@ test.describe('Memory profiles CRUD (API)', () => {
     expect(found).toMatchObject({ name: profile.name, provider: profile.provider });
   });
 
-  // Documents a known data-loss bug: POST /api/config/memory-profiles returns
-  // a profile with `type` set, but the subsequent GET strips it. This test is
-  // marked `.fail()` so the suite stays green; flip back to `.fixme()` or
-  // remove the `.fail` once the GET response shape is corrected.
-  test.fail('GET response should preserve `type` field set on create', async ({ request }) => {
+  // Regression guard for the `type` round-trip: previously stripped by the
+  // server-side MemoryProfileSchema not declaring `type`. Fixed in this PR.
+  test('GET response preserves `type` field set on create', async ({ request }) => {
     const profile = newProfile('type-roundtrip');
     await request.post(ROUTE, { data: profile });
     try {


### PR DESCRIPTION
Fixes the bug found by the memory CRUD e2e (`tests/e2e/memory-profiles-crud-api.spec.ts` `test.fail` marker).

Two co-conspirators:
1. `CreateMemoryProfileSchema` only declared `key`/`name`/`provider` — Zod stripped `type`/`isDefault`/`description`/`config` on POST.
2. `MemoryProfileSchema` (storage shape) also lacked `type`/`isDefault`/`inUseBy` — strip on read.

Adds the missing fields to both schemas + `.passthrough()` on the top-level for forward compat. Flips `test.fail` to a passing regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)