### PR TITLE
a11y(client): add contextual aria-label to AgentCard MCP server remove button

### DIFF
--- a/src/client/src/components/Dashboard/AgentCard.tsx
+++ b/src/client/src/components/Dashboard/AgentCard.tsx
@@ -292,9 +292,10 @@ const AgentCard: React.FC<AgentCardProps> = ({ agent, configurable }) => {
                   <Button
                     variant="ghost"
                     size="sm"
+                    aria-label={`Remove MCP server ${server.name}`}
                     onClick={() => handleRemoveMcpServer(index)}
                   >
-                    <Trash2 className="w-4 h-4" />
+                    <Trash2 className="w-4 h-4" aria-hidden="true" />
                   </Button>
                 </li>
               ))}


### PR DESCRIPTION
Re-opens the intent of closed #2651 (which was +545/-88 across 5 files including a stray `.original_AgentCard.tsx` backup, useInactivity test rewrite, and AuthManager test changes — all bot scope creep).

This is the actual one-line a11y improvement: the icon-only Trash2 button at `AgentCard.tsx:292` had no accessible name. Adds `aria-label="Remove MCP server ${server.name}"` plus `aria-hidden` on the decorative icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)