### PR TITLE
perf(message): early-break sliding-window scan in DuplicateMessageDetector

### DIFF
--- a/src/message/helpers/processing/DuplicateMessageDetector.ts
+++ b/src/message/helpers/processing/DuplicateMessageDetector.ts
@@ -49,6 +49,27 @@ export default class DuplicateMessageDetector {
   }
 
   /**
+   * Trim history to entries within the sliding time window. Because
+   * `recentMessages` is appended to in chronological order, we can scan
+   * backwards from the newest entry and break as soon as we find one
+   * outside the window — O(k) where k is the number of in-window entries
+   * rather than O(n) for the full history scan that `Array.filter` does.
+   */
+  private filterRecentMessages(
+    history: MessageRecord[],
+    windowMs: number,
+    now: number
+  ): MessageRecord[] {
+    const threshold = now - windowMs;
+    let keepCount = 0;
+    for (let i = history.length - 1; i >= 0; i--) {
+      if (history[i].timestamp <= threshold) break;
+      keepCount++;
+    }
+    return keepCount === history.length ? history : history.slice(history.length - keepCount);
+  }
+
+  /**
    * Check if a message is a duplicate
    * @param channelId The channel ID
    * @param content The message content to check
@@ -75,7 +96,7 @@ export default class DuplicateMessageDetector {
       const history = this.recentMessages.get(channelId) || [];
 
       // Clean up old messages outside the time window
-      const recentHistory = history.filter((msg) => now - msg.timestamp < windowMs);
+      const recentHistory = this.filterRecentMessages(history, windowMs, now);
 
       // Normalize content for comparison (trim, lowercase, remove extra whitespace)
       const normalizedContent = this.normalizeContent(content);
@@ -192,7 +213,7 @@ export default class DuplicateMessageDetector {
       let history = this.recentMessages.get(channelId) || [];
 
       // Clean up old messages
-      history = history.filter((msg) => now - msg.timestamp < windowMs);
+      history = this.filterRecentMessages(history, windowMs, now);
 
       // Add new message
       history.push({
@@ -238,9 +259,7 @@ export default class DuplicateMessageDetector {
 
       const now = Date.now();
       const history = this.recentMessages.get(channelId) || [];
-      const recentHistory = history
-        .filter((msg) => now - msg.timestamp < windowMs)
-        .slice(-historySize);
+      const recentHistory = this.filterRecentMessages(history, windowMs, now).slice(-historySize);
 
       if (recentHistory.length < minHistory) {
         return 0;
@@ -400,7 +419,7 @@ export default class DuplicateMessageDetector {
 
     // Remove expired messages from each channel
     for (const [channelId, history] of this.recentMessages) {
-      const filtered = history.filter((msg) => now - msg.timestamp < windowMs);
+      const filtered = this.filterRecentMessages(history, windowMs, now);
       if (filtered.length === 0) {
         this.recentMessages.delete(channelId);
         cleaned++;


### PR DESCRIPTION
Re-opens intent of closed #2677 (was conflicted at triage). 4 `Array.filter` callsites scanned the full history on every operation; replaced with a private `filterRecentMessages` helper that scans backwards and breaks at the threshold. O(k) instead of O(n).

🤖 Generated with [Claude Code](https://claude.com/claude-code)