### PR TITLE
docs(packages): correct memory-postgres README — create() and manifest are exported

### DIFF
--- a/packages/memory-postgres/README.md
+++ b/packages/memory-postgres/README.md
@@ -4,12 +4,14 @@ Memory provider backed by the host application's Postgres `DatabaseManager` and 
 
 ## Exports
 
-This package re-exports everything from `PostgresMemoryProvider`:
+This package re-exports everything from `PostgresMemoryProvider` via `src/index.ts` (`export * from './PostgresMemoryProvider'`):
 
 - `PostgresMemoryProvider` — class implementing `IMemoryProvider`
 - `PostgresMemoryConfig` — `{ embeddingProfile?: string }`
+- `create(config, dependencies)` — plugin factory that returns a new `PostgresMemoryProvider`
+- `manifest` — `{ displayName, description, type: 'memory' }` plugin metadata
 
-There is no `manifest` / `create()` in this package — it is wired in directly by the main app rather than through the generic PluginLoader because it depends on the host's `DatabaseManager`.
+The package is PluginLoader-compatible (it exposes both `create` and `manifest`). It still depends on the host's `DatabaseManager`, which must be supplied via `dependencies.getDatabaseManager()`.
 
 ## Environment variables
 


### PR DESCRIPTION
## Summary

The README in `packages/memory-postgres/` (added in #2707) incorrectly claims the package has no `create()` factory or `manifest` and is therefore not PluginLoader-compatible. In fact, `PostgresMemoryProvider.ts` exports both, and `src/index.ts` does `export * from './PostgresMemoryProvider'`, so both symbols are exposed at the package level.

## The incorrect claim (current README)

> There is no `manifest` / `create()` in this package — it is wired in directly by the main app rather than through the generic PluginLoader because it depends on the host's `DatabaseManager`.

## The reality (source)

`packages/memory-postgres/src/PostgresMemoryProvider.ts`:

```ts
// line 193
export function create(config: PostgresMemoryConfig, dependencies: IServiceDependencies) {
  return new PostgresMemoryProvider(config, dependencies);
}

// line 197
export const manifest = {
  displayName: 'Postgres Vector',
  description: 'Native Postgres vector memory storage using pgvector',
  type: 'memory',
};
```

`packages/memory-postgres/src/index.ts`:

```ts
export * from './PostgresMemoryProvider';
```

So `create`, `manifest`, `PostgresMemoryProvider`, and `PostgresMemoryConfig` are all exposed at the package level.

## Fix

Rewrite the **Exports** section to accurately list all four exports, and remove the inaccurate "no manifest/create" sentence. Note that the package IS PluginLoader-compatible — the dependency on `DatabaseManager` is supplied via the standard `dependencies.getDatabaseManager()` injection point, not a reason it bypasses the loader.

Pure docs change. No code modified.

## Test plan

- [ ] Confirm the rewritten Exports section matches the symbols actually exported by `src/PostgresMemoryProvider.ts`
- [ ] Spot-check the rest of the README still accurately reflects the source

🤖 Generated with [Claude Code](https://claude.com/claude-code)