### PR TITLE
fix(security): replace dangerouslySetInnerHTML with React-element JSON highlighter

### DIFF
--- a/src/client/src/components/ToolResultModal.tsx
+++ b/src/client/src/components/ToolResultModal.tsx
@@ -9,7 +9,7 @@ import Modal from './DaisyUI/Modal';
 import Mockup from './DaisyUI/Mockup';
 import { Alert } from './DaisyUI/Alert';
 import { logger } from '../utils/logger';
-import { renderJsonWithHighlighting } from '../utils/jsonHighlighter';
+import { HighlightedJson } from '../utils/jsonHighlighter';
 
 interface ToolResult {
   timestamp: string;
@@ -134,9 +134,7 @@ const ToolResultModal: React.FC<ToolResultModalProps> = ({ isOpen, onClose, resu
               )}
             </button>
           </div>
-          <Mockup type="code" content={
-            <span dangerouslySetInnerHTML={{ __html: renderJsonWithHighlighting(result.arguments) }} />
-          } className="bg-base-300 max-h-48 overflow-auto" />
+          <Mockup type="code" content={<HighlightedJson json={result.arguments} />} className="bg-base-300 max-h-48 overflow-auto" />
         </div>
 
         {/* Result or Error */}
@@ -202,9 +200,7 @@ const ToolResultModal: React.FC<ToolResultModalProps> = ({ isOpen, onClose, resu
                 )}
               </button>
             </div>
-            <Mockup type="code" content={
-              <span dangerouslySetInnerHTML={{ __html: renderJsonWithHighlighting(result.result) }} />
-            } className="bg-base-300 max-h-96 overflow-auto" />
+            <Mockup type="code" content={<HighlightedJson json={result.result} />} className="bg-base-300 max-h-96 overflow-auto" />
           </div>
         )}
 

--- a/src/client/src/utils/__tests__/jsonHighlighter.test.tsx
+++ b/src/client/src/utils/__tests__/jsonHighlighter.test.tsx
@@ -1,0 +1,61 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { HighlightedJson, renderJsonWithHighlighting } from '../jsonHighlighter';
+
+describe('HighlightedJson (React-element path)', () => {
+  it('renders null as a single span with the null token class', () => {
+    const { container } = render(<HighlightedJson json={null} />);
+    expect(container.textContent).toBe('null');
+  });
+
+  it('renders an object with all key/value tokens visible', () => {
+    const { container } = render(
+      <HighlightedJson json={{ name: 'bot', count: 3, active: true }} />
+    );
+    const text = container.textContent || '';
+    expect(text).toContain('"name"');
+    expect(text).toContain('"bot"');
+    expect(text).toContain('3');
+    expect(text).toContain('true');
+  });
+
+  it('escapes <script> tags as visible text, not executable HTML (no XSS)', () => {
+    const malicious = { payload: '<script>alert(1)</script>' };
+    const { container } = render(<HighlightedJson json={malicious} />);
+    // The literal `<script>` text appears as displayed text, NOT as a real script element.
+    expect(container.querySelector('script')).toBeNull();
+    expect(container.textContent).toContain('<script>alert(1)</script>');
+  });
+
+  it('escapes nested HTML inside string values', () => {
+    const { container } = render(
+      <HighlightedJson json={{ html: '<img src=x onerror=alert(1)>' }} />
+    );
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.textContent).toContain('<img src=x onerror=alert(1)>');
+  });
+
+  it('does not use dangerouslySetInnerHTML in the rendered output', () => {
+    const { container } = render(
+      <HighlightedJson json={{ x: '<b>bold</b>' }} />
+    );
+    // If we accidentally re-introduced dangerouslySetInnerHTML, <b> would
+    // render as an actual bold element.
+    expect(container.querySelector('b')).toBeNull();
+    expect(container.textContent).toContain('<b>bold</b>');
+  });
+});
+
+describe('renderJsonWithHighlighting (legacy HTML-string path)', () => {
+  it('still escapes HTML special characters', () => {
+    const html = renderJsonWithHighlighting({ payload: '<script>alert(1)</script>' });
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('escapes ampersands and quotes', () => {
+    const html = renderJsonWithHighlighting({ a: 'Tom & Jerry "say" hi' });
+    expect(html).toContain('&amp;');
+    expect(html).toContain('&quot;');
+  });
+});

--- a/src/client/src/utils/jsonHighlighter.tsx
+++ b/src/client/src/utils/jsonHighlighter.tsx
@@ -1,14 +1,21 @@
+import React from 'react';
+
 /**
  * JSON Syntax Highlighting Utility
- * 
+ *
  * Provides safe syntax highlighting for JSON content displayed in the UI.
- * This utility properly escapes all HTML characters before applying
- * syntax highlighting, preventing XSS attacks from malicious JSON payloads.
+ * The `<HighlightedJson>` component returns React elements directly so
+ * React handles HTML escaping inherently — no `dangerouslySetInnerHTML`,
+ * no `escapeHtml` shim that future maintainers might forget to call.
+ *
+ * The legacy `renderJsonWithHighlighting` HTML-string export is preserved
+ * (with its escapeHtml safety) for any external caller that still passes
+ * the result to dangerouslySetInnerHTML, but new callers should use
+ * `<HighlightedJson>`.
  */
 
 /**
  * Map of JSON token types to their DaisyUI color classes.
- * Uses safe CSS classes instead of inline styles.
  */
 const TOKEN_CLASSES: Record<string, string> = {
   string: 'text-success',
@@ -22,9 +29,9 @@ const TOKEN_CLASSES: Record<string, string> = {
 };
 
 /**
- * Escape HTML special characters to prevent XSS.
- * This is the primary security barrier - all input must be escaped
- * before any highlighting is applied.
+ * Escape HTML special characters — used only by the legacy
+ * `renderJsonWithHighlighting` HTML-string output. The React component
+ * path does not need this because React escapes text content for us.
  */
 function escapeHtml(str: string): string {
   return str
@@ -38,18 +45,26 @@ function escapeHtml(str: string): string {
 /**
  * Token types for JSON parsing.
  */
-type TokenType = 'string' | 'boolean' | 'null' | 'number' | 'key' | 'bracket' | 'comma' | 'colon' | 'whitespace';
+type TokenType =
+  | 'string'
+  | 'boolean'
+  | 'null'
+  | 'number'
+  | 'key'
+  | 'bracket'
+  | 'comma'
+  | 'colon'
+  | 'whitespace';
 
 interface Token {
   type: TokenType;
   value: string;
-  escaped: string;
 }
 
 /**
  * Tokenize JSON string into meaningful tokens for syntax highlighting.
- * This parser handles nested structures, escaped characters in strings,
- * and ensures proper token classification.
+ * Handles nested structures, escaped characters in strings, and ensures
+ * proper token classification.
  */
 function tokenizeJson(jsonString: string): Token[] {
   const tokens: Token[] = [];
@@ -59,17 +74,17 @@ function tokenizeJson(jsonString: string): Token[] {
   while (i < len) {
     const char = jsonString[i];
 
-    // Handle whitespace
+    // Whitespace
     if (/[\t\n\r\s]/.test(char)) {
       let whitespace = '';
       while (i < len && /[\t\n\r\s]/.test(jsonString[i])) {
         whitespace += jsonString[i++];
       }
-      tokens.push({ type: 'whitespace', value: whitespace, escaped: escapeHtml(whitespace) });
+      tokens.push({ type: 'whitespace', value: whitespace });
       continue;
     }
 
-    // Handle strings (including escaped characters)
+    // Strings (incl. escaped)
     if (char === '"') {
       let str = '"';
       i++;
@@ -81,63 +96,64 @@ function tokenizeJson(jsonString: string): Token[] {
         }
         str += jsonString[i++];
       }
-      tokens.push({ type: 'string', value: str, escaped: escapeHtml(str) });
+      tokens.push({ type: 'string', value: str });
       continue;
     }
 
-    // Handle braces/brackets
+    // Brackets
     if (/[(){}\[\]]/.test(char)) {
-      tokens.push({ type: 'bracket', value: char, escaped: escapeHtml(char) });
+      tokens.push({ type: 'bracket', value: char });
       i++;
       continue;
     }
 
-    // Handle commas and colons
+    // Commas / colons
     if (char === ',' || char === ':') {
-      tokens.push({ type: char === ',' ? 'comma' : 'colon', value: char, escaped: escapeHtml(char) });
+      tokens.push({ type: char === ',' ? 'comma' : 'colon', value: char });
       i++;
       continue;
     }
 
-    // Handle numbers
+    // Numbers
     if (/[\d-]/.test(char)) {
       let num = '';
       while (i < len && /[\d.eE+-]/.test(jsonString[i])) {
         num += jsonString[i++];
       }
-      tokens.push({ type: 'number', value: num, escaped: escapeHtml(num) });
+      tokens.push({ type: 'number', value: num });
       continue;
     }
 
-    // Handle booleans and null
+    // Booleans / null
     if (/[tfn]/.test(char)) {
       const keywords = ['true', 'false', 'null'];
+      let matched = false;
       for (const keyword of keywords) {
         if (jsonString.slice(i, i + keyword.length) === keyword) {
-          tokens.push({ type: keyword as TokenType, value: keyword, escaped: escapeHtml(keyword) });
+          tokens.push({ type: keyword as TokenType, value: keyword });
           i += keyword.length;
+          matched = true;
           break;
         }
       }
+      if (!matched) i++;
       continue;
     }
 
-    // Handle JSON keys (unquoted or quoted - though standard JSON requires quotes)
-    // This handles non-standard JSON that might come from some MCP servers
+    // Keys (handles non-standard unquoted keys some MCP servers emit)
     if (/[a-zA-Z_]/.test(char)) {
       let key = '';
       while (i < len && /[a-zA-Z_0-9]/.test(jsonString[i])) {
         key += jsonString[i++];
       }
-      // Check if this is a JSON keyword that we already handled
       if (!['true', 'false', 'null'].includes(key)) {
-        tokens.push({ type: 'key', value: key, escaped: escapeHtml(key) });
+        tokens.push({ type: 'key', value: key });
       }
       continue;
     }
 
-    // If we get here, it's an unexpected character - just include it as-is, but escaped
-    tokens.push({ type: 'whitespace', value: char, escaped: escapeHtml(char) });
+    // Unexpected character — pass through as whitespace (will be escaped by React)
+    tokens.push({ type: 'whitespace', value: char });
     i++;
   }
 
@@ -145,58 +161,66 @@ function tokenizeJson(jsonString: string): Token[] {
 }
 
 /**
- * Render JSON with syntax highlighting.
- * 
- * SECURITY: This function ALWAYS escapes HTML characters before applying
- * any styling. The order is:
- * 1. Parse JSON into tokens
- * 2. Escape each token's value
- * 3. Wrap escaped values in <span> with color classes
- * 
- * This prevents XSS attacks even if the JSON contains malicious HTML/JS.
- * 
- * @param obj - Any JavaScript value to render as JSON
- * @returns HTML string safe for use with dangerouslySetInnerHTML
+ * Render JSON with syntax highlighting as React elements.
+ *
+ * SECURITY: React escapes text content automatically, so injecting
+ * `<script>` etc. via the JSON value renders as visible text rather than
+ * executing. No `dangerouslySetInnerHTML` involved.
  */
-export function renderJsonWithHighlighting(obj: unknown): string {
-  // Handle non-object values
-  if (obj === null || obj === undefined) {
-    return `<span class="${TOKEN_CLASSES.null}">null</span>`;
+export function HighlightedJson({ json }: { json: unknown }): React.ReactElement {
+  if (json === null || json === undefined) {
+    return <span className={TOKEN_CLASSES.null}>null</span>;
   }
 
-  // Stringify to JSON
-  const jsonString = JSON.stringify(obj, null, 2);
-
-  // Tokenize the JSON string
+  const jsonString = JSON.stringify(json, null, 2);
   const tokens = tokenizeJson(jsonString);
 
-  // Build the highlighted HTML
-  let html = '';
-  for (const token of tokens) {
-    const cssClass = TOKEN_CLASSES[token.type] || '';
-    if (cssClass && token.type !== 'whitespace') {
-      html += `<span class="${cssClass}">${token.escaped}</span>`;
-    } else {
-      html += token.escaped;
-    }
-  }
-
-  return html;
+  return (
+    <>
+      {tokens.map((token, idx) => {
+        const cssClass = TOKEN_CLASSES[token.type] || '';
+        if (cssClass && token.type !== 'whitespace') {
+          return (
+            <span key={idx} className={cssClass}>
+              {token.value}
+            </span>
+          );
+        }
+        return <React.Fragment key={idx}>{token.value}</React.Fragment>;
+      })}
+    </>
+  );
 }
 
 /**
- * Create a highlighted display of JSON content using React elements.
- * This is a safer alternative to dangerouslySetInnerHTML for simple cases.
- * 
- * Note: For complex JSON with nested structures, use renderJsonWithHighlighting
- * with proper sanitization.
+ * @deprecated Use `<HighlightedJson>` instead. This HTML-string variant
+ * is preserved only for callers that already pass the result to
+ * `dangerouslySetInnerHTML` — new code should not use it.
+ *
+ * Returned HTML *is* escaped (via escapeHtml on every token) so it
+ * remains XSS-safe, but `<HighlightedJson>` is the architecturally
+ * preferred path because it removes the need to remember to escape at all.
  */
-export function HighlightedJson({ json }: { json: unknown }): React.ReactElement {
-  const html = renderJsonWithHighlighting(json);
-  return <span dangerouslySetInnerHTML={{ __html: html }} />;
+export function renderJsonWithHighlighting(obj: unknown): string {
+  if (obj === null || obj === undefined) {
+    return `<span class="${TOKEN_CLASSES.null}">null</span>`;
+  }
+  const jsonString = JSON.stringify(obj, null, 2);
+  const tokens = tokenizeJson(jsonString);
+  let html = '';
+  for (const token of tokens) {
+    const cssClass = TOKEN_CLASSES[token.type] || '';
+    const escaped = escapeHtml(token.value);
+    if (cssClass && token.type !== 'whitespace') {
+      html += `<span class="${cssClass}">${escaped}</span>`;
+    } else {
+      html += escaped;
+    }
+  }
+  return html;
 }
 
 export default {
-  renderJsonWithHighlighting,
   HighlightedJson,
+  renderJsonWithHighlighting,
 };


### PR DESCRIPTION
Re-opens intent of closed #2645/#2692. The previous `<span dangerouslySetInnerHTML={{__html: renderJsonWithHighlighting(...)}}>` path was XSS-safe (escapeHtml ran on every token) but required maintainers to remember that — any future caller bypassing escapeHtml would be a real sink.

Adds `<HighlightedJson>` returning React elements directly. React escapes text content automatically so dangerouslySetInnerHTML disappears from the render path. Migrates ToolResultModal's two callsites. Legacy HTML-string export preserved (@deprecated).

Adds 7 unit-test assertions including the canonical `<script>alert(1)</script>` payload + `<img onerror>` + a regression guard that catches accidental re-introduction of dangerouslySetInnerHTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)