### PR TITLE
🎨 Palette: Improve accessibility of BotConfigViewer tabs

### DIFF
--- a/src/client/src/components/BotConfigViewer.tsx
+++ b/src/client/src/components/BotConfigViewer.tsx
@@ -168,18 +168,24 @@ const BotConfigViewer: React.FC<BotConfigViewerProps> = ({
             </div>
             
             {showJson && (
-              <div className="btn-group">
+              <div className="btn-group" role="tablist" aria-label="View mode">
                 <button 
+                  id="tab-terminal"
+                  role="tab"
                   className={`btn btn-xs ${viewMode === 'terminal' ? 'btn-active' : 'btn-ghost'}`}
                   onClick={() => setViewMode('terminal')}
-                  aria-pressed={viewMode === 'terminal'}
+                  aria-selected={viewMode === 'terminal'}
+                  aria-controls="panel-terminal"
                 >
                   Terminal
                 </button>
                 <button 
+                  id="tab-json"
+                  role="tab"
                   className={`btn btn-xs ${viewMode === 'json' ? 'btn-active' : 'btn-ghost'}`}
                   onClick={() => setViewMode('json')}
-                  aria-pressed={viewMode === 'json'}
+                  aria-selected={viewMode === 'json'}
+                  aria-controls="panel-json"
                 >
                   JSON
                 </button>
@@ -190,7 +196,13 @@ const BotConfigViewer: React.FC<BotConfigViewerProps> = ({
       </div>
       
       <div className="card-body p-6">
-        {viewMode === 'terminal' ? renderTerminalView() : renderJsonView()}
+        <div
+          role="tabpanel"
+          id={`panel-${viewMode}`}
+          aria-labelledby={`tab-${viewMode}`}
+        >
+          {viewMode === 'terminal' ? renderTerminalView() : renderJsonView()}
+        </div>
         
         <div className="flex items-center justify-between mt-4 text-xs text-base-content/60">
           <span>Configuration loaded from: config/bots/{bot.name}.json</span>


### PR DESCRIPTION
**💡 What:** 
Upgraded the Terminal/JSON toggle buttons in the `BotConfigViewer` component to adhere to proper W3C ARIA tab component semantics. Replaced generic toggle behavior (`btn-group`, `aria-pressed`) with structural tab roles (`tablist`, `tab`, `tabpanel`) and relationship attributes (`aria-selected`, `aria-controls`, `aria-labelledby`).

**🎯 Why:** 
When custom components look and behave like tabs but lack the structural semantics, screen reader users receive no context about how the buttons relate to the content switching below them. This change enables screen readers to accurately announce "tab 1 of 2" and link the active tab to the displayed content panel.

**♿ Accessibility:** 
- Added `role="tablist"`
- Added `role="tab"`
- Switched `aria-pressed` to `aria-selected`
- Linked toggles to content via `aria-controls` and `id`s
- Defined the content container with `role="tabpanel"` and `aria-labelledby`

*Note: Documented this pattern in `.Jules/palette.md` as a key learning for custom UI component accessibility.*

---
*PR created automatically by Jules for task [16211681800341604862](https://jules.google.com/task/16211681800341604862) started by @matthewhand*