### PR TITLE
⚡ Bolt: Memoize schema field processing in ProviderConfigForm

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v3

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v3

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -39,3 +39,7 @@
 ## 2025-05-01 - Replace O(N) array search with O(1) map lookup in PersonaSelector render loop
 **Learning:** In React components like `PersonaSelector`, performing array `.find()` lookups inside `.map()` render loops (to match categories/attributes with items) degrades rendering performance to O(N * M), which is especially noticeable when lists grow long or are filtered frequently.
 **Action:** Always pre-compute a lookup map using `useMemo` (e.g., `Object.fromEntries(categories.map(c => [c.value, c.color]))`) and use O(1) object key lookups (`categoryColorMap[persona.category]`) inside render loops instead of array searches. Make sure static data referenced by useMemo is moved outside the component or the optimization is defeated.
+
+## 2026-05-02 - ProviderConfigForm Re-rendering
+**Learning:** The form components re-render frequently (e.g., on every keystroke). Using `.reduce()` and `.filter()` on potentially large arrays within the component body without memoization leads to O(N) recalculations on every render, which can cause typing lag on complex configuration forms.
+**Action:** Use `useMemo` to wrap expensive array transformations inside React components, especially forms.

--- a/src/client/src/components/ProviderConfigForm.tsx
+++ b/src/client/src/components/ProviderConfigForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import type { ProviderConfigFormProps, ProviderConfigField } from '../provider-configs/types';
 import Avatar from './DaisyUI/Avatar';
 import Input from './DaisyUI/Input';
@@ -40,38 +40,41 @@ export const ProviderConfigForm: React.FC<ProviderConfigFormProps> = ({
   const [abortController, setAbortController] = useState<AbortController | null>(null);
   const [showAdvanced, setShowAdvanced] = useState(false);
 
+  // ⚡ Bolt Optimization: Wrap computationally expensive schema field filtering and grouping in useMemo.
+  // This prevents O(N) recalculations on every render when the user types in the form inputs.
+  // Expected Impact: Reduces main-thread blocking during rapid keystrokes in complex provider configurations.
   // Separate mandatory and advanced fields
-  const mandatoryFields = schema.fields.filter(field => field.required);
-  const advancedFields = schema.fields.filter(field => !field.required);
+  const mandatoryFields = useMemo(() => schema.fields.filter(field => field.required), [schema.fields]);
+  const advancedFields = useMemo(() => schema.fields.filter(field => !field.required), [schema.fields]);
 
   // Group fields by their group property
-  const groupedFields = schema.fields.reduce((groups, field) => {
+  const groupedFields = useMemo(() => schema.fields.reduce((groups, field) => {
     const groupName = field.group || 'General';
     if (!groups[groupName]) {
       groups[groupName] = [];
     }
     groups[groupName].push(field);
     return groups;
-  }, {} as Record<string, ProviderConfigField[]>);
+  }, {} as Record<string, ProviderConfigField[]>), [schema.fields]);
 
   // Group mandatory and advanced fields separately
-  const groupedMandatoryFields = mandatoryFields.reduce((groups, field) => {
+  const groupedMandatoryFields = useMemo(() => mandatoryFields.reduce((groups, field) => {
     const groupName = field.group || 'General';
     if (!groups[groupName]) {
       groups[groupName] = [];
     }
     groups[groupName].push(field);
     return groups;
-  }, {} as Record<string, ProviderConfigField[]>);
+  }, {} as Record<string, ProviderConfigField[]>), [mandatoryFields]);
 
-  const groupedAdvancedFields = advancedFields.reduce((groups, field) => {
+  const groupedAdvancedFields = useMemo(() => advancedFields.reduce((groups, field) => {
     const groupName = field.group || 'General';
     if (!groups[groupName]) {
       groups[groupName] = [];
     }
     groups[groupName].push(field);
     return groups;
-  }, {} as Record<string, ProviderConfigField[]>);
+  }, {} as Record<string, ProviderConfigField[]>), [advancedFields]);
 
   const validateField = (field: ProviderConfigField, value: any): string | null => {
     if (field.required && (!value || (typeof value === 'string' && value.trim() === ''))) {


### PR DESCRIPTION
💡 **What:** Wrapped the computationally expensive schema field filtering and grouping (`mandatoryFields`, `advancedFields`, `groupedFields`, `groupedMandatoryFields`, `groupedAdvancedFields`) inside `useMemo` hooks.
🎯 **Why:** The `ProviderConfigForm` updates its state (`config`) on every keystroke. Previously, this caused the expensive `.reduce` and `.filter` operations on `schema.fields` to be re-run on every render, potentially leading to UI input lag for providers with many configuration fields.
📊 **Impact:** Prevents unnecessary O(N) array processing and re-allocation on every keystroke, reducing main-thread blocking and ensuring a smoother typing experience.
🔬 **Measurement:** Verify by typing rapidly in any complex provider configuration form; the inputs should feel responsive without input lag. Run `cd src/client && pnpm run build` and `cd src/client && pnpm test` to ensure stability.

---
*PR created automatically by Jules for task [10544033145828605785](https://jules.google.com/task/10544033145828605785) started by @matthewhand*