### PR TITLE
fix: replace Math.random() with crypto-secure alternative

### DIFF
--- a/src/server/services/websocket/broadcast/BroadcastDistributor.ts
+++ b/src/server/services/websocket/broadcast/BroadcastDistributor.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import type { Socket } from 'socket.io';
 import { DeliveryStatus, type MessageEnvelope } from '../../../../types/websocket';
 import { type ConnectionManager } from '../ConnectionManager';
@@ -53,7 +54,7 @@ export class BroadcastDistributor {
       deliveryStatus: DeliveryStatus.SENT,
     } as any;
 
-    (envelope as any).id = `msg-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    (envelope as any).id = `msg-${Date.now()}-${crypto.randomUUID()}`;
 
     this.messageTracker.trackMessage(envelope);
     this.broadcast(event, envelope);

--- a/src/services/demo/DemoActivitySimulator.ts
+++ b/src/services/demo/DemoActivitySimulator.ts
@@ -7,6 +7,7 @@ import type {
   PerformanceMetric,
 } from '../../server/services/websocket/types';
 import type { WebSocketService } from '../../server/services/WebSocketService';
+import { secureRandom } from '../../utils/secureRandom';
 import {
   CONVERSATION_THREADS,
   DEMO_USERS,
@@ -52,7 +53,7 @@ export class DemoActivitySimulatorService {
     // Random message simulation (every 10-30s)
     const runSimulation = () => {
       this.generateAndRecordMessageEvent();
-      const nextInterval = Math.floor(Math.random() * 20000) + 10000;
+      const nextInterval = Math.floor(secureRandom() * 20000) + 10000;
       this.simulationInterval = setTimeout(runSimulation, nextInterval);
     };
     runSimulation();
@@ -85,18 +86,18 @@ export class DemoActivitySimulatorService {
 
     // Pre-seed MetricsCollector with 60 data points
     for (let i = 60; i >= 0; i--) {
-      const cpu = 15 + Math.sin(i * 0.1) * 10 + (Math.random() - 0.5) * 8;
-      const mem = 45 + Math.sin(i * 0.2) * 15 + (Math.random() - 0.5) * 10;
+      const cpu = 15 + Math.sin(i * 0.1) * 10 + (secureRandom() - 0.5) * 8;
+      const mem = 45 + Math.sin(i * 0.2) * 15 + (secureRandom() - 0.5) * 10;
       this.metricsCollector.recordMetric('demo.cpu', Math.max(5, Math.min(60, cpu)), {
         source: 'demo',
       });
       this.metricsCollector.recordMetric('demo.memory', Math.max(20, Math.min(85, mem)), {
         source: 'demo',
       });
-      this.metricsCollector.recordResponseTime(100 + Math.random() * 500);
-      if (Math.random() < 0.3) {
+      this.metricsCollector.recordResponseTime(100 + secureRandom() * 500);
+      if (secureRandom() < 0.3) {
         this.metricsCollector.incrementMessages();
-        this.metricsCollector.recordLlmTokenUsage(Math.floor(Math.random() * 200) + 50);
+        this.metricsCollector.recordLlmTokenUsage(Math.floor(secureRandom() * 200) + 50);
       }
     }
 
@@ -131,7 +132,7 @@ export class DemoActivitySimulatorService {
     if (event.status === 'error') {
       this.metricsCollector.incrementErrors();
     }
-    this.metricsCollector.recordLlmTokenUsage(Math.floor(Math.random() * 300) + 50);
+    this.metricsCollector.recordLlmTokenUsage(Math.floor(secureRandom() * 300) + 50);
 
     try {
       this.activityLogger.log(event);
@@ -158,7 +159,7 @@ export class DemoActivitySimulatorService {
     this.metricsCollector.recordMetric('demo.messageRate', metric.messageRate, { source: 'demo' });
     this.metricsCollector.recordMetric('demo.errorRate', metric.errorRate, { source: 'demo' });
 
-    if (Math.random() < 0.1) {
+    if (secureRandom() < 0.1) {
       const alert = this.createAlertEventForWS();
       this.wsService.recordAlert(alert);
     }
@@ -167,8 +168,8 @@ export class DemoActivitySimulatorService {
   private generateThreadContent(): { content: string; isFromUser: boolean } {
     const now = Date.now();
 
-    if (Math.random() < 0.3 || this.activeThreads.size === 0) {
-      const threadIndex = Math.floor(Math.random() * CONVERSATION_THREADS.length);
+    if (secureRandom() < 0.3 || this.activeThreads.size === 0) {
+      const threadIndex = Math.floor(secureRandom() * CONVERSATION_THREADS.length);
       const channelKey = `thread-${Date.now()}`;
       this.activeThreads.set(channelKey, { threadIndex, stepIndex: 0, lastActivity: now });
 
@@ -177,7 +178,7 @@ export class DemoActivitySimulatorService {
     }
 
     const activeThreadKeys = Array.from(this.activeThreads.keys());
-    const channelKey = activeThreadKeys[Math.floor(Math.random() * activeThreadKeys.length)];
+    const channelKey = activeThreadKeys[Math.floor(secureRandom() * activeThreadKeys.length)];
 
     const threadState = this.activeThreads.get(channelKey);
     if (!threadState) {
@@ -207,10 +208,10 @@ export class DemoActivitySimulatorService {
   }
 
   private createMessageFlowEventForWS(timestamp?: string): MessageFlowEvent {
-    const bot = this.demoBots[Math.floor(Math.random() * this.demoBots.length)];
+    const bot = this.demoBots[Math.floor(secureRandom() * this.demoBots.length)];
     const processingTime = this.generateProcessingTime();
-    const hasError = Math.random() < 0.05;
-    const user = DEMO_USERS[Math.floor(Math.random() * DEMO_USERS.length)];
+    const hasError = secureRandom() < 0.05;
+    const user = DEMO_USERS[Math.floor(secureRandom() * DEMO_USERS.length)];
 
     const threadContent = this.generateThreadContent();
     const isIncoming = threadContent.isFromUser;
@@ -229,20 +230,20 @@ export class DemoActivitySimulatorService {
       processingTime: isIncoming ? undefined : processingTime,
       status: hasError ? 'error' : processingTime > 1500 ? 'timeout' : 'success',
       errorMessage: hasError
-        ? ERROR_MESSAGES[Math.floor(Math.random() * ERROR_MESSAGES.length)]
+        ? ERROR_MESSAGES[Math.floor(secureRandom() * ERROR_MESSAGES.length)]
         : undefined,
     };
   }
 
   private createAlertEventForWS(timestamp?: string): AlertEvent {
-    const bot = this.demoBots[Math.floor(Math.random() * this.demoBots.length)];
+    const bot = this.demoBots[Math.floor(secureRandom() * this.demoBots.length)];
     const levels: Array<'info' | 'warning' | 'error' | 'critical'> = [
       'info',
       'warning',
       'error',
       'critical',
     ];
-    const level = levels[Math.floor(Math.random() * levels.length)];
+    const level = levels[Math.floor(secureRandom() * levels.length)];
 
     const titles: Record<string, string[]> = {
       info: ['Bot connected successfully', 'Configuration reloaded', 'Health check passed'],
@@ -259,8 +260,8 @@ export class DemoActivitySimulatorService {
       id: `demo-alert-${Date.now()}-${crypto.randomUUID()}`,
       timestamp: timestamp || new Date().toISOString(),
       level,
-      title: titles[level][Math.floor(Math.random() * titles[level].length)],
-      message: `Demo alert: ${bot.name} — ${titles[level][Math.floor(Math.random() * titles[level].length)]}`,
+      title: titles[level][Math.floor(secureRandom() * titles[level].length)],
+      message: `Demo alert: ${bot.name} — ${titles[level][Math.floor(secureRandom() * titles[level].length)]}`,
       botName: bot.name,
       channelId: bot.discord?.channelId || bot.slack?.channelId,
       status: 'active',
@@ -273,8 +274,8 @@ export class DemoActivitySimulatorService {
     const cyclePosition = (elapsed / 60000) % 1;
     const hourOfDay = new Date().getHours();
     const todMultiplier = this.getTimeOfDayMultiplier(hourOfDay);
-    const hasSpike = Math.random() < 0.05;
-    const spikeMul = hasSpike ? 1.5 + Math.random() * 0.5 : 1;
+    const hasSpike = secureRandom() < 0.05;
+    const spikeMul = hasSpike ? 1.5 + secureRandom() * 0.5 : 1;
 
     const cpu = (15 + Math.sin(cyclePosition * Math.PI * 2) * 10) * todMultiplier;
     const mem = (45 + Math.sin(cyclePosition * Math.PI * 4) * 15) * (0.8 + todMultiplier * 0.4);
@@ -282,24 +283,24 @@ export class DemoActivitySimulatorService {
 
     return {
       timestamp: timestamp || new Date().toISOString(),
-      responseTime: Math.random() * 500 + 100 + (hasSpike ? 200 : 0),
-      memoryUsage: Math.max(20, Math.min(85, mem + (Math.random() - 0.5) * 10)),
-      cpuUsage: Math.max(5, Math.min(60, cpu * spikeMul + (Math.random() - 0.5) * 8)),
-      activeConnections: Math.floor(3 + msgRate + (Math.random() - 0.5) * 2),
-      messageRate: Math.max(0, msgRate * spikeMul + (Math.random() - 0.5) * 0.5),
-      errorRate: hasSpike ? Math.random() * 0.1 : Math.random() * 0.02,
+      responseTime: secureRandom() * 500 + 100 + (hasSpike ? 200 : 0),
+      memoryUsage: Math.max(20, Math.min(85, mem + (secureRandom() - 0.5) * 10)),
+      cpuUsage: Math.max(5, Math.min(60, cpu * spikeMul + (secureRandom() - 0.5) * 8)),
+      activeConnections: Math.floor(3 + msgRate + (secureRandom() - 0.5) * 2),
+      messageRate: Math.max(0, msgRate * spikeMul + (secureRandom() - 0.5) * 0.5),
+      errorRate: hasSpike ? secureRandom() * 0.1 : secureRandom() * 0.02,
     };
   }
 
   private generateProcessingTime(): number {
-    const r = Math.random();
+    const r = secureRandom();
     if (r < 0.6) {
-      return Math.random() * 400 + 100;
+      return secureRandom() * 400 + 100;
     }
     if (r < 0.9) {
-      return Math.random() * 1000 + 500;
+      return secureRandom() * 1000 + 500;
     }
-    return Math.random() * 1500 + 1500;
+    return secureRandom() * 1500 + 1500;
   }
 
   private getTimeOfDayMultiplier(hour: number): number {

--- a/src/services/demo/DemoConversationManager.ts
+++ b/src/services/demo/DemoConversationManager.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import { secureRandom } from '../../utils/secureRandom';
 import { MESSAGE_SCENARIOS, type DemoConversation, type DemoMessage } from './DemoConstants';
 
 /**
@@ -68,7 +69,7 @@ export class DemoConversationManager {
     if (lowerMessage.includes('help')) {
       return 'Open-Hivemind offers multi-platform bots, multiple LLM providers, MCP integration, and personas. Configure API keys to unlock full functionality!';
     }
-    const randomIndex = Math.floor(Math.random() * MESSAGE_SCENARIOS.length);
+    const randomIndex = Math.floor(secureRandom() * MESSAGE_SCENARIOS.length);
     const scenario = MESSAGE_SCENARIOS[randomIndex];
     return scenario.response;
   }

--- a/src/utils/secureRandom.ts
+++ b/src/utils/secureRandom.ts
@@ -1,0 +1,6 @@
+import crypto from 'crypto';
+
+/** Cryptographically secure replacement for Math.random(). Returns a number in [0, 1). */
+export function secureRandom(): number {
+  return crypto.getRandomValues(new Uint32Array(1))[0] / 0x100000000;
+}

--- a/tests/unit/demo/DemoActivitySimulator.test.ts
+++ b/tests/unit/demo/DemoActivitySimulator.test.ts
@@ -1,5 +1,6 @@
 import { DemoActivitySimulatorService } from '../../../src/services/demo/DemoActivitySimulator';
 import type { DemoBot } from '../../../src/services/demo/DemoConstants';
+import * as secureRandomModule from '../../../src/utils/secureRandom';
 
 function makeDemoBot(overrides: Partial<DemoBot> = {}): DemoBot {
   return {
@@ -84,7 +85,7 @@ describe('DemoActivitySimulatorService', () => {
     });
 
     it('should generate message events and performance metrics on timers', () => {
-      jest.spyOn(Math, 'random').mockReturnValue(0.5);
+      jest.spyOn(secureRandomModule, 'secureRandom').mockReturnValue(0.5);
 
       service.startActivitySimulation();
 
@@ -101,7 +102,7 @@ describe('DemoActivitySimulatorService', () => {
     });
 
     it('should record metrics to MetricsCollector every 5s', () => {
-      jest.spyOn(Math, 'random').mockReturnValue(0.1);
+      jest.spyOn(secureRandomModule, 'secureRandom').mockReturnValue(0.1);
 
       service.startActivitySimulation();
 
@@ -116,7 +117,7 @@ describe('DemoActivitySimulatorService', () => {
 
     it('should occasionally generate alerts', () => {
       // Force random < 0.1 to trigger alert generation
-      jest.spyOn(Math, 'random').mockReturnValue(0.05);
+      jest.spyOn(secureRandomModule, 'secureRandom').mockReturnValue(0.05);
 
       service.startActivitySimulation();
 
@@ -146,7 +147,7 @@ describe('DemoActivitySimulatorService', () => {
 
   describe('reset', () => {
     it('should stop simulation and clear threads', () => {
-      jest.spyOn(Math, 'random').mockReturnValue(0.5);
+      jest.spyOn(secureRandomModule, 'secureRandom').mockReturnValue(0.5);
 
       service.startActivitySimulation();
       jest.advanceTimersByTime(10000);

--- a/tests/unit/demo/DemoConversationManager.test.ts
+++ b/tests/unit/demo/DemoConversationManager.test.ts
@@ -1,5 +1,6 @@
 import type { DemoConversation, DemoMessage } from '../../../src/services/demo/DemoConstants';
 import { DemoConversationManager } from '../../../src/services/demo/DemoConversationManager';
+import * as secureRandomModule from '../../../src/utils/secureRandom';
 
 describe('DemoConversationManager', () => {
   let manager: DemoConversationManager;
@@ -162,7 +163,7 @@ describe('DemoConversationManager', () => {
     });
 
     it('should return a scenario response for non-greeting/non-help messages', () => {
-      jest.spyOn(Math, 'random').mockReturnValue(0);
+      jest.spyOn(secureRandomModule, 'secureRandom').mockReturnValue(0);
       const response = manager.generateDemoResponse('What config options?', 'BotA');
       expect(response.length).toBeGreaterThan(0);
       // The first scenario response


### PR DESCRIPTION
## Summary
Replace all `Math.random()` usages with cryptographically secure alternatives, resolving all 34 `no-restricted-properties` lint warnings.

## Changes
- Add `src/utils/secureRandom.ts` — drop-in replacement using `crypto.getRandomValues`
- Replace `Math.random()` → `secureRandom()` in `DemoActivitySimulator` and `DemoConversationManager`
- Replace `Math.random().toString(36)` → `crypto.randomUUID()` in `BroadcastDistributor`
- Update tests to mock `secureRandom` instead of `Math.random`

## Verified
- Lint: 0 errors, 0 warnings
- Build: passes
- Tests: 479 total (469 passed, 10 skipped, 0 failures)