### PR TITLE
fix: guard DemoActivitySimulator against empty bot list; add DemoStateService, BotConfigService tests

### DIFF
--- a/src/services/demo/DemoActivitySimulator.ts
+++ b/src/services/demo/DemoActivitySimulator.ts
@@ -207,6 +207,21 @@ export class DemoActivitySimulatorService {
   }
 
   private createMessageFlowEventForWS(timestamp?: string): MessageFlowEvent {
+    if (this.demoBots.length === 0) {
+      return {
+        id: `demo-msg-${Date.now()}-${crypto.randomUUID()}`,
+        timestamp: timestamp || new Date().toISOString(),
+        botName: 'demo',
+        provider: 'discord',
+        llmProvider: 'openai',
+        channelId: 'demo-channel',
+        userId: 'demo-user',
+        messageType: 'outgoing',
+        contentLength: 0,
+        processingTime: undefined,
+        status: 'success',
+      };
+    }
     const bot = this.demoBots[Math.floor(Math.random() * this.demoBots.length)];
     const processingTime = this.generateProcessingTime();
     const hasError = Math.random() < 0.05;
@@ -235,6 +250,19 @@ export class DemoActivitySimulatorService {
   }
 
   private createAlertEventForWS(timestamp?: string): AlertEvent {
+    if (this.demoBots.length === 0) {
+      return {
+        id: `demo-alert-${Date.now()}-${crypto.randomUUID()}`,
+        timestamp: timestamp || new Date().toISOString(),
+        level: 'info',
+        title: 'Demo Alert',
+        message: 'Demo alert placeholder',
+        botName: 'demo',
+        channelId: 'demo-channel',
+        status: 'active',
+        metadata: { isDemo: true },
+      };
+    }
     const bot = this.demoBots[Math.floor(Math.random() * this.demoBots.length)];
     const levels: Array<'info' | 'warning' | 'error' | 'critical'> = [
       'info',
@@ -269,6 +297,17 @@ export class DemoActivitySimulatorService {
   }
 
   private createPerformanceMetric(timestamp?: string): PerformanceMetric {
+    if (this.demoBots.length === 0) {
+      return {
+        timestamp: timestamp || new Date().toISOString(),
+        responseTime: 0,
+        memoryUsage: 0,
+        cpuUsage: 0,
+        activeConnections: 0,
+        messageRate: 0,
+        errorRate: 0,
+      };
+    }
     const elapsed = Date.now() - (this.activitySimulator.simulationStartTime || Date.now());
     const cyclePosition = (elapsed / 60000) % 1;
     const hourOfDay = new Date().getHours();

--- a/tests/unit/demo/DemoActivitySimulator.test.ts
+++ b/tests/unit/demo/DemoActivitySimulator.test.ts
@@ -208,12 +208,7 @@ describe('DemoActivitySimulatorService', () => {
   });
 
   describe('seed with empty bots', () => {
-    it('should not throw with empty bot list', () => {
-      // seedHistoricalData calls createMessageFlowEventForWS which accesses
-      // this.demoBots[Math.floor(Math.random() * this.demoBots.length)]
-      // With empty bots, this accesses undefined. The implementation does NOT
-      // guard against this, so we verify that behavior.
-      // Instead, verify that startActivitySimulation with empty bots early-returns:
+    it('should seed historical data without crashing', () => {
       const emptyService = new DemoActivitySimulatorService(
         [],
         mockMetricsCollector,
@@ -221,10 +216,13 @@ describe('DemoActivitySimulatorService', () => {
         mockWsService
       );
 
-      emptyService.startActivitySimulation();
-      jest.advanceTimersByTime(30000);
-      // No message events should be generated
-      expect(mockWsService.recordMessageFlow).not.toHaveBeenCalled();
+      expect(() => emptyService.seedHistoricalData()).not.toThrow();
+      // Should still seed metrics
+      expect(mockMetricsCollector.recordMetric).toHaveBeenCalled();
+      // Should still generate fallback message events
+      expect(mockWsService.recordMessageFlow).toHaveBeenCalled();
+      // Should still generate fallback alerts
+      expect(mockWsService.recordAlert).toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/demo/DemoStateService.test.ts
+++ b/tests/unit/demo/DemoStateService.test.ts
@@ -1,0 +1,229 @@
+import { DemoStateService } from '../../../src/services/demo/DemoStateService';
+
+describe('DemoStateService', () => {
+  let mockBotManager: any;
+  let mockConfigStore: any;
+  let service: DemoStateService;
+
+  beforeEach(() => {
+    mockBotManager = {
+      getAllBots: jest.fn().mockReturnValue([]),
+      addBot: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockConfigStore = {
+      get: jest.fn().mockReturnValue(false),
+    };
+
+    service = new DemoStateService(mockBotManager, mockConfigStore);
+  });
+
+  describe('isInDemoMode', () => {
+    it('should return false by default', () => {
+      expect(service.isInDemoMode()).toBe(false);
+    });
+  });
+
+  describe('detectDemoMode', () => {
+    it('should return false when DEMO_MODE is not set', () => {
+      const result = service.detectDemoMode();
+      expect(result).toBe(false);
+    });
+
+    it('should enable demo mode when DEMO_MODE env var is true', () => {
+      // We can't set process.env in the test environment due to the proxy in jest.setup
+      // Test the configStore path instead
+      mockConfigStore.get.mockReturnValue(true);
+
+      const result = service.detectDemoMode();
+      expect(result).toBe(true);
+      expect(service.isInDemoMode()).toBe(true);
+    });
+
+    it('should not toggle if already in demo mode', () => {
+      // Set demo mode first
+      mockConfigStore.get.mockReturnValue(true);
+      service.detectDemoMode();
+      expect(service.isInDemoMode()).toBe(true);
+
+      // Second call should not change state
+      const result = service.detectDemoMode();
+      expect(result).toBe(true);
+      expect(service.isInDemoMode()).toBe(true);
+    });
+  });
+
+  describe('setDemoMode', () => {
+    it('should enable demo mode', () => {
+      service.setDemoMode(true);
+      expect(service.isInDemoMode()).toBe(true);
+    });
+
+    it('should disable demo mode', () => {
+      service.setDemoMode(true);
+      expect(service.isInDemoMode()).toBe(true);
+      service.setDemoMode(false);
+      expect(service.isInDemoMode()).toBe(false);
+    });
+
+    it('should no-op when setting same value', () => {
+      service.setDemoMode(true);
+      const botsBefore = service.getDemoBots();
+      // Setting true again should be no-op
+      service.setDemoMode(true);
+      expect(service.isInDemoMode()).toBe(true);
+    });
+  });
+
+  describe('getDemoBots', () => {
+    it('should return empty array initially', () => {
+      expect(service.getDemoBots()).toEqual([]);
+    });
+
+    it('should return bots after seedDemoConfig runs', async () => {
+      mockBotManager.getAllBots.mockReturnValue([]);
+      await (service as any).seedDemoConfig();
+
+      const bots = service.getDemoBots();
+      expect(bots.length).toBeGreaterThan(0);
+      bots.forEach((b) => {
+        expect(b).toHaveProperty('id');
+        expect(b).toHaveProperty('name');
+        expect(b).toHaveProperty('messageProvider');
+        expect(b).toHaveProperty('llmProvider');
+        expect(b.status).toBe('demo');
+        expect(b.isDemo).toBe(true);
+      });
+    });
+
+    it('should track existing bots when BotConfigurationManager already has bots', async () => {
+      mockBotManager.getAllBots.mockReturnValue([
+        {
+          id: 'bot-1',
+          name: 'RealBot',
+          messageProvider: 'slack',
+          llmProvider: 'openai',
+          isActive: true,
+        },
+      ]);
+      await (service as any).seedDemoConfig();
+
+      const bots = service.getDemoBots();
+      expect(bots).toHaveLength(1);
+      expect(bots[0].name).toBe('RealBot');
+      expect(bots[0].status).toBe('active');
+    });
+  });
+
+  describe('startActivitySimulation', () => {
+    it('should not throw when simulator is not initialized', () => {
+      expect(() => service.startActivitySimulation()).not.toThrow();
+    });
+  });
+
+  describe('stopActivitySimulation', () => {
+    it('should not throw when simulator is not initialized', () => {
+      expect(() => service.stopActivitySimulation()).not.toThrow();
+    });
+  });
+
+  describe('getDemoStatus', () => {
+    it('should return status object with expected shape', () => {
+      const status = service.getDemoStatus();
+      expect(status).toHaveProperty('enabled', false);
+      expect(status).toHaveProperty('botCount', 0);
+      expect(status).toHaveProperty('conversationCount', 0);
+    });
+
+    it('should reflect enabled state and bot count', () => {
+      service.setDemoMode(true);
+      const status = service.getDemoStatus();
+      expect(status.enabled).toBe(true);
+    });
+  });
+
+  describe('reset', () => {
+    it('should clear demo bots and conversations', () => {
+      // Seed some bots first
+      mockBotManager.getAllBots.mockReturnValue([]);
+      return (service as any).seedDemoConfig().then(() => {
+        expect(service.getDemoBots().length).toBeGreaterThan(0);
+
+        service.reset();
+
+        expect(service.getDemoBots()).toEqual([]);
+        expect(service.getConversationManager().getAllConversations()).toEqual([]);
+      });
+    });
+  });
+
+  describe('getConversationManager', () => {
+    it('should return the conversation manager', () => {
+      const cm = service.getConversationManager();
+      expect(cm).toBeDefined();
+      expect(typeof cm.getOrCreateConversation).toBe('function');
+    });
+  });
+
+  describe('seedDemoConfig', () => {
+    it('should seed DEMO_BOT_CONFIGS when no bots exist', async () => {
+      expect(service.getDemoBots().length).toBe(0);
+
+      await (service as any).seedDemoConfig();
+
+      expect(mockBotManager.addBot).toHaveBeenCalled();
+      expect(service.getDemoBots().length).toBeGreaterThan(0);
+    });
+
+    it('should not call addBot when bots already exist', async () => {
+      mockBotManager.getAllBots.mockReturnValue([{ id: 'b1', name: 'Bot1' }]);
+
+      await (service as any).seedDemoConfig();
+
+      expect(mockBotManager.addBot).not.toHaveBeenCalled();
+    });
+
+    it('should handle addBot failures gracefully', async () => {
+      mockBotManager.addBot.mockRejectedValue(new Error('DB error'));
+
+      await expect((service as any).seedDemoConfig()).resolves.not.toThrow();
+      // Demo bots still get created as trackers even if addBot fails
+      expect(service.getDemoBots().length).toBeGreaterThan(0);
+    });
+
+    it('should populate provider-specific config for discord bots', async () => {
+      await (service as any).seedDemoConfig();
+
+      const discordBot = service.getDemoBots().find((b) => b.messageProvider === 'discord');
+      expect(discordBot).toBeDefined();
+      expect(discordBot?.discord).toBeDefined();
+    });
+
+    it('should populate provider-specific config for llm providers', async () => {
+      await (service as any).seedDemoConfig();
+
+      // Verify all demo bots have proper structure
+      const bots = service.getDemoBots();
+      bots.forEach((b) => {
+        expect(b.id).toBeDefined();
+        expect(b.name).toBeDefined();
+        expect(b.messageProvider).toBeDefined();
+        expect(b.llmProvider).toBeDefined();
+        expect(b.connected).toBe(true);
+      });
+    });
+
+    it('should handle existing bots with minimal config', async () => {
+      mockBotManager.getAllBots.mockReturnValue([
+        { name: 'MinimalBot', messageProvider: undefined, llmProvider: undefined },
+      ]);
+
+      await (service as any).seedDemoConfig();
+
+      const bots = service.getDemoBots();
+      expect(bots[0].messageProvider).toBe('discord');
+      expect(bots[0].llmProvider).toBe('openai');
+      expect(bots[0].persona).toBe('default');
+    });
+  });
+});

--- a/tests/unit/repositories/BotConfigService.test.ts
+++ b/tests/unit/repositories/BotConfigService.test.ts
@@ -1,0 +1,378 @@
+import { BotConfigService } from '../../../src/server/services/BotConfigService';
+import { ConfigurationError } from '../../../src/types/errorClasses';
+
+describe('BotConfigService', () => {
+  let mockDbManager: any;
+  let mockValidator: any;
+  let service: BotConfigService;
+
+  beforeEach(() => {
+    // Reset singleton
+    BotConfigService.resetInstance();
+
+    mockDbManager = {
+      isConfigured: jest.fn().mockReturnValue(true),
+      createBotConfiguration: jest.fn(),
+      getBotConfiguration: jest.fn(),
+      getBotConfigurationByName: jest.fn(),
+      getAllBotConfigurations: jest.fn(),
+      getAllBotConfigurationsWithDetails: jest.fn(),
+      updateBotConfiguration: jest.fn(),
+      deleteBotConfiguration: jest.fn(),
+      createBotConfigurationAudit: jest.fn(),
+      getBotConfigurationVersions: jest.fn(),
+      createBotConfigurationVersion: jest.fn(),
+      getBotConfigurationAudit: jest.fn(),
+    };
+
+    mockValidator = {
+      validateBotConfig: jest.fn().mockReturnValue({ isValid: true, errors: [] }),
+    };
+
+    service = new BotConfigService(mockDbManager, mockValidator);
+  });
+
+  describe('createBotConfig', () => {
+    const validRequest: any = {
+      name: 'TestBot',
+      messageProvider: 'discord',
+      llmProvider: 'openai',
+    };
+
+    it('should create a bot configuration', async () => {
+      mockDbManager.createBotConfiguration.mockResolvedValue(1);
+      mockDbManager.getBotConfiguration.mockResolvedValue({
+        id: 1,
+        name: 'TestBot',
+        messageProvider: 'discord',
+        llmProvider: 'openai',
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await service.createBotConfig(validRequest, 'admin');
+
+      expect(result.id).toBe(1);
+      expect(result.name).toBe('TestBot');
+      expect(mockDbManager.createBotConfigurationAudit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'CREATE' })
+      );
+    });
+
+    it('should throw when database is not configured', async () => {
+      mockDbManager.isConfigured.mockReturnValue(false);
+      await expect(service.createBotConfig(validRequest)).rejects.toThrow(ConfigurationError);
+    });
+
+    it('should throw when validation fails', async () => {
+      mockValidator.validateBotConfig.mockReturnValue({
+        isValid: false,
+        errors: ['Name is required'],
+      });
+      await expect(service.createBotConfig(validRequest)).rejects.toThrow(ConfigurationError);
+    });
+
+    it('should throw on duplicate name', async () => {
+      mockDbManager.getBotConfigurationByName.mockResolvedValue({ id: 2 });
+      await expect(service.createBotConfig(validRequest)).rejects.toThrow(/already exists/);
+    });
+
+    it('should serialize complex fields to JSON', async () => {
+      const request: any = {
+        ...validRequest,
+        mcpServers: ['server-1', 'server-2'],
+        mcpGuard: { enabled: true, type: 'owner' },
+        discord: { token: 'tok', channelId: 'ch' },
+      };
+      mockDbManager.createBotConfiguration.mockResolvedValue(1);
+      mockDbManager.getBotConfiguration.mockResolvedValue({ id: 1, name: 'TestBot' });
+
+      await service.createBotConfig(request);
+
+      const call = mockDbManager.createBotConfiguration.mock.calls[0][0];
+      expect(call.mcpServers).toBe(JSON.stringify(['server-1', 'server-2']));
+      expect(call.mcpGuard).toBe(JSON.stringify({ enabled: true, type: 'owner' }));
+      expect(call.discord).toBe(JSON.stringify({ token: 'tok', channelId: 'ch' }));
+    });
+  });
+
+  describe('getBotConfig', () => {
+    it('should return null when config not found', async () => {
+      mockDbManager.getBotConfiguration.mockResolvedValue(null);
+      const result = await service.getBotConfig(999);
+      expect(result).toBeNull();
+    });
+
+    it('should enrich response with versions and audit log', async () => {
+      mockDbManager.getBotConfiguration.mockResolvedValue({
+        id: 1,
+        name: 'TestBot',
+      });
+      mockDbManager.getBotConfigurationVersions.mockResolvedValue([{ id: 1, version: '1.0.0' }]);
+      mockDbManager.getBotConfigurationAudit.mockResolvedValue([{ id: 1, action: 'CREATE' }]);
+
+      const result = await service.getBotConfig(1);
+      expect(result).not.toBeNull();
+      expect(result!.versions).toHaveLength(1);
+      expect(result!.auditLog).toHaveLength(1);
+    });
+
+    it('should throw when database is not configured', async () => {
+      mockDbManager.isConfigured.mockReturnValue(false);
+      await expect(service.getBotConfig(1)).rejects.toThrow(ConfigurationError);
+    });
+  });
+
+  describe('getBotConfigByName', () => {
+    it('should return null when config not found', async () => {
+      mockDbManager.getBotConfigurationByName.mockResolvedValue(null);
+      const result = await service.getBotConfigByName('Unknown');
+      expect(result).toBeNull();
+    });
+
+    it('should return null when config has no id', async () => {
+      mockDbManager.getBotConfigurationByName.mockResolvedValue({ name: 'Bot' });
+      const result = await service.getBotConfigByName('Bot');
+      expect(result).toBeNull();
+    });
+
+    it('should enrich with versions and audit log', async () => {
+      mockDbManager.getBotConfigurationByName.mockResolvedValue({
+        id: 42,
+        name: 'BotA',
+      });
+      mockDbManager.getBotConfigurationVersions.mockResolvedValue([]);
+      mockDbManager.getBotConfigurationAudit.mockResolvedValue([]);
+
+      const result = await service.getBotConfigByName('BotA');
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe(42);
+    });
+  });
+
+  describe('getAllBotConfigs', () => {
+    it('should use bulk query method', async () => {
+      mockDbManager.getAllBotConfigurationsWithDetails.mockResolvedValue([
+        { id: 1, name: 'BotA' },
+        { id: 2, name: 'BotB' },
+      ]);
+
+      const configs = await service.getAllBotConfigs();
+      expect(configs).toHaveLength(2);
+    });
+  });
+
+  describe('getBotConfigsByProvider', () => {
+    it('should filter by message provider', async () => {
+      mockDbManager.getAllBotConfigurationsWithDetails.mockResolvedValue([
+        { id: 1, name: 'DiscordBot', messageProvider: 'discord' },
+        { id: 2, name: 'SlackBot', messageProvider: 'slack' },
+        { id: 3, name: 'DiscordBot2', messageProvider: 'discord' },
+      ]);
+
+      const configs = await service.getBotConfigsByProvider('discord');
+      expect(configs).toHaveLength(2);
+    });
+
+    it('should return empty array when no match', async () => {
+      mockDbManager.getAllBotConfigurationsWithDetails.mockResolvedValue([
+        { id: 1, name: 'Bot', messageProvider: 'discord' },
+      ]);
+
+      const configs = await service.getBotConfigsByProvider('slack');
+      expect(configs).toEqual([]);
+    });
+  });
+
+  describe('updateBotConfig', () => {
+    it('should throw when config not found', async () => {
+      mockDbManager.getBotConfiguration.mockResolvedValue(null);
+      await expect(service.updateBotConfig(999, {})).rejects.toThrow(/not found/);
+    });
+
+    it('should validate and update', async () => {
+      const existing = {
+        id: 1,
+        name: 'OldBot',
+        messageProvider: 'discord',
+        llmProvider: 'openai',
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      mockDbManager.getBotConfiguration
+        .mockResolvedValueOnce(existing)
+        .mockResolvedValueOnce({ id: 1, name: 'UpdatedBot' });
+
+      const result = await service.updateBotConfig(1, { name: 'UpdatedBot' }, 'admin');
+
+      expect(mockDbManager.updateBotConfiguration).toHaveBeenCalled();
+      expect(mockDbManager.createBotConfigurationAudit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'UPDATE' })
+      );
+      expect(result).not.toBeNull();
+    });
+  });
+
+  describe('deleteBotConfig', () => {
+    it('should throw when config not found', async () => {
+      mockDbManager.getBotConfiguration.mockResolvedValue(null);
+      await expect(service.deleteBotConfig(999)).rejects.toThrow(/not found/);
+    });
+
+    it('should create audit log and delete', async () => {
+      mockDbManager.getBotConfiguration.mockResolvedValue({
+        id: 1,
+        name: 'Bot',
+      });
+      mockDbManager.deleteBotConfiguration.mockResolvedValue(true);
+
+      const result = await service.deleteBotConfig(1, 'admin');
+
+      expect(mockDbManager.createBotConfigurationAudit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'DELETE' })
+      );
+      expect(result).toBe(true);
+    });
+
+    it('should return false when delete operation returns false', async () => {
+      mockDbManager.getBotConfiguration.mockResolvedValue({ id: 1, name: 'Bot' });
+      mockDbManager.deleteBotConfiguration.mockResolvedValue(false);
+
+      const result = await service.deleteBotConfig(1);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('activateBotConfig', () => {
+    it('should set isActive to true and create audit log', async () => {
+      mockDbManager.getBotConfiguration.mockResolvedValue({ id: 1, name: 'Bot' });
+
+      const result = await service.activateBotConfig(1, 'admin');
+
+      expect(mockDbManager.updateBotConfiguration).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          isActive: true,
+        })
+      );
+      expect(mockDbManager.createBotConfigurationAudit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'ACTIVATE' })
+      );
+    });
+
+    it('should throw when retrieval after activation fails', async () => {
+      mockDbManager.getBotConfiguration.mockReset();
+      mockDbManager.getBotConfiguration.mockResolvedValue(null);
+
+      await expect(service.activateBotConfig(1)).rejects.toThrow(ConfigurationError);
+    });
+  });
+
+  describe('deactivateBotConfig', () => {
+    it('should set isActive to false and create audit log', async () => {
+      mockDbManager.getBotConfiguration.mockResolvedValue({ id: 1, name: 'Bot' });
+
+      const result = await service.deactivateBotConfig(1, 'admin');
+
+      expect(mockDbManager.updateBotConfiguration).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          isActive: false,
+        })
+      );
+      expect(mockDbManager.createBotConfigurationAudit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'DEACTIVATE' })
+      );
+    });
+  });
+
+  describe('createBotConfigVersion', () => {
+    it('should throw when config not found', async () => {
+      mockDbManager.getBotConfiguration.mockResolvedValue(null);
+      await expect(service.createBotConfigVersion(999)).rejects.toThrow(/not found/);
+    });
+
+    it('should start version at 1 when no versions exist', async () => {
+      mockDbManager.getBotConfiguration.mockResolvedValue({
+        id: 1,
+        name: 'Bot',
+        messageProvider: 'discord',
+        llmProvider: 'openai',
+      });
+      mockDbManager.getBotConfigurationVersions.mockResolvedValue([]);
+      mockDbManager.createBotConfigurationVersion.mockResolvedValue(100);
+
+      const version = await service.createBotConfigVersion(1, 'Initial', 'admin');
+
+      expect(version.version).toBe('1');
+    });
+
+    it('should increment version number', async () => {
+      mockDbManager.getBotConfiguration.mockResolvedValue({
+        id: 1,
+        name: 'Bot',
+        messageProvider: 'discord',
+        llmProvider: 'openai',
+      });
+      mockDbManager.getBotConfigurationVersions.mockResolvedValue([
+        { id: 1, version: '1' },
+        { id: 2, version: '2' },
+        { id: 3, version: '3' },
+      ]);
+      mockDbManager.createBotConfigurationVersion.mockResolvedValue(101);
+
+      const version = await service.createBotConfigVersion(1, 'v4', 'admin');
+
+      expect(version.version).toBe('4');
+    });
+  });
+
+  describe('getConfigStats', () => {
+    it('should return stats object with correct shape', async () => {
+      mockDbManager.getAllBotConfigurations.mockResolvedValue([
+        { isActive: true, messageProvider: 'discord', llmProvider: 'openai' },
+        { isActive: true, messageProvider: 'slack', llmProvider: 'openai' },
+        { isActive: false, messageProvider: 'discord', llmProvider: 'flowise' },
+      ]);
+
+      const stats = await service.getConfigStats();
+
+      expect(stats.total).toBe(3);
+      expect(stats.active).toBe(2);
+      expect(stats.inactive).toBe(1);
+      expect(stats.byProvider.discord).toBe(2);
+      expect(stats.byProvider.slack).toBe(1);
+      expect(stats.byLlmProvider.openai).toBe(2);
+      expect(stats.byLlmProvider.flowise).toBe(1);
+    });
+
+    it('should throw when database is down', async () => {
+      mockDbManager.isConfigured.mockReturnValue(false);
+      await expect(service.getConfigStats()).rejects.toThrow(ConfigurationError);
+    });
+  });
+
+  describe('validateBotConfig', () => {
+    it('should return validation result', async () => {
+      const result = await service.validateBotConfig({
+        name: 'Test',
+        messageProvider: 'discord',
+        llmProvider: 'openai',
+      });
+
+      expect(result.isValid).toBe(true);
+    });
+
+    it('should catch validator errors gracefully', async () => {
+      mockValidator.validateBotConfig.mockImplementation(() => {
+        throw new Error('Validator crash');
+      });
+
+      const result = await service.validateBotConfig({});
+      expect(result.isValid).toBe(false);
+      expect(result.errors[0]).toBe('Validator crash');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Bug fix**: DemoActivitySimulator now guards 3 private methods against empty bot list (was crashing on `undefined.name`)
- **DemoStateService** (22 tests): detectDemoMode, setDemoMode, seedDemoConfig with/without existing bots, reset lifecycle
- **BotConfigService** (29 tests): full CRUD, activate/deactivate, config versioning, stats, validation, error paths
- All 296 unit tests pass, TypeScript and lint clean