### PR TITLE
🧹 Janitor: Fix test environment encryption

### DIFF
--- a/tests/database/Encryption.test.ts
+++ b/tests/database/Encryption.test.ts
@@ -6,6 +6,16 @@ import { IDatabase } from '../../src/database/types';
 describe('Database At-Rest Encryption', () => {
   let repository: BotConfigRepository;
   let mockDb: jest.Mocked<IDatabase>;
+  let originalKey: Buffer | undefined;
+
+  beforeAll(() => {
+    originalKey = (encryptionService as any).encryptionKey;
+    (encryptionService as any).encryptionKey = Buffer.alloc(32, 'a');
+  });
+
+  afterAll(() => {
+    (encryptionService as any).encryptionKey = originalKey;
+  });
 
   beforeEach(() => {
     mockDb = {


### PR DESCRIPTION
🧹 Janitor: Fix test environment encryption | 💡 What: Added explicitly mocked encryptionKey for testing with DISABLE_ENCRYPTION=true | 🎯 Why: Global test suite failed the Database At-Rest Encryption suite | 🚦 Status: Tests unblocked

---
*PR created automatically by Jules for task [4455030778692974294](https://jules.google.com/task/4455030778692974294) started by @matthewhand*