### PR TITLE
⚡ Bolt: [performance improvement] Replace O(N) array search with O(1) map lookup in MCP server backend routes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -43,3 +43,7 @@
 ## 2026-05-02 - ProviderConfigForm Re-rendering
 **Learning:** The form components re-render frequently (e.g., on every keystroke). Using `.reduce()` and `.filter()` on potentially large arrays within the component body without memoization leads to O(N) recalculations on every render, which can cause typing lag on complex configuration forms.
 **Action:** Use `useMemo` to wrap expensive array transformations inside React components, especially forms.
+
+## 2024-05-23 - Backend Route List Rendering Optimization
+**Learning:** In backend routes like `/mcp-servers` or `/maintenance`, mapping over an array of `connectedServers` and rendering configuration details directly using `.find()` inside the `.map()` loop creates an O(N*M) time complexity. This can cause significant bottlenecks as the number of connected servers grows.
+**Action:** Always pre-compute a lookup map using `new Map(items.map(i => [i.key, i.value]))` before iterating over the array. This reduces the time complexity from O(N*M) to O(N+M) and prevents synchronous blocking operations.

--- a/src/server/routes/admin/maintenance.ts
+++ b/src/server/routes/admin/maintenance.ts
@@ -226,8 +226,11 @@ router.get('/mcp-servers', async (req: Request, res: Response) => {
 
     // Enrich connected servers with stored configuration data
 
+    // Performance optimization: pre-compute map for O(1) lookups instead of calling .find() inside .map() loops
+    const storedMcpsMap = new Map(storedMcps.map((mcp: any) => [mcp.name, mcp]));
+
     const enrichedServers = connectedServers.map((server) => {
-      const storedConfig = storedMcps.find((mcp: any) => mcp.name === server.name);
+      const storedConfig = storedMcpsMap.get(server.name);
       return {
         name: server.name,
         serverUrl: storedConfig?.serverUrl || storedConfig?.url || '',

--- a/src/server/routes/admin/mcpServers.ts
+++ b/src/server/routes/admin/mcpServers.ts
@@ -224,8 +224,11 @@ router.get('/mcp-servers', async (req: Request, res: Response) => {
 
     // Enrich connected servers with stored configuration data
 
+    // Performance optimization: pre-compute map for O(1) lookups instead of calling .find() inside .map() loops
+    const storedMcpsMap = new Map(storedMcps.map((mcp: any) => [mcp.name, mcp]));
+
     const enrichedServers = connectedServers.map((server) => {
-      const storedConfig = storedMcps.find((mcp: any) => mcp.name === server.name);
+      const storedConfig = storedMcpsMap.get(server.name);
       return {
         name: server.name,
         serverUrl: storedConfig?.serverUrl || storedConfig?.url || '',


### PR DESCRIPTION
💡 What: Replaced an `Array.find()` lookup inside an `Array.map()` loop with a pre-computed `Map` in `src/server/routes/admin/mcpServers.ts` and `src/server/routes/admin/maintenance.ts`.
🎯 Why: Iterating over an array with a `.find()` inside a `.map()` creates an $O(N \times M)$ time complexity, which causes performance bottlenecks on the backend when rendering data with high numbers of connected servers.
📊 Impact: Reduces time complexity to $O(N + M)$, speeding up response times for backend routes and decreasing server block times.
🔬 Measurement: Verify by executing the `mcp-servers` backend route directly with large numbers of `connectedServers` and comparing response times.

---
*PR created automatically by Jules for task [7544946521781608035](https://jules.google.com/task/7544946521781608035) started by @matthewhand*