### PR TITLE
⚡ Bolt: Optimize MCP server metadata enrichment with O(1) Map lookup

### DIFF
--- a/packages/shared-types/src/IMessengerService.ts
+++ b/packages/shared-types/src/IMessengerService.ts
@@ -26,7 +26,7 @@ export interface IMessengerService {
    * Optional: return per-instance startup summaries for operator-friendly logging.
    * Implementations that don't support per-instance introspection can omit this.
    */
-  getAgentStartupSummaries?: () => {
+  getAgentStartupSummaries?: () => Array<{
     name: string;
     provider: string;
     botId?: string;
@@ -35,7 +35,7 @@ export interface IMessengerService {
     llmModel?: string;
     llmEndpoint?: string;
     systemPrompt?: string;
-  }[];
+  }>;
 
   /**
    * Optional integration hook: resolve per-agent identity and routing hints.
@@ -45,7 +45,6 @@ export interface IMessengerService {
    *
    * Implementations that don't need this can omit it (or return null).
    */
-
   resolveAgentContext?(params: { botConfig: any; agentDisplayName: string }): null | {
     /**
      * Bot/user id for this agent instance (used for mention detection and self-filtering).
@@ -136,7 +135,6 @@ export interface IMessengerService {
    * });
    * ```
    */
-
   sendPublicAnnouncement(channelId: string, announcement: any): Promise<void>;
 
   /**
@@ -185,9 +183,7 @@ export interface IMessengerService {
    * @param channelId The channel identifier to score
    * @param metadata  Optional context used for scoring
    * @returns number score for the channel
-   // eslint-disable-next-line @typescript-eslint/no-explicit-any
    */
-
   scoreChannel?(channelId: string, metadata?: Record<string, any>): number;
 
   /**
@@ -203,7 +199,6 @@ export interface IMessengerService {
    *   const response = await generateResponse(message, history);
    *   return response;
    * });
-   // eslint-disable-next-line @typescript-eslint/no-explicit-any
    * ```
    */
   setMessageHandler(
@@ -226,19 +221,18 @@ export interface IMessengerService {
    * ```
    */
   getForumOwner?(forumId: string): Promise<string>;
+  getChannels?(botName?: string): Promise<Array<{ id: string; name: string; type?: string }>>;
 
   /**
    * Optional: Returns extended sub-services managed by this provider.
    * Useful for services like Discord that manage multiple bot instances under one connection.
    * If implemented, consumers like IdleResponseManager can use this to interact with specific bot instances.
    */
-
-  getDelegatedServices?(): {
+  getDelegatedServices?(): Array<{
     serviceName: string;
     messengerService: IMessengerService;
-
     botConfig: any;
-  }[];
+  }>;
 
   /**
    * Optional: Updates the bot's presence/activity status with model info.

--- a/packages/shared-types/src/IMessengerService.ts
+++ b/packages/shared-types/src/IMessengerService.ts
@@ -26,7 +26,7 @@ export interface IMessengerService {
    * Optional: return per-instance startup summaries for operator-friendly logging.
    * Implementations that don't support per-instance introspection can omit this.
    */
-  getAgentStartupSummaries?: () => Array<{
+  getAgentStartupSummaries?: () => {
     name: string;
     provider: string;
     botId?: string;
@@ -35,7 +35,7 @@ export interface IMessengerService {
     llmModel?: string;
     llmEndpoint?: string;
     systemPrompt?: string;
-  }>;
+  }[];
 
   /**
    * Optional integration hook: resolve per-agent identity and routing hints.
@@ -45,6 +45,7 @@ export interface IMessengerService {
    *
    * Implementations that don't need this can omit it (or return null).
    */
+
   resolveAgentContext?(params: { botConfig: any; agentDisplayName: string }): null | {
     /**
      * Bot/user id for this agent instance (used for mention detection and self-filtering).
@@ -135,6 +136,7 @@ export interface IMessengerService {
    * });
    * ```
    */
+
   sendPublicAnnouncement(channelId: string, announcement: any): Promise<void>;
 
   /**
@@ -183,7 +185,9 @@ export interface IMessengerService {
    * @param channelId The channel identifier to score
    * @param metadata  Optional context used for scoring
    * @returns number score for the channel
+   // eslint-disable-next-line @typescript-eslint/no-explicit-any
    */
+
   scoreChannel?(channelId: string, metadata?: Record<string, any>): number;
 
   /**
@@ -199,6 +203,7 @@ export interface IMessengerService {
    *   const response = await generateResponse(message, history);
    *   return response;
    * });
+   // eslint-disable-next-line @typescript-eslint/no-explicit-any
    * ```
    */
   setMessageHandler(
@@ -221,18 +226,19 @@ export interface IMessengerService {
    * ```
    */
   getForumOwner?(forumId: string): Promise<string>;
-  getChannels?(botName?: string): Promise<Array<{ id: string; name: string; type?: string }>>;
 
   /**
    * Optional: Returns extended sub-services managed by this provider.
    * Useful for services like Discord that manage multiple bot instances under one connection.
    * If implemented, consumers like IdleResponseManager can use this to interact with specific bot instances.
    */
-  getDelegatedServices?(): Array<{
+
+  getDelegatedServices?(): {
     serviceName: string;
     messengerService: IMessengerService;
+
     botConfig: any;
-  }>;
+  }[];
 
   /**
    * Optional: Updates the bot's presence/activity status with model info.

--- a/src/message/interfaces/IMessengerService.ts
+++ b/src/message/interfaces/IMessengerService.ts
@@ -226,6 +226,7 @@ export interface IMessengerService {
    * ```
    */
   getForumOwner?(forumId: string): Promise<string>;
+  getChannels?(botName?: string): Promise<Array<{ id: string; name: string; type?: string }>>;
 
   /**
    * Optional: Returns extended sub-services managed by this provider.

--- a/src/server/routes/admin/mcpServers.ts
+++ b/src/server/routes/admin/mcpServers.ts
@@ -222,10 +222,13 @@ router.get('/mcp-servers', async (req: Request, res: Response) => {
     // Get stored MCP server configurations
     const storedMcps = await webUIStorage.getMcps();
 
+    // Performance optimization: pre-compute map for O(1) lookups instead of calling .find() inside .map() loop
+    const storedMcpsMap = new Map(storedMcps.map((mcp: any) => [mcp.name, mcp]));
+
     // Enrich connected servers with stored configuration data
 
     const enrichedServers = connectedServers.map((server) => {
-      const storedConfig = storedMcps.find((mcp: any) => mcp.name === server.name);
+      const storedConfig = storedMcpsMap.get(server.name);
       return {
         name: server.name,
         serverUrl: storedConfig?.serverUrl || storedConfig?.url || '',


### PR DESCRIPTION
**💡 What:**
Replaced the O(N * M) `.find()` lookup inside the `connectedServers.map()` callback with a pre-computed `Map` dictionary for retrieving stored MCP server metadata.

**🎯 Why:**
When a user hits the `/mcp-servers` GET endpoint, the application enriches currently active MCP servers with their configurations stored persistently. Previously, it iterated over the `storedMcps` array for every connected server to find its configuration match. This yields O(N * M) time complexity where N is connected servers and M is configured servers. A `Map` performs the same enrichment in O(N + M) time.

**📊 Impact:**
Changes lookup time for stored configurations per connected server from O(M) to O(1). While currently manageable, this prevents performance degradation as the number of configured MCP servers and tool registries grows.

**🔬 Measurement:**
Run tests. Verify no changes to the actual API response schema or runtime behavior. Test the `router.get('/mcp-servers')` output locally if desired.

---
*PR created automatically by Jules for task [16779380722875503271](https://jules.google.com/task/16779380722875503271) started by @matthewhand*