### PR TITLE
⚡ Bolt: [performance improvement] Pre-compute Maps for MCP Server Admin Routes

### DIFF
--- a/src/server/routes/admin/maintenance.ts
+++ b/src/server/routes/admin/maintenance.ts
@@ -225,9 +225,11 @@ router.get('/mcp-servers', async (req: Request, res: Response) => {
     const storedMcps = await webUIStorage.getMcps();
 
     // Enrich connected servers with stored configuration data
+    // Performance optimization: pre-compute map for O(1) lookups instead of calling .find() inside .map()
+    const storedMcpsMap = new Map(storedMcps.map((mcp: any) => [mcp.name, mcp]));
 
     const enrichedServers = connectedServers.map((server) => {
-      const storedConfig = storedMcps.find((mcp: any) => mcp.name === server.name);
+      const storedConfig = storedMcpsMap.get(server.name);
       return {
         name: server.name,
         serverUrl: storedConfig?.serverUrl || storedConfig?.url || '',

--- a/src/server/routes/admin/mcpServers.ts
+++ b/src/server/routes/admin/mcpServers.ts
@@ -223,9 +223,11 @@ router.get('/mcp-servers', async (req: Request, res: Response) => {
     const storedMcps = await webUIStorage.getMcps();
 
     // Enrich connected servers with stored configuration data
+    // Performance optimization: pre-compute map for O(1) lookups instead of calling .find() inside .map()
+    const storedMcpsMap = new Map(storedMcps.map((mcp: any) => [mcp.name, mcp]));
 
     const enrichedServers = connectedServers.map((server) => {
-      const storedConfig = storedMcps.find((mcp: any) => mcp.name === server.name);
+      const storedConfig = storedMcpsMap.get(server.name);
       return {
         name: server.name,
         serverUrl: storedConfig?.serverUrl || storedConfig?.url || '',


### PR DESCRIPTION
💡 What
Replaced `.find()` lookups inside `.map()` iterations with pre-computed `Map` objects in two MCP server admin routes (`/mcp-servers` GET endpoint and `/mcp-servers/maintenance` GET endpoint).

🎯 Why
When retrieving all connected MCP servers and enriching them with configuration data, the code was looping through `connectedServers` and for each one doing a `.find()` on `storedMcps`. This created an $O(n^2)$ time complexity.

📊 Impact
Reduces the algorithmic complexity of matching connected servers with their stored configuration from $O(N \times M)$ to $O(N + M)$, where $N$ is the number of connected servers and $M$ is the number of configured servers. 

🔬 Measurement
Review `src/server/routes/admin/mcpServers.ts` and `src/server/routes/admin/maintenance.ts` to see that a new `Map` is allocated before the mapping loop, and a simple `.get()` is used during iteration.

---
*PR created automatically by Jules for task [4863939795308852808](https://jules.google.com/task/4863939795308852808) started by @matthewhand*