### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -43,3 +43,6 @@
 ## 2026-05-02 - ProviderConfigForm Re-rendering
 **Learning:** The form components re-render frequently (e.g., on every keystroke). Using `.reduce()` and `.filter()` on potentially large arrays within the component body without memoization leads to O(N) recalculations on every render, which can cause typing lag on complex configuration forms.
 **Action:** Use `useMemo` to wrap expensive array transformations inside React components, especially forms.
+## 2024-05-23 - Optimize MCPServers array lookup
+**Learning:** React component renders often contain hidden O(N^2) complexity when checking for array duplicates using `.find()` inside `.forEach()` or `.map()` loops.
+**Action:** Replace nested array `.find()` operations during bulk processing with a pre-computed `Set` to achieve O(1) membership testing and linear overall time complexity.

--- a/src/server/routes/admin/maintenance.ts
+++ b/src/server/routes/admin/maintenance.ts
@@ -225,9 +225,10 @@ router.get('/mcp-servers', async (req: Request, res: Response) => {
     const storedMcps = await webUIStorage.getMcps();
 
     // Enrich connected servers with stored configuration data
+    const storedMcpsMap = new Map(storedMcps.map((mcp: any) => [mcp.name, mcp]));
 
     const enrichedServers = connectedServers.map((server) => {
-      const storedConfig = storedMcps.find((mcp: any) => mcp.name === server.name);
+      const storedConfig = storedMcpsMap.get(server.name);
       return {
         name: server.name,
         serverUrl: storedConfig?.serverUrl || storedConfig?.url || '',

--- a/src/server/routes/admin/mcpServers.ts
+++ b/src/server/routes/admin/mcpServers.ts
@@ -223,9 +223,10 @@ router.get('/mcp-servers', async (req: Request, res: Response) => {
     const storedMcps = await webUIStorage.getMcps();
 
     // Enrich connected servers with stored configuration data
+    const storedMcpsMap = new Map(storedMcps.map((mcp: any) => [mcp.name, mcp]));
 
     const enrichedServers = connectedServers.map((server) => {
-      const storedConfig = storedMcps.find((mcp: any) => mcp.name === server.name);
+      const storedConfig = storedMcpsMap.get(server.name);
       return {
         name: server.name,
         serverUrl: storedConfig?.serverUrl || storedConfig?.url || '',


### PR DESCRIPTION
💡 What: Replaced an `Array.find()` loop inside an `Array.map()` loop with a pre-computed `Map` lookup in `src/server/routes/admin/mcpServers.ts` and `src/server/routes/admin/maintenance.ts`.
🎯 Why: Admin routes fetching MCP servers were using nested loops to enrich server configurations, creating a performance bottleneck of `O(N * M)` time complexity.
📊 Impact: Reduces time complexity from `O(N * M)` to `O(N + M)` for building the server lists.
🔬 Measurement: Verify by executing a load of many stored MCP configurations and fetching the `/mcp-servers` endpoint.

Also cleaned up pnpm-lock changes generated by the sandbox.

---
*PR created automatically by Jules for task [15431675388140916889](https://jules.google.com/task/15431675388140916889) started by @matthewhand*