### PR TITLE
fix(errors): typed token-refresh recovery for AuthenticationError

### DIFF
--- a/src/types/errorClasses.ts
+++ b/src/types/errorClasses.ts
@@ -96,6 +96,53 @@ export interface ErrorRecoveryStrategy {
 }
 
 /**
+ * Callback that performs an actual token refresh.
+ *
+ * This is supplied by the calling code (for example a route handler that has
+ * access to {@link AuthManager.refreshToken}). It resolves with the refreshed
+ * credential on success and rejects/throws on failure.
+ *
+ * The error-class layer deliberately does not import any auth service so that
+ * `src/types` stays free of higher-level dependencies; instead the concrete
+ * refresh mechanism is injected at the call site.
+ */
+export type TokenRefreshHandler = () => Promise<unknown>;
+
+/**
+ * Thrown by an {@link AuthenticationError} recovery `fallbackAction` when an
+ * expired token is encountered but no token-refresh handler was supplied.
+ *
+ * This is a properly-typed, documented signal (rather than a bare
+ * `new Error('...not implemented')`) so callers can distinguish "refresh is not
+ * wired up for this provider" from a genuine refresh failure and degrade
+ * gracefully — typically by forcing a full re-authentication.
+ */
+export class TokenRefreshNotSupportedError extends BaseHivemindError {
+  public readonly provider?: string;
+
+  constructor(provider?: string, context?: Record<string, unknown>) {
+    super(
+      provider
+        ? `Token refresh is not supported for provider "${provider}". Re-authentication is required.`
+        : 'Token refresh is not supported. Re-authentication is required.',
+      'authentication',
+      'TOKEN_REFRESH_NOT_SUPPORTED',
+      401,
+      { provider },
+      context
+    );
+    this.provider = provider;
+  }
+
+  getRecoveryStrategy(): ErrorRecoveryStrategy {
+    return {
+      canRecover: false,
+      recoverySteps: ['Re-authenticate with the provider to obtain a new token'],
+    };
+  }
+}
+
+/**
  * Network error with retry capabilities
  */
 export class NetworkError extends BaseHivemindError {
@@ -330,28 +377,46 @@ export class AuthenticationError extends BaseHivemindError {
     | 'missing_token'
     | 'invalid_format';
 
+  /**
+   * Optional token-refresh callback injected by the calling code. When the
+   * error represents an expired token and a handler is present, the recovery
+   * strategy's `fallbackAction` delegates to it. When absent, the
+   * `fallbackAction` rejects with a {@link TokenRefreshNotSupportedError}.
+   */
+  private readonly tokenRefreshHandler?: TokenRefreshHandler;
+
   constructor(
     message: string,
     provider?: string,
     reason?: 'invalid_credentials' | 'expired_token' | 'missing_token' | 'invalid_format',
-    context?: Record<string, unknown>
+    context?: Record<string, unknown>,
+    tokenRefreshHandler?: TokenRefreshHandler
   ) {
     super(message, 'authentication', 'AUTH_ERROR', 401, { provider, reason }, context);
     this.provider = provider;
     this.reason = reason;
+    this.tokenRefreshHandler = tokenRefreshHandler;
   }
 
   getRecoveryStrategy(): ErrorRecoveryStrategy {
     // Allow token refresh for expired tokens
     if (this.reason === 'expired_token') {
+      const handler = this.tokenRefreshHandler;
+      const provider = this.provider;
       return {
         canRecover: true,
         maxRetries: 1,
         retryDelay: 0,
 
         fallbackAction: async () => {
-          // This would be implemented by the calling code
-          throw new Error('Token refresh not implemented');
+          // The concrete refresh mechanism is injected by the calling code
+          // (e.g. AuthManager.refreshToken). When none is provided we surface a
+          // typed, documented error so callers can fall back to a full
+          // re-authentication instead of receiving an opaque generic Error.
+          if (!handler) {
+            throw new TokenRefreshNotSupportedError(provider);
+          }
+          return handler();
         },
         recoverySteps: ['Attempt to refresh authentication token', 'Re-authenticate with provider'],
       };

--- a/tests/unit/types/authenticationError.tokenRefresh.test.ts
+++ b/tests/unit/types/authenticationError.tokenRefresh.test.ts
@@ -1,0 +1,103 @@
+import {
+  AuthenticationError,
+  TokenRefreshNotSupportedError,
+} from '../../../src/types/errorClasses';
+
+describe('AuthenticationError token-refresh recovery', () => {
+  describe('expired_token without a refresh handler', () => {
+    it('exposes a recoverable strategy with a fallbackAction', () => {
+      const error = new AuthenticationError('Token expired', 'discord', 'expired_token');
+      const recovery = error.getRecoveryStrategy();
+
+      expect(recovery.canRecover).toBe(true);
+      expect(recovery.maxRetries).toBe(1);
+      expect(typeof recovery.fallbackAction).toBe('function');
+    });
+
+    it('rejects fallbackAction with a typed TokenRefreshNotSupportedError', async () => {
+      const error = new AuthenticationError('Token expired', 'discord', 'expired_token');
+      const recovery = error.getRecoveryStrategy();
+
+      await expect(recovery.fallbackAction!()).rejects.toBeInstanceOf(
+        TokenRefreshNotSupportedError
+      );
+    });
+
+    it('includes the provider name in the not-supported error', async () => {
+      const error = new AuthenticationError('Token expired', 'slack', 'expired_token');
+      const recovery = error.getRecoveryStrategy();
+
+      await expect(recovery.fallbackAction!()).rejects.toMatchObject({
+        provider: 'slack',
+        code: 'TOKEN_REFRESH_NOT_SUPPORTED',
+        statusCode: 401,
+      });
+    });
+  });
+
+  describe('expired_token with an injected refresh handler', () => {
+    it('delegates fallbackAction to the supplied handler and returns its result', async () => {
+      const handler = jest.fn().mockResolvedValue({ accessToken: 'new-token' });
+      const error = new AuthenticationError(
+        'Token expired',
+        'discord',
+        'expired_token',
+        undefined,
+        handler
+      );
+
+      const recovery = error.getRecoveryStrategy();
+      const result = await recovery.fallbackAction!();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ accessToken: 'new-token' });
+    });
+
+    it('propagates a rejection from the handler unchanged', async () => {
+      const failure = new Error('refresh token revoked');
+      const handler = jest.fn().mockRejectedValue(failure);
+      const error = new AuthenticationError(
+        'Token expired',
+        'discord',
+        'expired_token',
+        undefined,
+        handler
+      );
+
+      const recovery = error.getRecoveryStrategy();
+
+      await expect(recovery.fallbackAction!()).rejects.toBe(failure);
+    });
+  });
+
+  describe('non-expired authentication reasons', () => {
+    it('is not recoverable and has no fallbackAction for invalid credentials', () => {
+      const error = new AuthenticationError('Bad credentials', 'discord', 'invalid_credentials');
+      const recovery = error.getRecoveryStrategy();
+
+      expect(recovery.canRecover).toBe(false);
+      expect(recovery.fallbackAction).toBeUndefined();
+    });
+  });
+});
+
+describe('TokenRefreshNotSupportedError', () => {
+  it('is non-recoverable and recommends re-authentication', () => {
+    const error = new TokenRefreshNotSupportedError('mattermost');
+    const recovery = error.getRecoveryStrategy();
+
+    expect(recovery.canRecover).toBe(false);
+    expect(error.message).toContain('mattermost');
+    expect(error.code).toBe('TOKEN_REFRESH_NOT_SUPPORTED');
+    expect(recovery.recoverySteps).toEqual([
+      'Re-authenticate with the provider to obtain a new token',
+    ]);
+  });
+
+  it('produces a generic message when no provider is given', () => {
+    const error = new TokenRefreshNotSupportedError();
+
+    expect(error.message).toBe('Token refresh is not supported. Re-authentication is required.');
+    expect(error.provider).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What
Replaces the `throw new Error('Token refresh not implemented')` placeholder in `AuthenticationError.getRecoveryStrategy()` (`src/types/errorClasses.ts`) with a properly-typed recovery path.

- `AuthenticationError` now accepts an optional `tokenRefreshHandler: TokenRefreshHandler` constructor argument.
- When the error reason is `expired_token`:
  - If a handler is supplied, the recovery `fallbackAction` delegates to it and returns/propagates its result. Calling code (e.g. a route with access to `AuthManager.refreshToken`) injects the concrete refresh mechanism.
  - If no handler is supplied, `fallbackAction` rejects with a new, documented `TokenRefreshNotSupportedError` instead of an opaque generic `Error`.
- Adds `TokenRefreshNotSupportedError` (typed, `code: 'TOKEN_REFRESH_NOT_SUPPORTED'`, status 401, non-recoverable strategy that recommends re-authentication).

## Why
The previous code always threw a bare, untyped `Error('Token refresh not implemented')` even though the strategy advertised `canRecover: true`. Callers had no way to distinguish "refresh isn't wired up" from a genuine refresh failure. The codebase already has a real refresh mechanism (`AuthManager.refreshToken`), but `src/types` must not depend on `src/auth`; injecting the handler keeps the layering clean while making the recovery path usable.

## Behavior
- Fully backward compatible: the new constructor parameter is optional and trailing; existing call sites (middleware, AuthManager, the deserialization factory) are unchanged.
- Default behavior for an expired token with no handler changes from throwing a generic `Error` to throwing a typed `TokenRefreshNotSupportedError` — same "this fails" outcome, but now catchable and documented.

## Verification
- `npx tsc --noEmit` — clean
- `eslint src/types/errorClasses.ts tests/unit/types/authenticationError.tokenRefresh.test.ts` — 0 errors
- `jest tests/unit/types/authenticationError.tokenRefresh.test.ts` — 8 passing (covers: recoverable strategy shape, typed not-supported rejection with provider, handler delegation + result, handler rejection propagation, non-expired non-recoverable case, and `TokenRefreshNotSupportedError` messages)

No new dependencies; lockfile unchanged.
