### PR TITLE
feat: implement YAML import/export in formatConverters

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,6 +213,7 @@
     "umzug": "^3.8.2",
     "uuid": "^11.1.0",
     "winston-daily-rotate-file": "^5.0.0",
+    "yaml": "^2.9.0",
     "yargs": "^17.7.2",
     "zod": "^3.25.1",
     "zod-to-json-schema": "3.25.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,6 +370,9 @@ importers:
       winston-daily-rotate-file:
         specifier: ^5.0.0
         version: 5.0.0(winston@3.19.0)
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -433,7 +436,7 @@ importers:
         version: 5.0.5(rollup@4.60.1)
       '@tailwindcss/vite':
         specifier: ^4.2.0
-        version: 4.2.2(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.2.2(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       '@testing-library/jest-dom':
         specifier: ^6.8.0
         version: 6.9.1
@@ -541,7 +544,7 @@ importers:
         version: 5.7.4(encoding@0.1.13)(rollup@4.60.1)
       '@vitejs/plugin-react':
         specifier: ^5.0.0
-        version: 5.2.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.2.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       babel-jest:
         specifier: ^29.7.0
         version: 29.7.0(@babel/core@7.29.0)
@@ -658,7 +661,7 @@ importers:
         version: 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: ^7.3.2
-        version: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       wrangler:
         specifier: ^4.34.0
         version: 4.81.1
@@ -1006,7 +1009,7 @@ importers:
         version: 0.5.19(tailwindcss@4.2.2)
       '@tailwindcss/vite':
         specifier: ^4.1.17
-        version: 4.2.2(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.2.2(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -1030,10 +1033,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^5.0.0
-        version: 5.2.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.2.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 3.2.4(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       eslint:
         specifier: ^9.34.0
         version: 9.39.4(jiti@2.6.1)
@@ -1054,10 +1057,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.3.2
-        version: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
 
 packages:
 
@@ -7852,6 +7855,7 @@ packages:
   recharts@2.15.4:
     resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
     engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -9167,8 +9171,8 @@ packages:
     resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
 
-  yaml@2.8.3:
-    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -11704,12 +11708,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.2.2
 
-  '@tailwindcss/vite@4.2.2(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tailwindcss/vite@4.2.2(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@tanstack/query-core@5.97.0': {}
 
@@ -12330,7 +12334,7 @@ snapshots:
       json-schema-to-ts: 1.6.4
       ts-morph: 12.0.0
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -12338,11 +12342,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -12357,7 +12361,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12369,13 +12373,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -15465,7 +15469,7 @@ snapshots:
       micromatch: 4.0.8
       pidtree: 0.6.0
       string-argv: 0.3.2
-      yaml: 2.8.3
+      yaml: 2.9.0
     transitivePeerDependencies:
       - supports-color
 
@@ -18145,13 +18149,13 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-node@3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
+  vite-node@3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -18166,7 +18170,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
+  vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -18180,13 +18184,13 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.32.0
       tsx: 4.21.0
-      yaml: 2.8.3
+      yaml: 2.9.0
 
-  vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
+  vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -18204,8 +18208,8 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@edge-runtime/vm': 3.2.0
@@ -18458,7 +18462,7 @@ snapshots:
 
   yaml@1.10.3: {}
 
-  yaml@2.8.3: {}
+  yaml@2.9.0: {}
 
   yargs-parser@20.2.9: {}
 

--- a/src/server/services/configImportExport/formatConverters.ts
+++ b/src/server/services/configImportExport/formatConverters.ts
@@ -2,6 +2,8 @@
  * Format detection and conversion utilities for configuration import/export.
  */
 
+import { parse as parseYamlString, stringify as stringifyYaml } from 'yaml';
+
 /**
  * Detect file format from extension
  */
@@ -21,39 +23,15 @@ export function detectFormat(filePath: string): 'json' | 'yaml' | 'csv' {
 }
 
 /**
- * Convert data to YAML (simplified implementation)
+ * Serialize an arbitrary data structure to a YAML document.
+ *
+ * Backed by the `yaml` package so that strings, numbers, booleans, nested
+ * objects and arrays are quoted/escaped correctly and round-trip cleanly
+ * through {@link parseYAML}.
  */
 
 export function convertToYAML(data: any): string {
-  // This is a simplified YAML converter
-  // In production, use a proper YAML library like js-yaml
-
-  const convert = (obj: any, indent = 0): string => {
-    const spaces = ' '.repeat(indent);
-    let result = '';
-
-    if (typeof obj === 'object' && obj !== null) {
-      if (Array.isArray(obj)) {
-        for (const item of obj) {
-          result += spaces + '- ' + convert(item, indent + 2).trim() + '\n';
-        }
-      } else {
-        for (const [key, value] of Object.entries(obj)) {
-          if (typeof value === 'object' && value !== null) {
-            result += spaces + key + ':\n' + convert(value, indent + 2);
-          } else {
-            result += spaces + key + ': ' + value + '\n';
-          }
-        }
-      }
-    } else {
-      return String(obj);
-    }
-
-    return result;
-  };
-
-  return convert(data);
+  return stringifyYaml(data);
 }
 
 /**
@@ -95,14 +73,14 @@ export function convertToCSV(data: any): string {
 }
 
 /**
- // eslint-disable-next-line @typescript-eslint/no-explicit-any
- * Parse YAML (simplified implementation)
+ * Parse a YAML document into a JavaScript value.
+ *
+ * Backed by the `yaml` package. Throws on malformed YAML so callers can
+ * surface a useful error to the user.
  */
 
-export function parseYAML(_yamlString: string): any {
-  // This is a simplified YAML parser
-  // In production, use a proper YAML library like js-yaml
-  throw new Error('YAML parsing not implemented in this version');
+export function parseYAML(yamlString: string): any {
+  return parseYamlString(yamlString);
 }
 
 /**

--- a/tests/unit/services/configImportExport/formatConverters.yaml.test.ts
+++ b/tests/unit/services/configImportExport/formatConverters.yaml.test.ts
@@ -1,0 +1,100 @@
+import {
+  convertToYAML,
+  detectFormat,
+  parseYAML,
+} from '../../../../src/server/services/configImportExport/formatConverters';
+
+describe('formatConverters - YAML', () => {
+  describe('parseYAML', () => {
+    it('parses a simple scalar mapping', () => {
+      const result = parseYAML('name: hivemind\nenabled: true\ncount: 3\n');
+      expect(result).toEqual({ name: 'hivemind', enabled: true, count: 3 });
+    });
+
+    it('parses nested objects and arrays', () => {
+      const yaml = [
+        'version: 1',
+        'configurations:',
+        '  - name: bot-a',
+        '    provider: openai',
+        '  - name: bot-b',
+        '    provider: anthropic',
+        '',
+      ].join('\n');
+      const result = parseYAML(yaml);
+      expect(result).toEqual({
+        version: 1,
+        configurations: [
+          { name: 'bot-a', provider: 'openai' },
+          { name: 'bot-b', provider: 'anthropic' },
+        ],
+      });
+    });
+
+    it('preserves strings that contain special characters', () => {
+      const result = parseYAML('token: "abc:123, with comma"\n');
+      expect(result.token).toBe('abc:123, with comma');
+    });
+
+    it('throws on malformed YAML', () => {
+      // Unbalanced flow collection is invalid YAML.
+      expect(() => parseYAML('foo: [1, 2')).toThrow();
+    });
+  });
+
+  describe('convertToYAML', () => {
+    it('serializes an object to a YAML document', () => {
+      const yaml = convertToYAML({ name: 'hivemind', enabled: true });
+      expect(yaml).toContain('name: hivemind');
+      expect(yaml).toContain('enabled: true');
+    });
+
+    it('quotes strings that would otherwise be ambiguous', () => {
+      const yaml = convertToYAML({ value: 'true', port: '8080' });
+      // String "true" must be quoted so it does not round-trip to a boolean.
+      const parsed = parseYAML(yaml);
+      expect(parsed.value).toBe('true');
+      expect(parsed.port).toBe('8080');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('round-trips a representative export payload', () => {
+      const exportData = {
+        version: '1.0.0',
+        exportedAt: '2026-06-02T00:00:00.000Z',
+        configurations: [
+          {
+            name: 'support-bot',
+            provider: 'openai',
+            enabled: true,
+            maxTokens: 2048,
+            systemPrompt: 'Be helpful, concise: answer well.',
+            channels: ['general', 'help'],
+            metadata: { owner: 'team-a', nested: { deep: 'value' } },
+          },
+        ],
+        settings: {
+          retries: 0,
+          flags: [true, false, true],
+        },
+      };
+
+      const yaml = convertToYAML(exportData);
+      const parsed = parseYAML(yaml);
+      expect(parsed).toEqual(exportData);
+    });
+
+    it('round-trips an empty object and empty array', () => {
+      expect(parseYAML(convertToYAML({}))).toEqual({});
+      expect(parseYAML(convertToYAML({ items: [] }))).toEqual({ items: [] });
+    });
+  });
+
+  describe('detectFormat', () => {
+    it('detects yaml and yml extensions', () => {
+      expect(detectFormat('config.yaml')).toBe('yaml');
+      expect(detectFormat('config.yml')).toBe('yaml');
+    });
+  });
+});


### PR DESCRIPTION
## What
Implement real YAML import/export in `src/server/services/configImportExport/formatConverters.ts`.

- `parseYAML()` previously threw `"YAML parsing not implemented in this version"`. It now parses YAML via the `yaml` npm package.
- `convertToYAML()` replaced the buggy hand-rolled serializer (which did not quote strings, mishandled arrays of objects, and could not round-trip) with the `yaml` package's `stringify`.

## Why
`parseYAML` was a hard failure for any YAML-format config import (used by `ConfigurationImportExportService`, `ConfigImporter`, and `ConfigSerializer`). The old `convertToYAML` produced output that did not round-trip, so exported YAML could not be re-imported.

## Behavior
- `yaml` added as a direct dependency (`^2.9.0`). It was already present transitively and pinned in `overrides`, so the resolved version is unchanged in spirit; `corepack pnpm install --frozen-lockfile` succeeds with the committed lockfile.
- YAML import/export now round-trips: `parseYAML(convertToYAML(x))` deep-equals `x` for representative config payloads (nested objects, arrays, booleans, numbers, strings with special chars).
- Malformed YAML now throws (surfaced to callers) instead of being silently mishandled.

## Verification
- `npx tsc --noEmit` — clean
- `eslint` on changed files — 0 errors
- `npx jest tests/unit/services/configImportExport/formatConverters.yaml.test.ts` — 9 passing (parse, serialize, round-trip, malformed-input, detectFormat)
- `corepack pnpm install --frozen-lockfile` — succeeds (lockfile committed)
