### PR TITLE
feat(specs): implement Add Specification and Share actions

### DIFF
--- a/src/client/src/pages/SpecDetailPage.tsx
+++ b/src/client/src/pages/SpecDetailPage.tsx
@@ -12,10 +12,11 @@ import PageHeader from '../components/DaisyUI/PageHeader';
 import { ArrowLeft, Download } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import useSpec from '../hooks/useSpec';
-import { useInfoToast } from '../components/DaisyUI/ToastNotification';
+import { useSuccessToast, useErrorToast } from '../components/DaisyUI/ToastNotification';
 
 const SpecDetailPage: React.FC = () => {
-  const infoToast = useInfoToast();
+  const successToast = useSuccessToast();
+  const errorToast = useErrorToast();
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const { spec, loading, error } = useSpec(id);
@@ -72,8 +73,18 @@ ${spec.content.replace(/^/gm, '  ')}
     { label: 'YAML', onClick: (): void => handleExport('yaml') },
   ];
 
-  const handleNotImplemented = (): void => {
-    infoToast('Coming Soon', 'This feature is currently under development.');
+  const handleShare = async (): Promise<void> => {
+    const url = window.location.href;
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(url);
+        successToast('Link copied', 'A link to this specification was copied to your clipboard.');
+        return;
+      }
+      throw new Error('Clipboard API unavailable');
+    } catch {
+      errorToast('Could not copy link', url);
+    }
   };
 
   if (loading) {
@@ -148,10 +159,12 @@ ${spec.content.replace(/^/gm, '  ')}
                 Last updated: {new Date(spec.timestamp).toLocaleString()}
               </p>
               <div className="flex gap-2">
-                <Button size="sm" className="btn-ghost" onClick={handleNotImplemented}>
-                  Edit
-                </Button>
-                <Button size="sm" className="btn-ghost" onClick={handleNotImplemented}>
+                <Button
+                  size="sm"
+                  className="btn-ghost"
+                  onClick={() => void handleShare()}
+                  data-testid="share-spec-button"
+                >
                   Share
                 </Button>
               </div>

--- a/src/client/src/pages/SpecsPage.tsx
+++ b/src/client/src/pages/SpecsPage.tsx
@@ -17,13 +17,32 @@ import { useSuccessToast, useErrorToast } from '../components/DaisyUI/ToastNotif
 import { apiService } from '../services/api';
 
 /** Build a filesystem-safe, path-traversal-free id matching the server regex /^[a-zA-Z0-9_-]+$/. */
-const slugifyTopic = (topic: string): string =>
+export const slugifyTopic = (topic: string): string =>
   topic
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, 64) || 'spec';
+
+/**
+ * Produce an id derived from the topic that does not collide with any id in `existingIds`.
+ * Different topics can slugify to the same base (e.g. "My Spec!" and "My___Spec" both -> "my-spec",
+ * and any all-symbol topic -> "spec"), so on collision we append an incrementing suffix.
+ */
+export const buildUniqueSpecId = (topic: string, existingIds: Iterable<string>): string => {
+  const taken = new Set(existingIds);
+  const base = slugifyTopic(topic);
+  if (!taken.has(base)) {
+    return base;
+  }
+  let suffix = 2;
+  // Keep the suffixed id within the same 64-char budget as the base slug.
+  while (taken.has(`${base.slice(0, 64 - `-${suffix}`.length)}-${suffix}`)) {
+    suffix += 1;
+  }
+  return `${base.slice(0, 64 - `-${suffix}`.length)}-${suffix}`;
+};
 
 const SpecsPage: React.FC = () => {
   const successToast = useSuccessToast();
@@ -93,7 +112,7 @@ const SpecsPage: React.FC = () => {
       .filter(Boolean);
 
     const payload = {
-      id: slugifyTopic(topic),
+      id: buildUniqueSpecId(topic, specs.map((s) => s.id)),
       topic,
       author: form.author.trim() || 'Unknown',
       tags,

--- a/src/client/src/pages/SpecsPage.tsx
+++ b/src/client/src/pages/SpecsPage.tsx
@@ -3,20 +3,36 @@ import { useNavigate } from 'react-router-dom';
 import Card from '../components/DaisyUI/Card';
 import Button from '../components/DaisyUI/Button';
 import Input from '../components/DaisyUI/Input';
+import Textarea from '../components/DaisyUI/Textarea';
 import Badge from '../components/DaisyUI/Badge';
 
+import Modal from '../components/DaisyUI/Modal';
 import Pagination from '../components/DaisyUI/Pagination';
 import { SkeletonPage } from '../components/DaisyUI/Skeleton';
 import { Search, Plus, BookOpen } from 'lucide-react';
 import PageHeader from '../components/DaisyUI/PageHeader';
 import useSpecs from '../hooks/useSpecs';
 import useUrlParams from '../hooks/useUrlParams';
-import { useInfoToast } from '../components/DaisyUI/ToastNotification';
+import { useSuccessToast, useErrorToast } from '../components/DaisyUI/ToastNotification';
+import { apiService } from '../services/api';
+
+/** Build a filesystem-safe, path-traversal-free id matching the server regex /^[a-zA-Z0-9_-]+$/. */
+const slugifyTopic = (topic: string): string =>
+  topic
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64) || 'spec';
 
 const SpecsPage: React.FC = () => {
-  const infoToast = useInfoToast();
+  const successToast = useSuccessToast();
+  const errorToast = useErrorToast();
   const navigate = useNavigate();
   const { specs, loading, error, refetch } = useSpecs();
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [form, setForm] = useState({ topic: '', author: '', tags: '', content: '' });
   const { values: urlParams, setValue: setUrlParam } = useUrlParams({
     search: { type: 'string', default: '', debounce: 300 },
     page: { type: 'number', default: 1 },
@@ -46,8 +62,66 @@ const SpecsPage: React.FC = () => {
     navigate(`/admin/specs/${id}`);
   };
 
-  const handleNotImplemented = (): void => {
-    infoToast('Coming Soon', 'This feature is currently under development.');
+  const openCreate = (): void => {
+    setForm({ topic: '', author: '', tags: '', content: '' });
+    setIsCreateOpen(true);
+  };
+
+  const closeCreate = (): void => {
+    if (creating) {
+      return;
+    }
+    setIsCreateOpen(false);
+  };
+
+  const handleCreate = async (): Promise<void> => {
+    const topic = form.topic.trim();
+    const content = form.content.trim();
+
+    if (!topic) {
+      errorToast('Topic required', 'Please enter a topic for the specification.');
+      return;
+    }
+    if (!content) {
+      errorToast('Content required', 'Please enter the specification content.');
+      return;
+    }
+
+    const tags = form.tags
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+    const payload = {
+      id: slugifyTopic(topic),
+      topic,
+      author: form.author.trim() || 'Unknown',
+      tags,
+      timestamp: new Date().toISOString(),
+      version: '1.0.0',
+      content,
+    };
+
+    setCreating(true);
+    try {
+      const response = await apiService.post<{ success: boolean; error?: string }>(
+        '/api/specs',
+        payload
+      );
+      if (!response.success) {
+        throw new Error(response.error || 'Failed to create specification');
+      }
+      setIsCreateOpen(false);
+      successToast('Specification created', `"${topic}" has been saved.`);
+      await refetch();
+    } catch (err) {
+      errorToast(
+        'Failed to create specification',
+        err instanceof Error ? err.message : 'An unexpected error occurred.'
+      );
+    } finally {
+      setCreating(false);
+    }
   };
 
   if (loading) {
@@ -90,7 +164,7 @@ const SpecsPage: React.FC = () => {
             data-testid="specs-search-input"
           />
         </div>
-        <Button className="btn-primary" onClick={handleNotImplemented} data-testid="add-spec-button">
+        <Button className="btn-primary" onClick={openCreate} data-testid="add-spec-button">
           <Plus className="w-4 h-4 mr-2" />
           Add Specification
         </Button>
@@ -158,12 +232,76 @@ const SpecsPage: React.FC = () => {
               ? 'Try adjusting your search terms'
               : 'Get started by creating your first specification'}
           </p>
-          <Button className="btn-primary" onClick={handleNotImplemented} data-testid="create-spec-button">
+          <Button className="btn-primary" onClick={openCreate} data-testid="create-spec-button">
             <Plus className="w-4 h-4 mr-2" />
             Create Specification
           </Button>
         </div>
       )}
+
+      {/* Create Specification Modal */}
+      <Modal
+        isOpen={isCreateOpen}
+        onClose={closeCreate}
+        title="Create Specification"
+        closable={!creating}
+        actions={[
+          { label: 'Cancel', onClick: closeCreate, variant: 'ghost', disabled: creating },
+          { label: 'Create', onClick: () => void handleCreate(), variant: 'primary', loading: creating },
+        ]}
+      >
+        <div className="space-y-4" data-testid="create-spec-form">
+          <div>
+            <label className="label" htmlFor="spec-topic">
+              <span className="label-text">Topic</span>
+            </label>
+            <Input
+              id="spec-topic"
+              placeholder="Specification topic"
+              value={form.topic}
+              onChange={(e) => setForm((f) => ({ ...f, topic: e.target.value }))}
+              data-testid="spec-topic-input"
+            />
+          </div>
+          <div>
+            <label className="label" htmlFor="spec-author">
+              <span className="label-text">Author</span>
+            </label>
+            <Input
+              id="spec-author"
+              placeholder="Author (optional)"
+              value={form.author}
+              onChange={(e) => setForm((f) => ({ ...f, author: e.target.value }))}
+              data-testid="spec-author-input"
+            />
+          </div>
+          <div>
+            <label className="label" htmlFor="spec-tags">
+              <span className="label-text">Tags</span>
+            </label>
+            <Input
+              id="spec-tags"
+              placeholder="Comma-separated tags (optional)"
+              value={form.tags}
+              onChange={(e) => setForm((f) => ({ ...f, tags: e.target.value }))}
+              data-testid="spec-tags-input"
+            />
+          </div>
+          <div>
+            <label className="label" htmlFor="spec-content">
+              <span className="label-text">Content (Markdown)</span>
+            </label>
+            <Textarea
+              id="spec-content"
+              className="w-full min-h-32"
+              placeholder="Specification content..."
+              value={form.content}
+              onChange={(e) => setForm((f) => ({ ...f, content: e.target.value }))}
+              data-testid="spec-content-input"
+            />
+          </div>
+        </div>
+      </Modal>
     </div>
   );
 };

--- a/src/client/src/pages/__tests__/SpecDetailPage.test.tsx
+++ b/src/client/src/pages/__tests__/SpecDetailPage.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import SpecDetailPage from '../SpecDetailPage';
+
+const mockUseSpec = vi.fn();
+vi.mock('../../hooks/useSpec', () => ({
+  __esModule: true,
+  default: () => mockUseSpec(),
+}));
+
+const mockSuccessToast = vi.fn();
+const mockErrorToast = vi.fn();
+vi.mock('../../components/DaisyUI/ToastNotification', () => ({
+  useSuccessToast: () => mockSuccessToast,
+  useErrorToast: () => mockErrorToast,
+}));
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={['/admin/specs/demo']}>
+      <SpecDetailPage />
+    </MemoryRouter>
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseSpec.mockReturnValue({
+    spec: {
+      id: 'demo',
+      topic: 'Demo Spec',
+      author: 'Ada',
+      timestamp: new Date('2024-01-01').toISOString(),
+      tags: ['x'],
+      content: '# Demo',
+    },
+    loading: false,
+    error: null,
+  });
+});
+
+describe('SpecDetailPage share action', () => {
+  it('copies the current URL to the clipboard and shows a success toast', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    renderPage();
+    fireEvent.click(screen.getByTestId('share-spec-button'));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(window.location.href));
+    expect(mockSuccessToast).toHaveBeenCalled();
+    expect(mockErrorToast).not.toHaveBeenCalled();
+  });
+
+  it('shows an error toast when clipboard access fails', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'));
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    renderPage();
+    fireEvent.click(screen.getByTestId('share-spec-button'));
+
+    await waitFor(() => expect(mockErrorToast).toHaveBeenCalled());
+    expect(mockSuccessToast).not.toHaveBeenCalled();
+  });
+});

--- a/src/client/src/pages/__tests__/SpecsPage.test.tsx
+++ b/src/client/src/pages/__tests__/SpecsPage.test.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import SpecsPage from '../SpecsPage';
+
+// --- Mocks ---------------------------------------------------------------
+
+const mockRefetch = vi.fn().mockResolvedValue(undefined);
+const mockUseSpecs = vi.fn();
+vi.mock('../../hooks/useSpecs', () => ({
+  __esModule: true,
+  default: () => mockUseSpecs(),
+}));
+
+const mockPost = vi.fn();
+vi.mock('../../services/api', () => ({
+  apiService: {
+    post: (...args: unknown[]) => mockPost(...args),
+  },
+}));
+
+const mockSuccessToast = vi.fn();
+const mockErrorToast = vi.fn();
+vi.mock('../../components/DaisyUI/ToastNotification', () => ({
+  useSuccessToast: () => mockSuccessToast,
+  useErrorToast: () => mockErrorToast,
+}));
+
+// Render the Modal inline (and its actions) without the <dialog> showModal machinery.
+vi.mock('../../components/DaisyUI/Modal', () => ({
+  __esModule: true,
+  default: ({ isOpen, title, children, actions = [] }: any) =>
+    isOpen ? (
+      <div role="dialog" aria-label={title}>
+        {children}
+        {actions.map((a: any) => (
+          <button key={a.label} onClick={a.onClick} disabled={a.disabled || a.loading}>
+            {a.label}
+          </button>
+        ))}
+      </div>
+    ) : null,
+}));
+
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <SpecsPage />
+    </MemoryRouter>
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseSpecs.mockReturnValue({
+    specs: [],
+    loading: false,
+    error: null,
+    refetch: mockRefetch,
+  });
+});
+
+describe('SpecsPage create specification', () => {
+  it('opens the create modal when "Add Specification" is clicked', () => {
+    renderPage();
+    fireEvent.click(screen.getByTestId('add-spec-button'));
+    expect(screen.getByTestId('create-spec-form')).toBeInTheDocument();
+  });
+
+  it('validates that a topic is required', () => {
+    renderPage();
+    fireEvent.click(screen.getByTestId('add-spec-button'));
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(mockErrorToast).toHaveBeenCalledWith('Topic required', expect.any(String));
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('POSTs a new specification to /api/specs and refetches on success', async () => {
+    mockPost.mockResolvedValue({ success: true });
+    renderPage();
+
+    fireEvent.click(screen.getByTestId('add-spec-button'));
+    fireEvent.change(screen.getByTestId('spec-topic-input'), {
+      target: { value: 'My New Spec' },
+    });
+    fireEvent.change(screen.getByTestId('spec-author-input'), {
+      target: { value: 'Ada' },
+    });
+    fireEvent.change(screen.getByTestId('spec-tags-input'), {
+      target: { value: 'alpha, beta' },
+    });
+    fireEvent.change(screen.getByTestId('spec-content-input'), {
+      target: { value: '# Heading' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
+
+    const [endpoint, payload] = mockPost.mock.calls[0];
+    expect(endpoint).toBe('/api/specs');
+    expect(payload).toMatchObject({
+      id: 'my-new-spec',
+      topic: 'My New Spec',
+      author: 'Ada',
+      tags: ['alpha', 'beta'],
+      version: '1.0.0',
+      content: '# Heading',
+    });
+    expect(typeof payload.timestamp).toBe('string');
+
+    await waitFor(() => expect(mockRefetch).toHaveBeenCalled());
+    expect(mockSuccessToast).toHaveBeenCalled();
+  });
+
+  it('shows an error toast and does not close when the API fails', async () => {
+    mockPost.mockResolvedValue({ success: false, error: 'boom' });
+    renderPage();
+
+    fireEvent.click(screen.getByTestId('add-spec-button'));
+    fireEvent.change(screen.getByTestId('spec-topic-input'), {
+      target: { value: 'Doomed Spec' },
+    });
+    fireEvent.change(screen.getByTestId('spec-content-input'), {
+      target: { value: 'content' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() =>
+      expect(mockErrorToast).toHaveBeenCalledWith('Failed to create specification', 'boom')
+    );
+    expect(mockRefetch).not.toHaveBeenCalled();
+    // Modal stays open
+    expect(screen.getByTestId('create-spec-form')).toBeInTheDocument();
+  });
+});

--- a/src/client/src/pages/__tests__/SpecsPage.test.tsx
+++ b/src/client/src/pages/__tests__/SpecsPage.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import SpecsPage from '../SpecsPage';
+import SpecsPage, { slugifyTopic, buildUniqueSpecId } from '../SpecsPage';
 
 // --- Mocks ---------------------------------------------------------------
 
@@ -60,6 +60,43 @@ beforeEach(() => {
   });
 });
 
+describe('spec id generation', () => {
+  it('slugifies normal topics', () => {
+    expect(slugifyTopic('My New Spec')).toBe('my-new-spec');
+  });
+
+  it('falls back to "spec" when a topic has no alphanumerics', () => {
+    expect(slugifyTopic('!!!')).toBe('spec');
+  });
+
+  it('returns the base slug when no collision exists', () => {
+    expect(buildUniqueSpecId('My New Spec', [])).toBe('my-new-spec');
+  });
+
+  it('appends a numeric suffix when the slug collides', () => {
+    // "My Spec!" and "My___Spec" both slugify to "my-spec".
+    expect(buildUniqueSpecId('My___Spec', ['my-spec'])).toBe('my-spec-2');
+  });
+
+  it('increments past multiple collisions', () => {
+    expect(buildUniqueSpecId('My Spec', ['my-spec', 'my-spec-2'])).toBe('my-spec-3');
+  });
+
+  it('disambiguates empty-slug topics so they never share the "spec" id', () => {
+    expect(buildUniqueSpecId('!!!', ['spec'])).toBe('spec-2');
+    expect(buildUniqueSpecId('@@@', ['spec', 'spec-2'])).toBe('spec-3');
+  });
+
+  it('keeps the suffixed id within the 64-char budget', () => {
+    const longTopic = 'a'.repeat(80);
+    const base = slugifyTopic(longTopic);
+    expect(base.length).toBe(64);
+    const unique = buildUniqueSpecId(longTopic, [base]);
+    expect(unique.length).toBeLessThanOrEqual(64);
+    expect(unique.endsWith('-2')).toBe(true);
+  });
+});
+
 describe('SpecsPage create specification', () => {
   it('opens the create modal when "Add Specification" is clicked', () => {
     renderPage();
@@ -112,6 +149,41 @@ describe('SpecsPage create specification', () => {
 
     await waitFor(() => expect(mockRefetch).toHaveBeenCalled());
     expect(mockSuccessToast).toHaveBeenCalled();
+  });
+
+  it('generates a unique id when the slug collides with an existing spec', async () => {
+    mockUseSpecs.mockReturnValue({
+      specs: [
+        {
+          id: 'my-spec',
+          topic: 'My Spec',
+          author: 'Ada',
+          tags: [],
+          timestamp: new Date().toISOString(),
+          version: '1.0.0',
+          content: 'x',
+        },
+      ],
+      loading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+    mockPost.mockResolvedValue({ success: true });
+    renderPage();
+
+    fireEvent.click(screen.getByTestId('add-spec-button'));
+    // "My___Spec" slugifies to "my-spec", colliding with the existing spec above.
+    fireEvent.change(screen.getByTestId('spec-topic-input'), {
+      target: { value: 'My___Spec' },
+    });
+    fireEvent.change(screen.getByTestId('spec-content-input'), {
+      target: { value: 'content' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
+    const [, payload] = mockPost.mock.calls[0];
+    expect(payload.id).toBe('my-spec-2');
   });
 
   it('shows an error toast and does not close when the API fails', async () => {


### PR DESCRIPTION
## What

Replaces the "Coming Soon / under development" info toasts on the Specifications pages with real, persisted behavior.

- **SpecsPage** — `Add Specification` and the empty-state `Create Specification` button now open a modal form (Topic, Author, Tags, Content). On submit it `POST`s to the existing `POST /api/specs` endpoint via `apiService.post`, then refetches the list and shows a success/error toast. The spec `id` is slugified from the topic to satisfy the server's `/^[a-zA-Z0-9_-]+$/` id validation; `version` defaults to `1.0.0` and `timestamp` to the current ISO time.
- **SpecDetailPage** — `Share` now copies the spec's URL to the clipboard (`navigator.clipboard.writeText`) with success/error toasts. The `Edit` button is removed because there is no backend update endpoint — leaving a dead "Coming Soon" toast would have been misleading.

## Why

These were the primary calls-to-action that previously did nothing but pop a placeholder toast. The backend already exposes a working `POST /api/specs` route (`src/server/routes/specs.ts`), so wiring the create flow reuses existing infrastructure rather than inventing a parallel one.

## Behavior

- Topic and Content are required (validated client-side with an error toast); Author defaults to `Unknown`; Tags are comma-separated and trimmed.
- On API failure the modal stays open and an error toast is shown; the list is not refetched.
- Share degrades gracefully to an error toast (showing the URL) when the Clipboard API is unavailable or denied.

## Verification

- `cd src/client && npx tsc --noEmit` — clean.
- `npx vitest run src/pages/__tests__/SpecsPage.test.tsx src/pages/__tests__/SpecDetailPage.test.tsx` — 6 tests pass (open modal, required-field validation, successful POST + payload assertion + refetch, API-failure handling, clipboard success, clipboard failure).
- Spot-checked related component tests (ToastNotification, Button) — no regressions.

> Note: repo-wide `eslint` is currently broken in this environment due to an `@eslint/eslintrc` + `ajv` dependency conflict (`TypeError: Cannot set properties of undefined (setting 'defaultMeta')`) that reproduces on untouched files too, so lint could not be run. No backend files changed.

## Reviewer notes (best-guess feature)

- The create form fields (topic/author/tags/content, version `1.0.0`) are a best guess at the intended UX — confirm these match the product intent.
- Newly created specs are written to a `specs/` directory + `index.json` on disk by the existing backend route; confirm that storage model is desired in your deployment.
- Removing the `Edit` button is a judgment call (no update endpoint exists). If editing is desired, a `PUT /api/specs/:id` endpoint would be the follow-up.
