### PR TITLE
feat(bots): wire BotSettingsTab to real bot-config API

### DIFF
--- a/src/client/src/pages/BotsPage/BotSettingsTab.tsx
+++ b/src/client/src/pages/BotsPage/BotSettingsTab.tsx
@@ -1,18 +1,132 @@
 import { Info } from 'lucide-react';
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
+import { useErrorToast } from '../../components/DaisyUI/ToastNotification';
+import { useSavedStamp } from '../../contexts/SavedStampContext';
+import { apiService } from '../../services/api';
 import { Alert } from '../../components/DaisyUI/Alert';
 import Card from '../../components/DaisyUI/Card';
 import Select from '../../components/DaisyUI/Select';
 import Toggle from '../../components/DaisyUI/Toggle';
 
+/**
+ * App-wide default settings applied to newly created bots. These are persisted
+ * via the general-settings path of the global config API
+ * (`apiService.updateGlobalConfig` with a flat key patch — no `configName`),
+ * the same mechanism used by the Settings → General panel. Values are namespaced
+ * under `botDefaults.*` so they never collide with convict-backed config sections.
+ */
+interface BotDefaults {
+  autoStart: boolean;
+  llmProfile: string;
+  persona: string;
+  startupGreeting: string;
+  autoReconnect: boolean;
+  maxRetryAttempts: string;
+  suppressDuplicates: boolean;
+  dedupWindowSeconds: string;
+}
+
+const DEFAULTS: BotDefaults = {
+  autoStart: false,
+  llmProfile: '',
+  persona: '',
+  startupGreeting: '',
+  autoReconnect: false,
+  maxRetryAttempts: '',
+  suppressDuplicates: false,
+  dedupWindowSeconds: '',
+};
+
+const KEY_PREFIX = 'botDefaults.';
+
 const BotSettingsTab: React.FC = () => {
   const [showAdvanced, setShowAdvanced] = useLocalStorage('ui.botSettings.showAdvanced', false);
+  const { showStamp } = useSavedStamp();
+  const errorToast = useErrorToast();
+
+  const [settings, setSettings] = useState<BotDefaults>(DEFAULTS);
+  const [personaOptions, setPersonaOptions] = useState<Array<{ id: string; name: string }>>([]);
+  const [llmProfileOptions, setLlmProfileOptions] = useState<
+    Array<{ key: string; name: string }>
+  >([]);
+  const [loading, setLoading] = useState(true);
+
+  // Load saved defaults + the persona / LLM-profile option lists from the same
+  // endpoints the rest of the Bots page uses.
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      const [globalResult, personasResult, profilesResult] = await Promise.allSettled([
+        apiService.getGlobalConfig(),
+        apiService.getPersonas(),
+        apiService.getLlmProfiles(),
+      ]);
+
+      if (!active) return;
+
+      if (globalResult.status === 'fulfilled') {
+        const saved = (globalResult.value as any)?._userSettings?.values ?? {};
+        const next: BotDefaults = { ...DEFAULTS };
+        (Object.keys(DEFAULTS) as Array<keyof BotDefaults>).forEach((field) => {
+          const stored = saved[`${KEY_PREFIX}${field}`];
+          if (stored !== undefined && stored !== null) {
+            (next as any)[field] = stored;
+          }
+        });
+        setSettings(next);
+      }
+
+      if (personasResult.status === 'fulfilled') {
+        const list = (personasResult.value as any[]) ?? [];
+        setPersonaOptions(
+          list
+            .filter((p) => p && p.id)
+            .map((p) => ({ id: String(p.id), name: String(p.name ?? p.id) })),
+        );
+      }
+
+      if (profilesResult.status === 'fulfilled') {
+        const data = profilesResult.value as any;
+        const profiles = data?.llm || data?.profiles?.llm || [];
+        setLlmProfileOptions(
+          (profiles as any[])
+            .filter((p) => p && p.key)
+            .map((p) => ({ key: String(p.key), name: String(p.name ?? p.key) })),
+        );
+      }
+
+      setLoading(false);
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // Persist a single field change. Optimistically updates local state, then saves
+  // via the general-settings path. On failure the previous value is restored and
+  // an error toast is shown.
+  const saveField = useCallback(
+    async <K extends keyof BotDefaults>(field: K, value: BotDefaults[K]) => {
+      const previous = settings[field];
+      setSettings((prev) => ({ ...prev, [field]: value }));
+      try {
+        await apiService.updateGlobalConfig({ [`${KEY_PREFIX}${field}`]: value });
+        showStamp();
+      } catch {
+        setSettings((prev) => ({ ...prev, [field]: previous }));
+        errorToast('Save failed', 'Could not save bot default. Please try again.');
+      }
+    },
+    [settings, showStamp, errorToast],
+  );
 
   return (
     <div className="space-y-6">
       <Alert status="info" icon={<Info className="w-5 h-5" />}>
-        <span>Bot settings API coming soon — these controls are placeholders.</span>
+        <span>
+          Defaults applied to newly created bots. Changes are saved automatically.
+        </span>
       </Alert>
 
       {/* Basic Settings */}
@@ -20,24 +134,46 @@ const BotSettingsTab: React.FC = () => {
         <div className="space-y-4">
           <Toggle
             label="Auto-start on creation"
-            disabled
-            checked={false}
-            onChange={() => {}}
+            disabled={loading}
+            checked={settings.autoStart}
+            onChange={(e) => saveField('autoStart', e.target.checked)}
           />
           <div className="form-control w-full max-w-xs">
             <label className="label">
               <span className="label-text">Default LLM Profile</span>
             </label>
-            <Select disabled className="select-bordered" size="sm">
-              <option>Select LLM profile...</option>
+            <Select
+              className="select-bordered"
+              size="sm"
+              disabled={loading}
+              value={settings.llmProfile}
+              onChange={(e) => saveField('llmProfile', e.target.value)}
+            >
+              <option value="">System default</option>
+              {llmProfileOptions.map((p) => (
+                <option key={p.key} value={p.key}>
+                  {p.name}
+                </option>
+              ))}
             </Select>
           </div>
           <div className="form-control w-full max-w-xs">
             <label className="label">
               <span className="label-text">Default Persona</span>
             </label>
-            <Select disabled className="select-bordered" size="sm">
-              <option>Select persona...</option>
+            <Select
+              className="select-bordered"
+              size="sm"
+              disabled={loading}
+              value={settings.persona}
+              onChange={(e) => saveField('persona', e.target.value)}
+            >
+              <option value="">Default persona</option>
+              {personaOptions.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
             </Select>
           </div>
         </div>
@@ -62,8 +198,13 @@ const BotSettingsTab: React.FC = () => {
             <textarea
               className="textarea textarea-bordered w-full mt-2"
               placeholder="Hello! I'm ready to help."
-              disabled
+              disabled={loading}
               rows={3}
+              value={settings.startupGreeting}
+              onChange={(e) =>
+                setSettings((prev) => ({ ...prev, startupGreeting: e.target.value }))
+              }
+              onBlur={(e) => saveField('startupGreeting', e.target.value)}
             />
           </Card>
 
@@ -71,9 +212,9 @@ const BotSettingsTab: React.FC = () => {
             <div className="space-y-3">
               <Toggle
                 label="Auto-reconnect on disconnect"
-                disabled
-                checked={false}
-                onChange={() => {}}
+                disabled={loading}
+                checked={settings.autoReconnect}
+                onChange={(e) => saveField('autoReconnect', e.target.checked)}
               />
               <div className="form-control w-full max-w-xs">
                 <label className="label">
@@ -83,7 +224,12 @@ const BotSettingsTab: React.FC = () => {
                   type="number"
                   className="input input-bordered input-sm w-full max-w-xs"
                   placeholder="3"
-                  disabled
+                  disabled={loading}
+                  value={settings.maxRetryAttempts}
+                  onChange={(e) =>
+                    setSettings((prev) => ({ ...prev, maxRetryAttempts: e.target.value }))
+                  }
+                  onBlur={(e) => saveField('maxRetryAttempts', e.target.value)}
                 />
               </div>
             </div>
@@ -93,9 +239,9 @@ const BotSettingsTab: React.FC = () => {
             <div className="space-y-3">
               <Toggle
                 label="Suppress duplicate responses"
-                disabled
-                checked={false}
-                onChange={() => {}}
+                disabled={loading}
+                checked={settings.suppressDuplicates}
+                onChange={(e) => saveField('suppressDuplicates', e.target.checked)}
               />
               <div className="form-control w-full max-w-xs">
                 <label className="label">
@@ -105,7 +251,12 @@ const BotSettingsTab: React.FC = () => {
                   type="number"
                   className="input input-bordered input-sm w-full max-w-xs"
                   placeholder="5"
-                  disabled
+                  disabled={loading}
+                  value={settings.dedupWindowSeconds}
+                  onChange={(e) =>
+                    setSettings((prev) => ({ ...prev, dedupWindowSeconds: e.target.value }))
+                  }
+                  onBlur={(e) => saveField('dedupWindowSeconds', e.target.value)}
                 />
               </div>
             </div>

--- a/src/client/src/pages/BotsPage/BotSettingsTab.tsx
+++ b/src/client/src/pages/BotsPage/BotSettingsTab.tsx
@@ -22,9 +22,9 @@ interface BotDefaults {
   persona: string;
   startupGreeting: string;
   autoReconnect: boolean;
-  maxRetryAttempts: string;
+  maxRetryAttempts: number;
   suppressDuplicates: boolean;
-  dedupWindowSeconds: string;
+  dedupWindowSeconds: number;
 }
 
 const DEFAULTS: BotDefaults = {
@@ -33,9 +33,9 @@ const DEFAULTS: BotDefaults = {
   persona: '',
   startupGreeting: '',
   autoReconnect: false,
-  maxRetryAttempts: '',
+  maxRetryAttempts: 3,
   suppressDuplicates: false,
-  dedupWindowSeconds: '',
+  dedupWindowSeconds: 5,
 };
 
 const KEY_PREFIX = 'botDefaults.';
@@ -71,7 +71,10 @@ const BotSettingsTab: React.FC = () => {
         (Object.keys(DEFAULTS) as Array<keyof BotDefaults>).forEach((field) => {
           const stored = saved[`${KEY_PREFIX}${field}`];
           if (stored !== undefined && stored !== null) {
-            (next as any)[field] = stored;
+            // Coerce to the field's declared type so number inputs receive numbers
+            // even if the API returned the value as a string.
+            (next as any)[field] =
+              typeof DEFAULTS[field] === 'number' ? Number(stored) || 0 : stored;
           }
         });
         setSettings(next);
@@ -107,18 +110,25 @@ const BotSettingsTab: React.FC = () => {
   // via the general-settings path. On failure the previous value is restored and
   // an error toast is shown.
   const saveField = useCallback(
-    async <K extends keyof BotDefaults>(field: K, value: BotDefaults[K]) => {
-      const previous = settings[field];
-      setSettings((prev) => ({ ...prev, [field]: value }));
-      try {
-        await apiService.updateGlobalConfig({ [`${KEY_PREFIX}${field}`]: value });
-        showStamp();
-      } catch {
-        setSettings((prev) => ({ ...prev, [field]: previous }));
-        errorToast('Save failed', 'Could not save bot default. Please try again.');
-      }
+    <K extends keyof BotDefaults>(field: K, value: BotDefaults[K]) => {
+      setSettings((prev) => {
+        const previous = prev[field];
+        // Optimistically update, capturing the up-to-date previous value for rollback.
+        const next = { ...prev, [field]: value };
+
+        // Save in the background; restore the captured value if it fails.
+        apiService
+          .updateGlobalConfig({ [`${KEY_PREFIX}${field}`]: value })
+          .then(() => showStamp())
+          .catch(() => {
+            setSettings((current) => ({ ...current, [field]: previous }));
+            errorToast('Save failed', 'Could not save bot default. Please try again.');
+          });
+
+        return next;
+      });
     },
-    [settings, showStamp, errorToast],
+    [showStamp, errorToast],
   );
 
   return (
@@ -227,9 +237,9 @@ const BotSettingsTab: React.FC = () => {
                   disabled={loading}
                   value={settings.maxRetryAttempts}
                   onChange={(e) =>
-                    setSettings((prev) => ({ ...prev, maxRetryAttempts: e.target.value }))
+                    setSettings((prev) => ({ ...prev, maxRetryAttempts: Number(e.target.value) || 0 }))
                   }
-                  onBlur={(e) => saveField('maxRetryAttempts', e.target.value)}
+                  onBlur={(e) => saveField('maxRetryAttempts', Number(e.target.value) || 0)}
                 />
               </div>
             </div>
@@ -254,9 +264,9 @@ const BotSettingsTab: React.FC = () => {
                   disabled={loading}
                   value={settings.dedupWindowSeconds}
                   onChange={(e) =>
-                    setSettings((prev) => ({ ...prev, dedupWindowSeconds: e.target.value }))
+                    setSettings((prev) => ({ ...prev, dedupWindowSeconds: Number(e.target.value) || 0 }))
                   }
-                  onBlur={(e) => saveField('dedupWindowSeconds', e.target.value)}
+                  onBlur={(e) => saveField('dedupWindowSeconds', Number(e.target.value) || 0)}
                 />
               </div>
             </div>

--- a/src/client/src/pages/BotsPage/__tests__/BotSettingsTab.test.tsx
+++ b/src/client/src/pages/BotsPage/__tests__/BotSettingsTab.test.tsx
@@ -117,4 +117,92 @@ describe('BotSettingsTab', () => {
     });
     await waitFor(() => expect(autoStart.checked).toBe(true));
   });
+
+  it('saves numeric defaults as numbers, not strings', async () => {
+    render(<BotSettingsTab />);
+
+    // Reveal the advanced section that holds the numeric inputs.
+    const advancedToggle = (await screen.findByRole('switch', {
+      name: /Advanced/i,
+    })) as HTMLInputElement;
+    fireEvent.click(advancedToggle);
+
+    const maxRetry = (await screen.findByPlaceholderText('3')) as HTMLInputElement;
+    fireEvent.change(maxRetry, { target: { value: '7' } });
+    fireEvent.blur(maxRetry);
+
+    await waitFor(() => {
+      expect(updateGlobalConfigMock).toHaveBeenCalledWith({
+        'botDefaults.maxRetryAttempts': 7,
+      });
+    });
+  });
+
+  it('surfaces an error toast when a numeric save fails', async () => {
+    updateGlobalConfigMock.mockRejectedValueOnce(new Error('network'));
+    render(<BotSettingsTab />);
+
+    const advancedToggle = (await screen.findByRole('switch', {
+      name: /Advanced/i,
+    })) as HTMLInputElement;
+    fireEvent.click(advancedToggle);
+
+    const dedup = (await screen.findByPlaceholderText('5')) as HTMLInputElement;
+    fireEvent.change(dedup, { target: { value: '9' } });
+    fireEvent.blur(dedup);
+
+    await waitFor(() => {
+      expect(updateGlobalConfigMock).toHaveBeenCalledWith({ 'botDefaults.dedupWindowSeconds': 9 });
+    });
+    await waitFor(() => expect(errorToastMock).toHaveBeenCalled());
+  });
+
+  it('rolls back to the captured value when a direct save fails (closure freshness)', async () => {
+    // Toggles call saveField directly, so the rollback target is meaningful.
+    // The first save (autoReconnect) fails AFTER a prior successful change,
+    // proving saveField captures the up-to-date previous value, not a stale one.
+    render(<BotSettingsTab />);
+
+    const advancedToggle = (await screen.findByRole('switch', {
+      name: /Advanced/i,
+    })) as HTMLInputElement;
+    fireEvent.click(advancedToggle);
+
+    const autoReconnect = (await screen.findByRole('switch', {
+      name: /Auto-reconnect on disconnect/i,
+    })) as HTMLInputElement;
+    expect(autoReconnect.checked).toBe(false);
+
+    // First toggle succeeds -> now true.
+    fireEvent.click(autoReconnect);
+    await waitFor(() => expect(autoReconnect.checked).toBe(true));
+
+    // Second toggle fails -> must roll back to the freshly-captured true.
+    updateGlobalConfigMock.mockRejectedValueOnce(new Error('network'));
+    fireEvent.click(autoReconnect);
+    await waitFor(() => expect(errorToastMock).toHaveBeenCalled());
+    await waitFor(() => expect(autoReconnect.checked).toBe(true));
+  });
+
+  it('coerces stored numeric defaults that arrive as strings', async () => {
+    getGlobalConfigMock.mockResolvedValueOnce({
+      _userSettings: {
+        values: {
+          'botDefaults.maxRetryAttempts': '8',
+          'botDefaults.dedupWindowSeconds': '12',
+        },
+      },
+    });
+    render(<BotSettingsTab />);
+
+    const advancedToggle = (await screen.findByRole('switch', {
+      name: /Advanced/i,
+    })) as HTMLInputElement;
+    fireEvent.click(advancedToggle);
+
+    const maxRetry = (await screen.findByPlaceholderText('3')) as HTMLInputElement;
+    expect(maxRetry.value).toBe('8');
+    const dedup = (await screen.findByPlaceholderText('5')) as HTMLInputElement;
+    expect(dedup.value).toBe('12');
+  });
 });

--- a/src/client/src/pages/BotsPage/__tests__/BotSettingsTab.test.tsx
+++ b/src/client/src/pages/BotsPage/__tests__/BotSettingsTab.test.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const getGlobalConfigMock = vi.fn();
+const getPersonasMock = vi.fn();
+const getLlmProfilesMock = vi.fn();
+const updateGlobalConfigMock = vi.fn();
+
+vi.mock('../../../services/api', () => ({
+  apiService: {
+    getGlobalConfig: (...args: unknown[]) => getGlobalConfigMock(...args),
+    getPersonas: (...args: unknown[]) => getPersonasMock(...args),
+    getLlmProfiles: (...args: unknown[]) => getLlmProfilesMock(...args),
+    updateGlobalConfig: (...args: unknown[]) => updateGlobalConfigMock(...args),
+  },
+}));
+
+const showStampMock = vi.fn();
+vi.mock('../../../contexts/SavedStampContext', () => ({
+  useSavedStamp: () => ({ showStamp: showStampMock }),
+}));
+
+const errorToastMock = vi.fn();
+vi.mock('../../../components/DaisyUI/ToastNotification', () => ({
+  useErrorToast: () => errorToastMock,
+}));
+
+// localStorage hook — keep advanced section collapsed by default but controllable.
+vi.mock('../../../hooks/useLocalStorage', () => ({
+  useLocalStorage: (_key: string, initial: boolean) => {
+    const [value, setValue] = React.useState(initial);
+    return [value, setValue];
+  },
+}));
+
+import BotSettingsTab from '../BotSettingsTab';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getGlobalConfigMock.mockResolvedValue({
+    _userSettings: {
+      values: {
+        'botDefaults.autoStart': true,
+        'botDefaults.llmProfile': 'gpt4',
+      },
+    },
+  });
+  getPersonasMock.mockResolvedValue([
+    { id: 'p1', name: 'Helpful Assistant' },
+    { id: 'p2', name: 'Code Reviewer' },
+  ]);
+  getLlmProfilesMock.mockResolvedValue({
+    llm: [
+      { key: 'gpt4', name: 'GPT-4' },
+      { key: 'claude', name: 'Claude' },
+    ],
+  });
+  updateGlobalConfigMock.mockResolvedValue({ success: true });
+});
+
+describe('BotSettingsTab', () => {
+  it('loads persona and LLM profile options from the API', async () => {
+    render(<BotSettingsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Helpful Assistant')).toBeTruthy();
+    });
+    expect(screen.getByText('Code Reviewer')).toBeTruthy();
+    expect(screen.getByText('GPT-4')).toBeTruthy();
+    expect(screen.getByText('Claude')).toBeTruthy();
+
+    expect(getGlobalConfigMock).toHaveBeenCalledTimes(1);
+    expect(getPersonasMock).toHaveBeenCalledTimes(1);
+    expect(getLlmProfilesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('hydrates controls from saved general settings', async () => {
+    render(<BotSettingsTab />);
+
+    const autoStart = await screen.findByRole('switch', { name: /Auto-start on creation/i });
+    await waitFor(() => expect((autoStart as HTMLInputElement).checked).toBe(true));
+
+    const llmSelect = screen.getByDisplayValue('GPT-4') as HTMLSelectElement;
+    expect(llmSelect.value).toBe('gpt4');
+  });
+
+  it('persists a change through updateGlobalConfig and shows the saved stamp', async () => {
+    render(<BotSettingsTab />);
+
+    const personaSelect = (await screen.findByText('Helpful Assistant')).closest('select')!;
+    fireEvent.change(personaSelect, { target: { value: 'p2' } });
+
+    await waitFor(() => {
+      expect(updateGlobalConfigMock).toHaveBeenCalledWith({ 'botDefaults.persona': 'p2' });
+    });
+    expect(showStampMock).toHaveBeenCalled();
+  });
+
+  it('reverts and shows an error toast when the save fails', async () => {
+    updateGlobalConfigMock.mockRejectedValueOnce(new Error('network'));
+    render(<BotSettingsTab />);
+
+    const autoStart = (await screen.findByRole('switch', {
+      name: /Auto-start on creation/i,
+    })) as HTMLInputElement;
+    await waitFor(() => expect(autoStart.checked).toBe(true));
+
+    fireEvent.click(autoStart); // toggle off -> save rejects -> revert to true
+
+    await waitFor(() => {
+      expect(errorToastMock).toHaveBeenCalled();
+    });
+    await waitFor(() => expect(autoStart.checked).toBe(true));
+  });
+});


### PR DESCRIPTION
## What

Replaces the placeholder Bot Settings tab (`src/client/src/pages/BotsPage/BotSettingsTab.tsx`) — previously a static "Bot settings API coming soon — these controls are placeholders" panel with all controls `disabled` — with real, persisted controls wired to the existing global-config API.

## Why

The tab rendered dead, disabled inputs. This wires the same controls that already exist in the design to real data and a real persistence path, reusing existing services rather than inventing new endpoints.

## Behavior

- **Options** are loaded from the same endpoints the rest of the Bots page already uses: `apiService.getPersonas()` (Default Persona) and `apiService.getLlmProfiles()` (Default LLM Profile).
- **Saved values** are hydrated from `apiService.getGlobalConfig()` via its `_userSettings.values` general-settings bag.
- **Persistence** goes through `apiService.updateGlobalConfig({ 'botDefaults.<field>': value })` — the no-`configName` general-settings path that writes to `user-config.json` (the same auto-save mechanism used by Settings → General / `SettingsGeneral.tsx`). Keys are namespaced under `botDefaults.*` so they never collide with convict-backed config sections.
- Each control auto-saves on change/blur with an optimistic update; on failure the previous value is restored and an error toast is shown. Success triggers the existing `showStamp()` "SAVED" animation.
- No new backend code, routes, or endpoints. The Advanced section (greeting, reconnection, dedup) is now enabled and persisted the same way.

## Verification

- `cd src/client && npx tsc --noEmit` — clean
- `npx eslint <changed files>` — 0 errors, 0 warnings
- `npx vitest run src/pages/BotsPage/__tests__/BotSettingsTab.test.tsx` — 4/4 pass (load options, hydrate from saved settings, persist + stamp, revert + error toast on failure)
- `npx vitest run src/pages/BotsPage/__tests__/index.test.tsx` — 9/9 pass (no regression)

## Review notes

This is a best-guess product wiring. Reviewers should confirm:
- Storing these defaults under `botDefaults.*` in the general-settings bag is the intended home (vs. a dedicated config section or per-bot config). They are **persisted but not yet consumed** by bot-creation logic — this PR only saves them; a follow-up would read `botDefaults.*` when creating bots.
- The auto-save-on-change UX (no explicit Save button) matches the existing `SettingsGeneral` pattern and is acceptable here.
