### PR TITLE
feat(guards): wire global guard settings to backend

### DIFF
--- a/src/client/src/pages/GuardsPage.tsx
+++ b/src/client/src/pages/GuardsPage.tsx
@@ -15,13 +15,21 @@ import Button from '../components/DaisyUI/Button';
 import Toggle from '../components/DaisyUI/Toggle';
 import Select from '../components/DaisyUI/Select';
 import Tabs from '../components/DaisyUI/Tabs';
-import Textarea from '../components/DaisyUI/Textarea';
 import { ConfirmModal } from '../components/DaisyUI/Modal';
 import ModalForm from '../components/DaisyUI/ModalForm';
 import { FormField } from '../components/DaisyUI/formTypes';
 import RangeSlider from '../components/DaisyUI/RangeSlider';
 import { Badge } from '../components/DaisyUI/Badge';
 import Accordion from '../components/DaisyUI/Accordion';
+import {
+  coerceGuardSettings,
+  settingsEqual,
+  windowSecondsToMs,
+  clampMaxRequests,
+  formatWindow,
+  DEFAULT_GUARD_SETTINGS,
+  type GuardSettings,
+} from './guardSettings';
 export interface GuardProfile {
   id: string;
   name: string;
@@ -152,9 +160,58 @@ const GuardStatusRow: React.FC<{ icon: React.ReactNode; label: string; enabled: 
   </div>
 );
 
-/** Guard Settings tab (placeholder — no settings API yet) */
+/**
+ * Guard Settings tab — wired to GET/PUT /api/admin/guard-profiles/settings.
+ * Edits global defaults applied to newly created guard profiles plus the
+ * guard evaluation order.
+ */
 const GuardSettingsTab: React.FC = () => {
+  const { addToast } = useToast();
+  const queryClient = useQueryClient();
   const [showAdvanced, setShowAdvanced] = useLocalStorage('ui.guardSettings.showAdvanced', false);
+  const [draft, setDraft] = useState<GuardSettings>(DEFAULT_GUARD_SETTINGS);
+
+  const { data: settings, isLoading } = useQuery<GuardSettings>({
+    queryKey: ['guardSettings'],
+    queryFn: async () => {
+      const res = await authFetch('/api/admin/guard-profiles/settings');
+      if (!res.ok) throw new Error('Failed to fetch guard settings');
+      const json = await res.json();
+      return coerceGuardSettings(json?.data);
+    },
+  });
+
+  // Sync the server value into the local draft once it loads / changes.
+  React.useEffect(() => {
+    if (settings) setDraft(settings);
+  }, [settings]);
+
+  const saveMutation = useMutation({
+    mutationFn: async (next: GuardSettings) => {
+      const res = await authFetch('/api/admin/guard-profiles/settings', {
+        method: 'PUT',
+        body: JSON.stringify(next),
+      });
+      if (!res.ok) throw new Error('Failed to save guard settings');
+      const json = await res.json();
+      return coerceGuardSettings(json?.data);
+    },
+    onSuccess: (saved) => {
+      queryClient.setQueryData(['guardSettings'], saved);
+      setDraft(saved);
+      addToast({ type: 'success', title: 'Saved', message: 'Guard settings updated' });
+    },
+    onError: (error) => {
+      addToast({
+        type: 'error',
+        title: 'Error',
+        message: error instanceof Error ? error.message : 'Failed to save guard settings',
+      });
+    },
+  });
+
+  const dirty = !settings || !settingsEqual(draft, settings);
+  const windowSeconds = Math.round(draft.defaultRateLimit.windowMs / 1000);
 
   return (
     <div className="space-y-6">
@@ -166,22 +223,43 @@ const GuardSettingsTab: React.FC = () => {
 
         <div className="space-y-4">
           {/* Default rate limit */}
-          <div className="form-control opacity-50 pointer-events-none">
+          <div className="form-control">
             <label className="label"><span className="label-text font-medium">Default Rate Limit</span></label>
             <div className="grid grid-cols-2 gap-4">
               <Input
                 label="Max Requests"
                 type="number"
-                value={100}
-                readOnly
-                disabled
+                min={1}
+                max={1000000}
+                value={draft.defaultRateLimit.maxRequests}
+                disabled={isLoading}
+                onChange={e =>
+                  setDraft(d => ({
+                    ...d,
+                    defaultRateLimit: {
+                      ...d.defaultRateLimit,
+                      maxRequests: clampMaxRequests(parseInt(e.target.value, 10) || 1),
+                    },
+                  }))
+                }
               />
               <Input
                 label="Window (seconds)"
                 type="number"
-                value={60}
-                readOnly
-                disabled
+                min={1}
+                max={3600}
+                value={windowSeconds}
+                disabled={isLoading}
+                helperText={formatWindow(draft.defaultRateLimit.windowMs)}
+                onChange={e =>
+                  setDraft(d => ({
+                    ...d,
+                    defaultRateLimit: {
+                      ...d.defaultRateLimit,
+                      windowMs: windowSecondsToMs(parseInt(e.target.value, 10) || 1),
+                    },
+                  }))
+                }
               />
             </div>
             <label className="label">
@@ -194,11 +272,17 @@ const GuardSettingsTab: React.FC = () => {
           <Divider>Content Filtering</Divider>
 
           {/* Default content filter level */}
-          <div className="form-control opacity-50 pointer-events-none">
+          <div className="form-control">
             <label className="label"><span className="label-text font-medium">Default Content Filter Level</span></label>
             <Select
-              disabled
-              value="medium"
+              disabled={isLoading}
+              value={draft.defaultContentFilterStrictness}
+              onChange={e =>
+                setDraft(d => ({
+                  ...d,
+                  defaultContentFilterStrictness: e.target.value as GuardSettings['defaultContentFilterStrictness'],
+                }))
+              }
               options={[
                 { value: 'low', label: 'Low' },
                 { value: 'medium', label: 'Medium' },
@@ -208,8 +292,15 @@ const GuardSettingsTab: React.FC = () => {
           </div>
         </div>
 
-        <div className="mt-6 p-4 bg-info/10 rounded-lg text-info text-sm">
-          Guard settings coming soon. These controls will be connected in a future release.
+        <div className="mt-6 flex justify-end">
+          <Button
+            variant="primary"
+            loading={saveMutation.isPending}
+            disabled={!dirty || isLoading}
+            onClick={() => saveMutation.mutate(draft)}
+          >
+            Save Settings
+          </Button>
         </div>
       </Card>
 
@@ -224,28 +315,29 @@ const GuardSettingsTab: React.FC = () => {
         {showAdvanced && (
           <div className="mt-4 space-y-4 animate-fadeIn">
             <Divider>Advanced Guard Settings</Divider>
-            <div className="form-control opacity-50 pointer-events-none">
-              <label className="label"><span className="label-text">Custom Rule Configuration</span></label>
-              <Textarea
-                disabled
-                placeholder="Define custom guard rules in JSON format..."
-                rows={4}
-              />
-            </div>
-            <div className="form-control opacity-50 pointer-events-none">
-              <label className="label"><span className="label-text">Guard Evaluation Order</span></label>
+            <div className="form-control">
+              <label className="label" htmlFor="guard-evaluation-order"><span className="label-text">Guard Evaluation Order</span></label>
               <Select
-                disabled
-                value="sequential"
+                id="guard-evaluation-order"
+                disabled={isLoading}
+                value={draft.evaluationOrder}
+                onChange={e =>
+                  setDraft(d => ({
+                    ...d,
+                    evaluationOrder: e.target.value as GuardSettings['evaluationOrder'],
+                  }))
+                }
                 options={[
                   { value: 'sequential', label: 'Sequential (all guards run in order)' },
                   { value: 'parallel', label: 'Parallel (all guards run simultaneously)' },
                   { value: 'fail-fast', label: 'Fail-Fast (stop on first failure)' },
                 ]}
               />
-            </div>
-            <div className="p-4 bg-info/10 rounded-lg text-info text-sm">
-              Advanced guard settings coming soon.
+              <label className="label">
+                <span className="label-text-alt text-base-content/50">
+                  Controls how multiple guards are evaluated for a request.
+                </span>
+              </label>
             </div>
           </div>
         )}

--- a/src/client/src/pages/guardSettings.test.ts
+++ b/src/client/src/pages/guardSettings.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import {
+  coerceGuardSettings,
+  settingsEqual,
+  windowSecondsToMs,
+  clampMaxRequests,
+  formatWindow,
+  DEFAULT_GUARD_SETTINGS,
+  type GuardSettings,
+} from './guardSettings';
+
+describe('guardSettings logic', () => {
+  describe('coerceGuardSettings', () => {
+    it('returns defaults for non-object input', () => {
+      expect(coerceGuardSettings(null)).toEqual(DEFAULT_GUARD_SETTINGS);
+      expect(coerceGuardSettings(undefined)).toEqual(DEFAULT_GUARD_SETTINGS);
+      expect(coerceGuardSettings('garbage')).toEqual(DEFAULT_GUARD_SETTINGS);
+    });
+
+    it('preserves valid values', () => {
+      const input = {
+        defaultRateLimit: { maxRequests: 25, windowMs: 30000 },
+        defaultContentFilterStrictness: 'high',
+        evaluationOrder: 'fail-fast',
+      };
+      expect(coerceGuardSettings(input)).toEqual(input);
+    });
+
+    it('falls back per-field for invalid values', () => {
+      const result = coerceGuardSettings({
+        defaultRateLimit: { maxRequests: -5, windowMs: 10 },
+        defaultContentFilterStrictness: 'extreme',
+        evaluationOrder: 'random',
+      });
+      expect(result.defaultRateLimit.maxRequests).toBe(
+        DEFAULT_GUARD_SETTINGS.defaultRateLimit.maxRequests
+      );
+      // windowMs < 1000 is rejected
+      expect(result.defaultRateLimit.windowMs).toBe(
+        DEFAULT_GUARD_SETTINGS.defaultRateLimit.windowMs
+      );
+      expect(result.defaultContentFilterStrictness).toBe('medium');
+      expect(result.evaluationOrder).toBe('sequential');
+    });
+
+    it('floors fractional numbers', () => {
+      const result = coerceGuardSettings({
+        defaultRateLimit: { maxRequests: 12.9, windowMs: 5500.7 },
+      });
+      expect(result.defaultRateLimit.maxRequests).toBe(12);
+      expect(result.defaultRateLimit.windowMs).toBe(5500);
+    });
+  });
+
+  describe('windowSecondsToMs', () => {
+    it('clamps to the [1, 3600] second range and converts to ms', () => {
+      expect(windowSecondsToMs(60)).toBe(60000);
+      expect(windowSecondsToMs(0)).toBe(1000);
+      expect(windowSecondsToMs(-10)).toBe(1000);
+      expect(windowSecondsToMs(99999)).toBe(3600000);
+      expect(windowSecondsToMs(NaN)).toBe(1000);
+    });
+  });
+
+  describe('clampMaxRequests', () => {
+    it('clamps to [1, 1000000]', () => {
+      expect(clampMaxRequests(50)).toBe(50);
+      expect(clampMaxRequests(0)).toBe(1);
+      expect(clampMaxRequests(-3)).toBe(1);
+      expect(clampMaxRequests(9999999)).toBe(1000000);
+      expect(clampMaxRequests(NaN)).toBe(1);
+    });
+  });
+
+  describe('formatWindow', () => {
+    it('formats sub-minute windows', () => {
+      expect(formatWindow(1000)).toBe('1 second');
+      expect(formatWindow(30000)).toBe('30 seconds');
+    });
+    it('formats minute boundaries', () => {
+      expect(formatWindow(60000)).toBe('1 minute');
+      expect(formatWindow(150000)).toBe('2 min 30s');
+      expect(formatWindow(120000)).toBe('2 minutes');
+    });
+    it('formats an hour', () => {
+      expect(formatWindow(3600000)).toBe('1 hour');
+    });
+  });
+
+  describe('settingsEqual', () => {
+    const base: GuardSettings = {
+      defaultRateLimit: { maxRequests: 100, windowMs: 60000 },
+      defaultContentFilterStrictness: 'medium',
+      evaluationOrder: 'sequential',
+    };
+
+    it('is true for value-equal objects', () => {
+      expect(settingsEqual(base, { ...base, defaultRateLimit: { ...base.defaultRateLimit } })).toBe(
+        true
+      );
+    });
+
+    it('detects every changed field', () => {
+      expect(
+        settingsEqual(base, {
+          ...base,
+          defaultRateLimit: { ...base.defaultRateLimit, maxRequests: 99 },
+        })
+      ).toBe(false);
+      expect(
+        settingsEqual(base, {
+          ...base,
+          defaultRateLimit: { ...base.defaultRateLimit, windowMs: 30000 },
+        })
+      ).toBe(false);
+      expect(settingsEqual(base, { ...base, defaultContentFilterStrictness: 'high' })).toBe(false);
+      expect(settingsEqual(base, { ...base, evaluationOrder: 'parallel' })).toBe(false);
+    });
+  });
+});

--- a/src/client/src/pages/guardSettings.ts
+++ b/src/client/src/pages/guardSettings.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure logic for the Guard Settings tab — kept separate from the React component
+ * so it can be unit-tested without rendering. Mirrors the backend GuardSettings
+ * shape served by GET/PUT /api/admin/guard-profiles/settings.
+ */
+
+export type GuardStrictness = 'low' | 'medium' | 'high';
+export type GuardEvaluationOrder = 'sequential' | 'parallel' | 'fail-fast';
+
+export interface GuardSettings {
+  defaultRateLimit: {
+    maxRequests: number;
+    windowMs: number;
+  };
+  defaultContentFilterStrictness: GuardStrictness;
+  evaluationOrder: GuardEvaluationOrder;
+}
+
+export const DEFAULT_GUARD_SETTINGS: GuardSettings = {
+  defaultRateLimit: { maxRequests: 100, windowMs: 60000 },
+  defaultContentFilterStrictness: 'medium',
+  evaluationOrder: 'sequential',
+};
+
+const STRICTNESS: GuardStrictness[] = ['low', 'medium', 'high'];
+const ORDERS: GuardEvaluationOrder[] = ['sequential', 'parallel', 'fail-fast'];
+
+/** Coerce a server response (which may be partial/garbage) into valid settings. */
+export const coerceGuardSettings = (input: unknown): GuardSettings => {
+  const obj = (input && typeof input === 'object' ? input : {}) as Record<string, unknown>;
+  const rl = (
+    obj.defaultRateLimit && typeof obj.defaultRateLimit === 'object' ? obj.defaultRateLimit : {}
+  ) as Record<string, unknown>;
+
+  const maxRequests = Number(rl.maxRequests);
+  const windowMs = Number(rl.windowMs);
+  const strictness = obj.defaultContentFilterStrictness as GuardStrictness;
+  const order = obj.evaluationOrder as GuardEvaluationOrder;
+
+  return {
+    defaultRateLimit: {
+      maxRequests:
+        Number.isFinite(maxRequests) && maxRequests >= 1
+          ? Math.floor(maxRequests)
+          : DEFAULT_GUARD_SETTINGS.defaultRateLimit.maxRequests,
+      windowMs:
+        Number.isFinite(windowMs) && windowMs >= 1000
+          ? Math.floor(windowMs)
+          : DEFAULT_GUARD_SETTINGS.defaultRateLimit.windowMs,
+    },
+    defaultContentFilterStrictness: STRICTNESS.includes(strictness)
+      ? strictness
+      : DEFAULT_GUARD_SETTINGS.defaultContentFilterStrictness,
+    evaluationOrder: ORDERS.includes(order)
+      ? order
+      : DEFAULT_GUARD_SETTINGS.evaluationOrder,
+  };
+};
+
+/**
+ * Convert a UI window value in seconds into a settings object delta.
+ * Clamps to [1, 3600] seconds, matching the per-profile editor's range.
+ */
+export const windowSecondsToMs = (seconds: number): number => {
+  const clamped = Math.max(1, Math.min(3600, Math.floor(Number.isFinite(seconds) ? seconds : 1)));
+  return clamped * 1000;
+};
+
+/** Clamp a max-requests value to the editor's supported range [1, 1000000]. */
+export const clampMaxRequests = (value: number): number => {
+  const n = Math.floor(Number.isFinite(value) ? value : 1);
+  return Math.max(1, Math.min(1000000, n));
+};
+
+/** Human-readable label for a rate-limit window in milliseconds. */
+export const formatWindow = (windowMs: number): string => {
+  const seconds = Math.round(windowMs / 1000);
+  if (seconds < 60) return `${seconds} second${seconds === 1 ? '' : 's'}`;
+  if (seconds === 60) return '1 minute';
+  if (seconds < 3600) {
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return s === 0 ? `${m} minutes` : `${m} min ${s}s`;
+  }
+  return '1 hour';
+};
+
+/** True when two settings objects are value-equal (used to disable the Save button). */
+export const settingsEqual = (a: GuardSettings, b: GuardSettings): boolean =>
+  a.defaultRateLimit.maxRequests === b.defaultRateLimit.maxRequests &&
+  a.defaultRateLimit.windowMs === b.defaultRateLimit.windowMs &&
+  a.defaultContentFilterStrictness === b.defaultContentFilterStrictness &&
+  a.evaluationOrder === b.evaluationOrder;

--- a/src/config/guardSettings.ts
+++ b/src/config/guardSettings.ts
@@ -1,0 +1,89 @@
+import { loadProfiles, saveProfiles } from './profileUtils';
+
+/**
+ * Global guard defaults applied to newly created guard profiles.
+ * Persisted alongside the guardrail profiles via the same JSON-file mechanism.
+ */
+export interface GuardSettings {
+  /** Default rate limit applied to new guard profiles. */
+  defaultRateLimit: {
+    maxRequests: number;
+    windowMs: number;
+  };
+  /** Default content-filter strictness applied to new guard profiles. */
+  defaultContentFilterStrictness: 'low' | 'medium' | 'high';
+  /** Order in which guards are evaluated. */
+  evaluationOrder: 'sequential' | 'parallel' | 'fail-fast';
+}
+
+export const DEFAULT_GUARD_SETTINGS: GuardSettings = {
+  defaultRateLimit: {
+    maxRequests: 100,
+    windowMs: 60000,
+  },
+  defaultContentFilterStrictness: 'medium',
+  evaluationOrder: 'sequential',
+};
+
+const STRICTNESS_VALUES: GuardSettings['defaultContentFilterStrictness'][] = [
+  'low',
+  'medium',
+  'high',
+];
+const EVALUATION_ORDER_VALUES: GuardSettings['evaluationOrder'][] = [
+  'sequential',
+  'parallel',
+  'fail-fast',
+];
+
+/**
+ * Coerce arbitrary parsed JSON into a well-formed GuardSettings object,
+ * falling back to defaults for any missing or invalid field.
+ */
+export const normalizeGuardSettings = (parsed: unknown): GuardSettings => {
+  const input = (parsed && typeof parsed === 'object' ? parsed : {}) as Record<string, unknown>;
+  const rateLimit = (
+    input.defaultRateLimit && typeof input.defaultRateLimit === 'object'
+      ? input.defaultRateLimit
+      : {}
+  ) as Record<string, unknown>;
+
+  const maxRequests = Number(rateLimit.maxRequests);
+  const windowMs = Number(rateLimit.windowMs);
+  const strictness = input.defaultContentFilterStrictness as GuardSettings['defaultContentFilterStrictness'];
+  const order = input.evaluationOrder as GuardSettings['evaluationOrder'];
+
+  return {
+    defaultRateLimit: {
+      maxRequests:
+        Number.isFinite(maxRequests) && maxRequests >= 1
+          ? Math.floor(maxRequests)
+          : DEFAULT_GUARD_SETTINGS.defaultRateLimit.maxRequests,
+      windowMs:
+        Number.isFinite(windowMs) && windowMs >= 1000
+          ? Math.floor(windowMs)
+          : DEFAULT_GUARD_SETTINGS.defaultRateLimit.windowMs,
+    },
+    defaultContentFilterStrictness: STRICTNESS_VALUES.includes(strictness)
+      ? strictness
+      : DEFAULT_GUARD_SETTINGS.defaultContentFilterStrictness,
+    evaluationOrder: EVALUATION_ORDER_VALUES.includes(order)
+      ? order
+      : DEFAULT_GUARD_SETTINGS.evaluationOrder,
+  };
+};
+
+export const loadGuardSettings = (): GuardSettings => {
+  return loadProfiles<GuardSettings>({
+    filename: 'guard-settings.json',
+    defaultData: DEFAULT_GUARD_SETTINGS,
+    profileType: 'guard-settings',
+    validateAndMigrate: normalizeGuardSettings,
+  });
+};
+
+export const saveGuardSettings = (settings: GuardSettings): GuardSettings => {
+  const normalized = normalizeGuardSettings(settings);
+  saveProfiles('guard-settings.json', normalized);
+  return normalized;
+};

--- a/src/server/routes/guardProfiles.ts
+++ b/src/server/routes/guardProfiles.ts
@@ -8,6 +8,11 @@ import {
   saveGuardrailProfiles,
   type GuardrailProfile,
 } from '../../config/guardrailProfiles';
+import {
+  loadGuardSettings,
+  saveGuardSettings,
+  type GuardSettings,
+} from '../../config/guardSettings';
 import { asyncErrorHandler } from '../../middleware/errorHandler';
 import { HTTP_STATUS } from '../../types/constants';
 import {
@@ -16,6 +21,7 @@ import {
   CreateGuardProfileSchema,
   GuardProfileIdParamSchema,
   UpdateGuardProfileSchema,
+  UpdateGuardSettingsSchema,
 } from '../../validation/schemas/guardProfilesSchema';
 import { validateRequest } from '../../validation/validateRequest';
 
@@ -40,6 +46,48 @@ router.get(
       return res
         .status(HTTP_STATUS.INTERNAL_SERVER_ERROR)
         .json(ApiResponse.error('Failed to load guardrail profiles'));
+    }
+  })
+);
+
+// GET /settings - Get global guard defaults
+// NOTE: Must be registered before '/:id' so 'settings' is not captured as an id.
+router.get(
+  '/settings',
+  asyncErrorHandler(async (req, res) => {
+    try {
+      const settings = loadGuardSettings();
+      return res.json(ApiResponse.success(settings));
+    } catch {
+      return res
+        .status(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+        .json(ApiResponse.error('Failed to load guard settings'));
+    }
+  })
+);
+
+// PUT /settings - Update global guard defaults
+router.put(
+  '/settings',
+  validateRequest(UpdateGuardSettingsSchema),
+  asyncErrorHandler(async (req, res) => {
+    try {
+      const current = loadGuardSettings();
+      const body = req.body as Partial<GuardSettings>;
+      const merged: GuardSettings = {
+        defaultRateLimit: body.defaultRateLimit
+          ? { ...current.defaultRateLimit, ...body.defaultRateLimit }
+          : current.defaultRateLimit,
+        defaultContentFilterStrictness:
+          body.defaultContentFilterStrictness ?? current.defaultContentFilterStrictness,
+        evaluationOrder: body.evaluationOrder ?? current.evaluationOrder,
+      };
+      const saved = saveGuardSettings(merged);
+      return res.json(ApiResponse.success(saved));
+    } catch {
+      return res
+        .status(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+        .json(ApiResponse.error('Failed to update guard settings'));
     }
   })
 );

--- a/src/validation/schemas/guardProfilesSchema.ts
+++ b/src/validation/schemas/guardProfilesSchema.ts
@@ -187,6 +187,35 @@ export const TestGuardProfileSchema = z.object({
   }),
 });
 
+/** Schema for PUT /settings — update global guard defaults */
+export const UpdateGuardSettingsSchema = z.object({
+  body: z.object({
+    defaultRateLimit: z
+      .object({
+        maxRequests: z
+          .number()
+          .int({ message: 'maxRequests must be an integer' })
+          .min(1, { message: 'maxRequests must be at least 1' })
+          .max(1000000, { message: 'maxRequests must not exceed 1,000,000' }),
+        windowMs: z
+          .number()
+          .int({ message: 'windowMs must be an integer' })
+          .min(1000, { message: 'windowMs must be at least 1000' }),
+      })
+      .optional(),
+    defaultContentFilterStrictness: z
+      .enum(['low', 'medium', 'high'], {
+        message: 'strictness must be low, medium, or high',
+      })
+      .optional(),
+    evaluationOrder: z
+      .enum(['sequential', 'parallel', 'fail-fast'], {
+        message: 'evaluationOrder must be sequential, parallel, or fail-fast',
+      })
+      .optional(),
+  }),
+});
+
 /** Schema for POST /bulk/toggle — bulk toggle guard profiles */
 export const BulkToggleGuardProfilesSchema = z.object({
   body: z.object({

--- a/tests/config/guardSettings.test.ts
+++ b/tests/config/guardSettings.test.ts
@@ -1,0 +1,101 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  DEFAULT_GUARD_SETTINGS,
+  normalizeGuardSettings,
+  loadGuardSettings,
+  saveGuardSettings,
+  type GuardSettings,
+} from '@src/config/guardSettings';
+
+describe('guardSettings config module', () => {
+  let tmpDir: string;
+  let prevConfigDir: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'guard-settings-'));
+    prevConfigDir = process.env.NODE_CONFIG_DIR;
+    process.env.NODE_CONFIG_DIR = tmpDir;
+  });
+
+  afterEach(() => {
+    if (prevConfigDir === undefined) {
+      delete process.env.NODE_CONFIG_DIR;
+    } else {
+      process.env.NODE_CONFIG_DIR = prevConfigDir;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('normalizeGuardSettings', () => {
+    it('returns defaults for non-object input', () => {
+      expect(normalizeGuardSettings(null)).toEqual(DEFAULT_GUARD_SETTINGS);
+      expect(normalizeGuardSettings('nope')).toEqual(DEFAULT_GUARD_SETTINGS);
+    });
+
+    it('preserves valid values', () => {
+      const input: GuardSettings = {
+        defaultRateLimit: { maxRequests: 42, windowMs: 30000 },
+        defaultContentFilterStrictness: 'high',
+        evaluationOrder: 'fail-fast',
+      };
+      expect(normalizeGuardSettings(input)).toEqual(input);
+    });
+
+    it('falls back per-field for invalid values', () => {
+      const result = normalizeGuardSettings({
+        defaultRateLimit: { maxRequests: 0, windowMs: 500 },
+        defaultContentFilterStrictness: 'nuclear',
+        evaluationOrder: 'sideways',
+      });
+      expect(result.defaultRateLimit.maxRequests).toBe(
+        DEFAULT_GUARD_SETTINGS.defaultRateLimit.maxRequests
+      );
+      expect(result.defaultRateLimit.windowMs).toBe(
+        DEFAULT_GUARD_SETTINGS.defaultRateLimit.windowMs
+      );
+      expect(result.defaultContentFilterStrictness).toBe('medium');
+      expect(result.evaluationOrder).toBe('sequential');
+    });
+  });
+
+  describe('load/save round trip', () => {
+    it('scaffolds defaults when no file exists', () => {
+      const settings = loadGuardSettings();
+      expect(settings).toEqual(DEFAULT_GUARD_SETTINGS);
+      // Scaffolding should have written the file
+      expect(fs.existsSync(path.join(tmpDir, 'guard-settings.json'))).toBe(true);
+    });
+
+    it('persists and reloads normalized settings', () => {
+      const saved = saveGuardSettings({
+        defaultRateLimit: { maxRequests: 7, windowMs: 120000 },
+        defaultContentFilterStrictness: 'high',
+        evaluationOrder: 'parallel',
+      });
+      expect(saved.defaultRateLimit.maxRequests).toBe(7);
+
+      const reloaded = loadGuardSettings();
+      expect(reloaded).toEqual({
+        defaultRateLimit: { maxRequests: 7, windowMs: 120000 },
+        defaultContentFilterStrictness: 'high',
+        evaluationOrder: 'parallel',
+      });
+    });
+
+    it('normalizes corrupt on-disk data on load', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'guard-settings.json'),
+        JSON.stringify({ defaultRateLimit: { maxRequests: -1 }, evaluationOrder: 'bogus' }),
+        'utf8'
+      );
+      const reloaded = loadGuardSettings();
+      expect(reloaded.defaultRateLimit.maxRequests).toBe(
+        DEFAULT_GUARD_SETTINGS.defaultRateLimit.maxRequests
+      );
+      expect(reloaded.evaluationOrder).toBe('sequential');
+    });
+  });
+});


### PR DESCRIPTION
## What

Wires the **Guards page → Settings tab** to a real backend instead of the
`"Guard settings coming soon"` / `"Advanced guard settings coming soon"`
placeholders (previously `src/client/src/pages/GuardsPage.tsx` lines ~212/248).

The tab now reads and persists **global guard defaults**:

- Default rate limit (max requests + window seconds)
- Default content-filter strictness
- Guard evaluation order (Advanced section)

## Why

The controls were rendered disabled with placeholder copy and no persistence.
This makes them functional, reusing the existing guard-profiles route + the
`profileUtils` JSON persistence mechanism rather than inventing a new store.

## How / Behavior

**Backend**
- New `src/config/guardSettings.ts` — `loadGuardSettings` / `saveGuardSettings`
  backed by `config/guard-settings.json` via the same `loadProfiles` /
  `saveProfiles` helpers used by guardrail profiles. `normalizeGuardSettings`
  coerces missing/invalid fields to safe defaults (per-field fallback).
- New routes on the existing guard-profiles router:
  - `GET  /api/admin/guard-profiles/settings`
  - `PUT  /api/admin/guard-profiles/settings`
  Registered **before** `/:id` so `settings` is not captured as a profile id.
  PUT merges the request body over current settings and re-normalizes.
- `UpdateGuardSettingsSchema` (zod) validates the PUT body, mirroring the
  existing schema style (all fields optional, bounded ranges).

**Frontend**
- `GuardSettingsTab` now uses react-query (`useQuery` + `useMutation`) following
  the same patterns already in `GuardsPage`. Controls are live, with a
  dirty-state-aware **Save Settings** button and toast feedback.
- Pure UI logic extracted to `src/client/src/pages/guardSettings.ts`
  (`coerceGuardSettings`, `windowSecondsToMs`, `clampMaxRequests`,
  `formatWindow`, `settingsEqual`) for testability.
- Removed the now-unused `Textarea` import and the placeholder JSON textarea.

## Verification

- Backend: `npx tsc --noEmit` clean; `eslint` 0 errors on changed files;
  `jest tests/config/guardSettings.test.ts` → 6 passing.
- Frontend: `cd src/client && npx tsc --noEmit` clean; `eslint` 0 errors;
  `vitest run src/pages/guardSettings.test.ts` → 11 passing.
- `corepack pnpm install --frozen-lockfile` succeeds; no new dependency, no
  lockfile change.

## Reviewer notes

- This is a **best-guess product feature**. The three persisted settings
  (default rate limit, default content-filter strictness, evaluation order)
  are surfaced and stored, but **not yet consumed** elsewhere: new guard
  profiles are still created with the hardcoded `defaultNewProfile` values,
  and `evaluationOrder` is not yet read by the guard-evaluation pipeline.
  This PR establishes the storage + UI; wiring those values into profile
  creation / evaluation is a deliberate follow-up.
- Persistence uses the same flat-JSON config dir as guardrail profiles
  (`config/guard-settings.json`); confirm that matches deployment expectations.
