### PR TITLE
refactor(client): type CreateBotWizard apiService payloads, drop lint suppression

### DIFF
--- a/src/client/src/components/BotManagement/CreateBotWizard.tsx
+++ b/src/client/src/components/BotManagement/CreateBotWizard.tsx
@@ -1,9 +1,3 @@
-// TODO(lint-hygiene): the dynamic shapes returned by `apiService.{get,post}`
-// in this wizard (personas, llmProfiles, guardProfiles, AI generation result)
-// are not strongly typed yet. Pre-existing technical debt — disabling
-// `no-explicit-any` here so the file passes `--max-warnings 0` while the
-// types are tightened in a follow-up PR.
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, useEffect, useMemo } from 'react';
 import { User, Check, AlertCircle, Wand2, Sparkles, Send, MessageSquare } from 'lucide-react';
 import Button from '../DaisyUI/Button';
@@ -25,12 +19,76 @@ import Mockup from '../DaisyUI/Mockup';
 import LlmTestChat from '../LlmTestChat';
 const debug = Debug('app:client:components:BotManagement:CreateBotWizard');
 
+/**
+ * Minimal shapes of the dynamic data this wizard consumes from `apiService`.
+ * These intentionally describe only the fields the wizard reads, so the
+ * component is decoupled from the full backend payloads while still being
+ * type-checked instead of relying on `any`.
+ */
+interface WizardPersona {
+    id: string;
+    name: string;
+    description?: string;
+}
+
+interface WizardLlmProfile {
+    id: string;
+    name: string;
+    provider?: string;
+    key?: string;
+}
+
+interface WizardGuardProfile {
+    id: string;
+    name: string;
+}
+
+interface AiGeneratedConfig {
+    name?: string;
+    personaName?: string;
+    systemInstruction?: string;
+    suggestedMcpTools?: string[];
+}
+
+/** Common `{ success, data }` envelope returned by several admin/config endpoints. */
+interface ApiEnvelope<T> {
+    success?: boolean;
+    data?: T;
+}
+
+/** Response shape of `GET /api/config/llm-profiles` (several historical shapes supported). */
+interface LlmProfilesResponse {
+    llm?: WizardLlmProfile[];
+    profiles?: { llm?: WizardLlmProfile[] };
+    data?: WizardLlmProfile[];
+}
+
+/** Response shape of `GET /api/config/llm-status`. */
+interface LlmStatusResponse {
+    defaultConfigured?: boolean;
+}
+
+interface BotSubmitPayload {
+    name: string;
+    description: string;
+    messageProvider: string;
+    llmProvider?: string;
+    persona: string;
+    mcpGuardProfile: string;
+    maxTokensPerDay?: number;
+    config: {
+        mcpGuard: { enabled: boolean };
+        rateLimit: { enabled: boolean };
+        contentFilter: { enabled: boolean };
+    };
+}
+
 interface CreateBotWizardProps {
     isOpen: boolean;
     onClose: () => void;
-    onSubmit?: (data: any) => void;
-    personas?: any[];
-    llmProfiles?: any[];
+    onSubmit?: (data: BotSubmitPayload) => void | Promise<void>;
+    personas?: WizardPersona[];
+    llmProfiles?: WizardLlmProfile[];
     defaultLlmConfigured?: boolean;
 }
 
@@ -46,9 +104,9 @@ export const CreateBotWizard: React.FC<CreateBotWizardProps> = (props) => {
 
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
-    const [guardProfiles, setGuardProfiles] = useState<any[]>([]);
-    const [fetchedPersonas, setFetchedPersonas] = useState<any[]>([]);
-    const [fetchedLlmProfiles, setFetchedLlmProfiles] = useState<any[]>([]);
+    const [guardProfiles, setGuardProfiles] = useState<WizardGuardProfile[]>([]);
+    const [fetchedPersonas, setFetchedPersonas] = useState<WizardPersona[]>([]);
+    const [fetchedLlmProfiles, setFetchedLlmProfiles] = useState<WizardLlmProfile[]>([]);
     const [fetchedDefaultLlmConfigured, setFetchedDefaultLlmConfigured] = useState(true);
 
     const personas = propsPersonas ?? fetchedPersonas;
@@ -62,6 +120,7 @@ export const CreateBotWizard: React.FC<CreateBotWizardProps> = (props) => {
         llmProvider: '',
         persona: 'default',
         mcpGuardProfile: '',
+        maxTokensPerDay: 0,
         guards: {
             accessControl: false,
             rateLimit: false,
@@ -76,7 +135,7 @@ export const CreateBotWizard: React.FC<CreateBotWizardProps> = (props) => {
     const [isAiModalOpen, setIsAiModalOpen] = useState(false);
     const [aiDescription, setAiDescription] = useState('');
     const [isGenerating, setIsGenerating] = useState(false);
-    const [aiGeneratedResult, setAiGeneratedResult] = useState<any>(null);
+    const [aiGeneratedResult, setAiGeneratedResult] = useState<AiGeneratedConfig | null>(null);
     const [isPreviewOpen, setIsPreviewOpen] = useState(false);
 
     const handleAiGenerate = async () => {
@@ -84,8 +143,8 @@ export const CreateBotWizard: React.FC<CreateBotWizardProps> = (props) => {
         setIsGenerating(true);
         setAiGeneratedResult(null);
         try {
-            const result: any = await apiService.post('/api/bots/generate-config', { 
-                description: aiDescription 
+            const result: ApiEnvelope<AiGeneratedConfig> = await apiService.post('/api/bots/generate-config', {
+                description: aiDescription
             });
             if (result.success && result.data) {
                 setAiGeneratedResult(result.data);
@@ -124,7 +183,7 @@ export const CreateBotWizard: React.FC<CreateBotWizardProps> = (props) => {
     useEffect(() => {
         const fetchGuardProfiles = async () => {
             try {
-                const data: any = await apiService.get('/api/admin/guard-profiles');
+                const data: ApiEnvelope<WizardGuardProfile[]> = await apiService.get('/api/admin/guard-profiles');
                 setGuardProfiles(Array.isArray(data.data) ? data.data : []);
             } catch (e) {
                 debug('ERROR:', 'Failed to fetch guard profiles', e);
@@ -136,7 +195,7 @@ export const CreateBotWizard: React.FC<CreateBotWizardProps> = (props) => {
         if (!propsPersonas) {
             const fetchPersonas = async () => {
                 try {
-                    const data: any = await apiService.getPersonas();
+                    const data = await apiService.getPersonas();
                     setFetchedPersonas(Array.isArray(data) ? data : []);
                 } catch (e) {
                     debug('ERROR:', 'Failed to fetch personas', e);
@@ -149,7 +208,7 @@ export const CreateBotWizard: React.FC<CreateBotWizardProps> = (props) => {
         if (!propsLlmProfiles) {
             const fetchLlmProfiles = async () => {
                 try {
-                    const data: any = await apiService.getLlmProfiles();
+                    const data = await apiService.getLlmProfiles() as LlmProfilesResponse;
                     setFetchedLlmProfiles(data?.llm || data?.profiles?.llm || data?.data || []);
                 } catch (e) {
                     debug('ERROR:', 'Failed to fetch LLM profiles', e);
@@ -162,7 +221,7 @@ export const CreateBotWizard: React.FC<CreateBotWizardProps> = (props) => {
         if (propsDefaultLlmConfigured === undefined) {
             const fetchLlmStatus = async () => {
                 try {
-                    const data: any = await apiService.get('/api/config/llm-status');
+                    const data: LlmStatusResponse = await apiService.get('/api/config/llm-status');
                     setFetchedDefaultLlmConfigured(data?.defaultConfigured ?? true);
                 } catch (e) {
                     debug('ERROR:', 'Failed to fetch LLM status', e);
@@ -191,7 +250,7 @@ export const CreateBotWizard: React.FC<CreateBotWizardProps> = (props) => {
         setLoading(true);
         setError(null);
         try {
-            const payload = {
+            const payload: BotSubmitPayload = {
                 name: formData.name,
                 description: formData.description,
                 messageProvider: formData.messageProvider,
@@ -424,7 +483,7 @@ export const CreateBotWizard: React.FC<CreateBotWizardProps> = (props) => {
                         <Select
                             className="select-bordered"
                             value={formData.mcpGuardProfile || ''}
-                            onChange={e => setFormData({ ...formData, mcpGuardProfile: e.target.value || null })}
+                            onChange={e => setFormData({ ...formData, mcpGuardProfile: e.target.value })}
                         >
                             <option value="">No Profile (Use Manual Config)</option>
                             {guardProfiles.map(p => (

--- a/src/client/src/components/BotManagement/__tests__/CreateBotWizard.test.tsx
+++ b/src/client/src/components/BotManagement/__tests__/CreateBotWizard.test.tsx
@@ -1,0 +1,181 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// apiService mock
+//
+// These tests focus on the typed `apiService.{get,post}` call sites in the
+// wizard (personas, llmProfiles, guardProfiles, AI generation result). The
+// mock returns the historical/dynamic envelope shapes the component unwraps
+// so we can assert the typing change preserved runtime behavior exactly.
+// ---------------------------------------------------------------------------
+const getMock = vi.fn();
+const postMock = vi.fn();
+const getPersonasMock = vi.fn();
+const getLlmProfilesMock = vi.fn();
+
+vi.mock('../../../services/api', () => ({
+  apiService: {
+    get: (...args: unknown[]) => getMock(...args),
+    post: (...args: unknown[]) => postMock(...args),
+    getPersonas: (...args: unknown[]) => getPersonasMock(...args),
+    getLlmProfiles: (...args: unknown[]) => getLlmProfilesMock(...args),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Presentational child mocks
+//
+// Modal -> render children when open.
+// StepWizard -> render the active step's content plus a button that invokes
+//   onComplete, so we can drive the wizard to submission without simulating
+//   multi-step navigation.
+// LlmTestChat -> inert (avoids unrelated network/render concerns).
+// ---------------------------------------------------------------------------
+type StepLike = { id: string; content: React.ReactNode };
+
+vi.mock('../../DaisyUI/Modal', () => ({
+  __esModule: true,
+  default: ({ isOpen, children }: { isOpen: boolean; children: React.ReactNode }) =>
+    isOpen ? <div data-testid="modal">{children}</div> : null,
+}));
+
+vi.mock('../../DaisyUI/StepWizard', () => ({
+  __esModule: true,
+  default: ({
+    steps,
+    onComplete,
+  }: {
+    steps: StepLike[];
+    onComplete?: () => void;
+  }) => (
+    <div data-testid="step-wizard">
+      {steps.map((s) => (
+        <div key={s.id} data-step={s.id}>
+          {s.content}
+        </div>
+      ))}
+      <button type="button" onClick={() => onComplete?.()}>
+        complete-wizard
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('../../LlmTestChat', () => ({
+  __esModule: true,
+  default: () => <div data-testid="llm-test-chat" />,
+}));
+
+import { CreateBotWizard } from '../CreateBotWizard';
+
+const flushFetches = async () => {
+  await waitFor(() => {
+    expect(getPersonasMock).toHaveBeenCalled();
+    expect(getLlmProfilesMock).toHaveBeenCalled();
+  });
+};
+
+describe('CreateBotWizard typed apiService integration', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    postMock.mockReset();
+    getPersonasMock.mockReset();
+    getLlmProfilesMock.mockReset();
+
+    // Guard profiles: { success, data } envelope.
+    getMock.mockImplementation((endpoint: string) => {
+      if (endpoint === '/api/admin/guard-profiles') {
+        return Promise.resolve({
+          success: true,
+          data: [{ id: 'guard-1', name: 'Strict Guard' }],
+        });
+      }
+      if (endpoint === '/api/config/llm-status') {
+        return Promise.resolve({ defaultConfigured: true });
+      }
+      return Promise.resolve({});
+    });
+
+    // Personas: bare array (Persona[] shape).
+    getPersonasMock.mockResolvedValue([
+      { id: 'persona-1', name: 'Helper', description: 'A helpful persona' },
+    ]);
+
+    // LLM profiles: legacy `{ llm: [...] }` envelope the component unwraps.
+    getLlmProfilesMock.mockResolvedValue({
+      llm: [{ id: 'llm-1', name: 'GPT', provider: 'openai' }],
+    });
+
+    postMock.mockResolvedValue({ success: true, data: {} });
+  });
+
+  it('fetches guard profiles, personas, llm profiles and llm status on mount', async () => {
+    render(<CreateBotWizard isOpen onClose={vi.fn()} />);
+    await flushFetches();
+
+    expect(getMock).toHaveBeenCalledWith('/api/admin/guard-profiles');
+    expect(getMock).toHaveBeenCalledWith('/api/config/llm-status');
+    expect(getPersonasMock).toHaveBeenCalledTimes(1);
+    expect(getLlmProfilesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders fetched persona, llm profile and guard profile options', async () => {
+    render(<CreateBotWizard isOpen onClose={vi.fn()} />);
+    await flushFetches();
+
+    // Persona option (from bare-array response).
+    await waitFor(() => expect(screen.getByText('Helper')).toBeInTheDocument());
+    // LLM profile option label `${name} (${provider})` (from { llm: [...] } envelope).
+    expect(screen.getByText('GPT (openai)')).toBeInTheDocument();
+    // Guard profile option (from { success, data } envelope).
+    expect(screen.getByText('Strict Guard')).toBeInTheDocument();
+  });
+
+  it('submits a correctly shaped payload through onSubmit on completion', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    render(<CreateBotWizard isOpen onClose={onClose} onSubmit={onSubmit} />);
+    await flushFetches();
+
+    fireEvent.click(screen.getByText('complete-wizard'));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    const payload = onSubmit.mock.calls[0][0];
+    expect(payload).toMatchObject({
+      name: '',
+      persona: 'default',
+      mcpGuardProfile: '',
+      config: {
+        mcpGuard: { enabled: false },
+        rateLimit: { enabled: false },
+        contentFilter: { enabled: false },
+      },
+    });
+    // maxTokensPerDay of 0 collapses to undefined (unlimited).
+    expect(payload.maxTokensPerDay).toBeUndefined();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('calls apiService.post with the AI-generation endpoint and typed body', async () => {
+    // Return an unsuccessful envelope so the (separately) rendered result panel
+    // is not exercised here — this test pins the typed POST call site only.
+    postMock.mockResolvedValueOnce({ success: false });
+
+    render(<CreateBotWizard isOpen onClose={vi.fn()} />);
+    await flushFetches();
+
+    // Open AI modal and trigger generation.
+    fireEvent.click(screen.getByRole('button', { name: /generate with ai/i }));
+    const textarea = await screen.findByPlaceholderText(/proactive DevOps assistant/i);
+    fireEvent.change(textarea, { target: { value: 'a monitoring bot' } });
+    fireEvent.click(screen.getByRole('button', { name: /generate persona/i }));
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith('/api/bots/generate-config', {
+        description: 'a monitoring bot',
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## What

Resolves the single `TODO(lint-hygiene)` at the top of `src/client/src/components/BotManagement/CreateBotWizard.tsx`. That TODO disabled `@typescript-eslint/no-explicit-any` for the whole file because the dynamic shapes returned by `apiService.{get,post}` (personas, LLM profiles, guard profiles, AI generation result) were untyped.

## Why

The file-wide `/* eslint-disable @typescript-eslint/no-explicit-any */` was masking real typing gaps and tracked as tech debt. The TODO asked to tighten the typing (or remove the need for the suppression) in a follow-up.

## Changes

- Added small local interfaces describing **only** the fields the wizard actually reads: `WizardPersona`, `WizardLlmProfile`, `WizardGuardProfile`, `AiGeneratedConfig`, plus the response envelopes (`ApiEnvelope<T>`, `LlmProfilesResponse`, `LlmStatusResponse`) and the submit payload (`BotSubmitPayload`).
- Replaced the `const x: any = await apiService.get/post(...)` sites with typed result annotations, and tightened the component props (`onSubmit`, `personas`, `llmProfiles`).
- Removed the file-wide `eslint-disable` and the TODO comment.
- Added `maxTokensPerDay: 0` to the initial form state — the field was already read in two places, and the old `any` was hiding the missing-property type errors.
- Normalised the guard-profile `onChange` to set `''` instead of `null`, so `mcpGuardProfile` stays a `string` (behaviour-identical: both are falsy "no profile").

## Behaviour

Unchanged. All edits are type-level plus an equivalent `''`-vs-`null` normalisation. The only caller (`BotsPage`) passes `isOpen`/`onClose`/`onSubmit`, all still compatible.

## Verification

- **Type-check (whole-program, `tsconfig.app.json`):** this file went from **7 pre-existing errors on `main` to 3**. The 4 latent `maxTokensPerDay` errors that the old `any` masked are now fixed; **no new errors introduced**. The 3 remaining (1 React default-import config artifact shared by every `.tsx`, 2 `Collapse is not defined`) pre-date this PR and are out of scope.
- **Unit tests:** added `src/client/src/components/BotManagement/__tests__/CreateBotWizard.test.tsx` (4 vitest tests) covering the typed mount fetches, option rendering from the various envelope shapes, submit-payload shape, and the AI-generation POST call site. All 4 pass.
- ESLint could not be run in this environment (the installed eslint 9.39.4 + eslintrc shim throws at module load, independent of this change), so lint was validated by inspection — the only `no-explicit-any` trigger (the file-wide disable) is removed and no `any` remains in the file.

## Reviewer notes

- Pre-existing bug spotted but left out of scope: the AI-result panel renders `<Collapse>` which is **never imported** (`Collapse is not defined`), so generating an AI persona would crash at render. Flagged separately.
