### PR TITLE
fix(llm-letta): isolate provider config per bot

### DIFF
--- a/packages/llm-letta/README.md
+++ b/packages/llm-letta/README.md
@@ -8,7 +8,7 @@ LLM provider for [Letta](https://letta.com) (formerly MemGPT) — stateful agent
 - `listAgents`, `getAgent`, `AgentSummary` — helpers in `agentBrowser` for picking an agent ID at config time
 - `schema` — UI/config schema descriptor
 - `manifest` — `{ displayName: 'Letta', type: 'llm', ... }`
-- `create(config?)` — factory returning the singleton instance
+- `create(config?)` — factory returning a fresh provider per call, so each bot keeps its own `agentId`/session config isolated
 
 ## Environment variables
 

--- a/packages/llm-letta/src/index.ts
+++ b/packages/llm-letta/src/index.ts
@@ -5,9 +5,13 @@ export { LettaProvider, LettaProviderConfig } from './lettaProvider';
 export { listAgents, getAgent, type AgentSummary } from './agentBrowser';
 export { schema } from './schema';
 
-/** Standard factory — preferred entry point for PluginLoader */
+/**
+ * Standard factory — preferred entry point for PluginLoader.
+ * Returns a fresh provider per call so each bot keeps its own config
+ * (agentId, session mode, conversation cache) isolated.
+ */
 export function create(config?: any): LettaProvider {
-  return LettaProvider.getInstance(config);
+  return new LettaProvider(config);
 }
 
 export const manifest: PluginManifest = {

--- a/packages/llm-letta/src/lettaProvider.test.ts
+++ b/packages/llm-letta/src/lettaProvider.test.ts
@@ -222,6 +222,60 @@ describe('LettaProvider session modes', () => {
   });
 });
 
+describe('LettaProvider per-bot config isolation', () => {
+  it('create() returns distinct providers honoring each bot config', async () => {
+    const { create } = await import('./index');
+
+    const botA = create({ agentId: 'agent-aaa' });
+    const botB = create({ agentId: 'agent-bbb' });
+
+    // Two different bots must not share one instance.
+    expect(botA).not.toBe(botB);
+
+    mockCreate.mockResolvedValue({
+      messages: [{ role: 'assistant', content: 'ok' }],
+    });
+
+    // Each provider routes to its own configured agentId (no metadata override).
+    await botA.generateChatCompletion('hi', []);
+    expect(mockCreate).toHaveBeenLastCalledWith('agent-aaa', { input: 'hi' });
+
+    await botB.generateChatCompletion('hi', []);
+    expect(mockCreate).toHaveBeenLastCalledWith('agent-bbb', { input: 'hi' });
+  });
+
+  it('isolates session config and conversation caches between bots', async () => {
+    const { create } = await import('./index');
+
+    mockConvList.mockResolvedValue([]);
+    mockConvCreate.mockResolvedValue({ id: 'conv-fixed-A', summary: '' });
+    mockConvMessageCreate.mockResolvedValue({
+      messages: [{ role: 'assistant', content: 'reply' }],
+    });
+
+    const fixedBot = create({
+      agentId: 'agent-fixed',
+      sessionMode: 'fixed',
+      conversationId: 'conv-fixed-A',
+    });
+    const defaultBot = create({ agentId: 'agent-default' });
+
+    await fixedBot.generateChatCompletion('hi', []);
+    // Fixed bot uses its conversation API with its own conversationId.
+    expect(mockConvMessageCreate).toHaveBeenCalledWith('conv-fixed-A', {
+      agent_id: 'agent-fixed',
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+
+    mockCreate.mockResolvedValue({
+      messages: [{ role: 'assistant', content: 'reply' }],
+    });
+    await defaultBot.generateChatCompletion('hi', []);
+    // Default bot is unaffected by the other bot's session config.
+    expect(mockCreate).toHaveBeenCalledWith('agent-default', { input: 'hi' });
+  });
+});
+
 describe('LettaProvider.generateCompletion', () => {
   it('throws unsupported error', async () => {
     const provider = LettaProvider.getInstance();

--- a/packages/llm-letta/src/lettaProvider.ts
+++ b/packages/llm-letta/src/lettaProvider.ts
@@ -14,12 +14,11 @@ export interface LettaProviderConfig {
 
 export class LettaProvider implements ILlmProvider {
   name = 'letta';
-  private static instance: LettaProvider;
   private client: Letta;
   private config: LettaProviderConfig;
   private conversationCache = new Map<string, string>(); // contextKey → conv-* id
 
-  private constructor(config?: LettaProviderConfig) {
+  constructor(config?: LettaProviderConfig) {
     this.config = config || {};
     // Uses LETTA_SERVER_PASSWORD for both cloud and self-hosted auth
     this.client = new Letta({
@@ -27,11 +26,13 @@ export class LettaProvider implements ILlmProvider {
     });
   }
 
+  /**
+   * Back-compat factory. A new provider is returned for each call so that
+   * multiple bots with different agentId/session configs stay isolated
+   * (the previous singleton honored only the first config supplied).
+   */
   static getInstance(config?: LettaProviderConfig): LettaProvider {
-    if (!LettaProvider.instance) {
-      LettaProvider.instance = new LettaProvider(config);
-    }
-    return LettaProvider.instance;
+    return new LettaProvider(config);
   }
 
   supportsChatCompletion(): boolean {


### PR DESCRIPTION
## What
`create()` in `packages/llm-letta/src/index.ts` returned a `LettaProvider.getInstance(config)` singleton that honored only the **first** config supplied. Drop the singleton so each call returns a fresh, independently-configured provider.

## Why
With the singleton, a second bot configured with a different `agentId` / server / session mode reused the first bot's provider — silently routing messages to the **wrong Letta agent** and sharing one conversation cache. This broke multi-bot Letta deployments.

## Behavior
- `create(config)` and `LettaProvider.getInstance(config)` now each return a new `LettaProvider`, keeping per-bot `agentId`, `sessionMode`, `conversationId`, and conversation cache isolated.
- Matches the existing factory pattern already used by the OpenAI and Flowise providers (`new Provider(config)`).
- Constructor made public (was `private`); the static `instance` field is removed. No external callers relied on the singleton — only the plugin loader's `create()` and the unrelated `getAgent`/`listAgents` helpers.

## Verification
- `npx tsc --noEmit` — clean.
- `npx jest packages/llm-letta/src/lettaProvider.test.ts` — 13/13 pass, including two new tests:
  - `create() returns distinct providers honoring each bot config` — proves two configs yield two providers each routing to its own `agentId`.
  - `isolates session config and conversation caches between bots` — proves session config does not bleed across bots.
  - Both fail against the old singleton (botB would route to botA's agentId).

> Note: repo-wide `eslint` currently crashes with a pre-existing ajv/eslintrc `defaultMeta` TypeError on `main` (unrelated to this change). The diff is minimal, idiomatic TS matching surrounding code.