### PR TITLE
fix(mcp): catch spawn errors via 'error' event instead of non-existent 'configuration'

### DIFF
--- a/src/config/mcp/serverLifecycle.ts
+++ b/src/config/mcp/serverLifecycle.ts
@@ -188,16 +188,13 @@ export class ServerLifecycle {
         resolve(providerProcess);
       });
 
-   
-       
-       
-      providerProcess.on('configuration', (error: any) => {
+      // Spawn failures (e.g. ENOENT when the command is missing) surface as an
+      // 'error' event on the ChildProcess, not 'configuration'. Reject so the
+      // caller can mark the provider as errored.
+      providerProcess.on('error', (error: any) => {
         reject(error);
       });
 
-    
-   
-       
       providerProcess.on('close', (code: any) => {
         if (code !== 0) {
           reject(new Error(`MCP process exited with code ${code}`));

--- a/src/config/mcp/toolRegistry.ts
+++ b/src/config/mcp/toolRegistry.ts
@@ -71,7 +71,9 @@ export class ToolRegistry {
 
    
        
-      mcpProcess.on('configuration', (error: any) => {
+      // Spawn failures (e.g. ENOENT when the command is missing) surface as an
+      // 'error' event on the ChildProcess, not 'configuration'.
+      mcpProcess.on('error', (error: any) => {
         resolve({
           success: false,
           error: error.message,

--- a/tests/config/mcpSpawnError.test.ts
+++ b/tests/config/mcpSpawnError.test.ts
@@ -1,0 +1,98 @@
+import 'reflect-metadata';
+import { EventEmitter } from 'events';
+import { ServerLifecycle } from '@src/config/mcp/serverLifecycle';
+import { ToolRegistry } from '@src/config/mcp/toolRegistry';
+import type { MCPProviderConfig } from '@src/types/mcp';
+
+// Mock child_process.spawn so we can simulate a spawn failure (e.g. ENOENT)
+// without actually launching a process.
+jest.mock('child_process', () => ({
+  spawn: jest.fn(),
+}));
+
+import { spawn } from 'child_process';
+
+const mockedSpawn = spawn as unknown as jest.Mock;
+
+/**
+ * Build a fake ChildProcess that emits an 'error' event on the next tick,
+ * mimicking what Node does when a spawn fails (the command does not exist).
+ */
+function createErroringChildProcess(error: Error): EventEmitter {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: jest.Mock;
+    killed: boolean;
+    pid?: number;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = jest.fn();
+  child.killed = false;
+  child.pid = undefined;
+
+  // Emit asynchronously so listeners registered after spawn() returns still fire.
+  setImmediate(() => {
+    child.emit('error', error);
+  });
+
+  return child;
+}
+
+const baseProvider: MCPProviderConfig = {
+  id: 'mcp-test',
+  name: 'Missing Command Provider',
+  type: 'desktop',
+  command: 'this-command-does-not-exist',
+  args: '',
+  env: {},
+  enabled: true,
+  timeout: 5,
+};
+
+describe('MCP spawn error handling', () => {
+  beforeEach(() => {
+    mockedSpawn.mockReset();
+  });
+
+  describe('ServerLifecycle.startProvider', () => {
+    it('rejects and marks the provider as errored when spawn emits an error event', async () => {
+      const spawnError = Object.assign(new Error('spawn this-command-does-not-exist ENOENT'), {
+        code: 'ENOENT',
+      });
+      mockedSpawn.mockReturnValue(createErroringChildProcess(spawnError));
+
+      const lifecycle = new ServerLifecycle();
+      const providers = new Map<string, MCPProviderConfig>([[baseProvider.id, baseProvider]]);
+      const emitter = new EventEmitter();
+      const errorEvents: any[] = [];
+      emitter.on('provider_error', (evt) => errorEvents.push(evt));
+
+      lifecycle.initialize(providers, emitter);
+
+      await expect(lifecycle.startProvider(baseProvider.id)).rejects.toThrow(/ENOENT/);
+
+      const status = lifecycle.getStatus(baseProvider.id);
+      expect(status?.status).toBe('error');
+      expect(lifecycle.hasProcess(baseProvider.id)).toBe(false);
+      expect(errorEvents).toHaveLength(1);
+    });
+  });
+
+  describe('ToolRegistry.executeProviderTest', () => {
+    it('resolves with success=false when spawn emits an error event', async () => {
+      const spawnError = new Error('spawn this-command-does-not-exist ENOENT');
+      mockedSpawn.mockReturnValue(createErroringChildProcess(spawnError));
+
+      const registry = new ToolRegistry();
+      const parseArgs = (args: string | string[]): string[] =>
+        Array.isArray(args) ? args : [];
+
+      const result = await registry.executeProviderTest(baseProvider, parseArgs);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('ENOENT');
+    });
+  });
+});


### PR DESCRIPTION
@
## What
Fix MCP provider spawn-failure handling in two places that listened for a `configuration` event that `ChildProcess` never emits:
- `src/config/mcp/serverLifecycle.ts` (`startProviderProcess`)
- `src/config/mcp/toolRegistry.ts` (`executeProviderTest`)

Both now listen for the real `error` event.

## Why
Node `ChildProcess` emits `error` (not `configuration`) when a spawn fails — e.g. `ENOENT` when the configured `command` does not exist. Because the listeners were bound to a non-existent event name, spawn failures were never caught:
- In `ServerLifecycle`, the start promise would hang until the timeout fired (up to `provider.timeout` seconds) instead of failing fast and marking the provider `error`.
- In `ToolRegistry.executeProviderTest`, the connection test would similarly wait for the timeout instead of returning the spawn error.

## Behavior
- Spawn failure now rejects `startProvider(...)` immediately, sets the provider status to `error`, and emits `provider_error`.
- `executeProviderTest(...)` resolves `{ success: false, error: <message> }` immediately on spawn failure.
- No change to the success path, close-code handling, or timeout fallback.

## Verification
- `npx tsc --noEmit` — clean.
- `npx eslint` on the 3 changed files — 0 errors.
- `npx jest tests/config/mcpSpawnError.test.ts` — 2 passing. New test mocks `child_process.spawn` to emit an `error` event (simulated `ENOENT`); it FAILS against the pre-fix code (both cases time out) and PASSES after the fix.
@