### PR TITLE
fix(openswarm): wire per-bot config through create/constructor

### DIFF
--- a/packages/llm-openswarm/README.md
+++ b/packages/llm-openswarm/README.md
@@ -8,7 +8,7 @@ LLM provider for [OpenSwarm](https://github.com/openai/swarm) — multi-agent or
 - `SwarmInstaller` — helper that installs / launches the local OpenSwarm WebUI
 - `schema` — UI/config schema descriptor
 - `manifest` — `{ displayName: 'OpenSwarm', type: 'llm', ... }`
-- `create(_config?)` — factory used by the PluginLoader (config is currently ignored — env vars drive it)
+- `create(config?)` — factory used by the PluginLoader. Accepts an optional per-bot config (`baseUrl`, `apiKey`, `team`; the raw `OPENSWARM_*` schema keys are also honored). Any omitted field falls back to the matching environment variable, then to a built-in default.
 
 ## Environment variables
 

--- a/packages/llm-openswarm/src/OpenSwarmProvider.test.ts
+++ b/packages/llm-openswarm/src/OpenSwarmProvider.test.ts
@@ -73,4 +73,44 @@ describe('OpenSwarmProvider', () => {
     const msg = { getText: () => 'hi', metadata: {} } as any;
     expect(await new OpenSwarmProvider().generateResponse(msg, [])).toBe('response');
   });
+
+  it('create() wires per-bot baseUrl and apiKey through to requests', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ choices: [{ message: { content: 'ok' } }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+
+    const provider = create({
+      baseUrl: 'http://custom-host:9000/v1',
+      apiKey: 'bot-specific-key',
+      team: 'bot-team',
+    });
+    await provider.generateChatCompletion('hello', [], {});
+
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://custom-host:9000/v1/chat/completions');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer bot-specific-key');
+    expect(JSON.parse(init.body as string).model).toBe('bot-team');
+  });
+
+  it('create() accepts raw schema env-var keys', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ choices: [{ message: { content: 'ok' } }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+
+    const provider = create({
+      OPENSWARM_BASE_URL: 'http://env-style:7000/v1',
+      OPENSWARM_API_KEY: 'env-style-key',
+    } as any);
+    await provider.generateChatCompletion('hello', [], {});
+
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://env-style:7000/v1/chat/completions');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer env-style-key');
+  });
 });

--- a/packages/llm-openswarm/src/OpenSwarmProvider.ts
+++ b/packages/llm-openswarm/src/OpenSwarmProvider.ts
@@ -6,15 +6,27 @@ import Logger from '@common/logger';
 
 const logger = Logger.withContext('OpenSwarmProvider');
 
+/**
+ * Per-bot configuration for the OpenSwarm provider. Any field omitted falls
+ * back to the corresponding environment variable, then to a built-in default.
+ */
+export interface OpenSwarmConfig {
+  baseUrl?: string;
+  apiKey?: string;
+  team?: string;
+}
+
 export class OpenSwarmProvider implements ILlmProvider {
   name = 'openswarm';
 
   private baseUrl: string;
   private apiKey: string;
+  private team?: string;
 
-  constructor() {
-    this.baseUrl = process.env.OPENSWARM_BASE_URL || 'http://localhost:8000/v1';
-    this.apiKey = process.env.OPENSWARM_API_KEY || 'dummy-key';
+  constructor(config: OpenSwarmConfig = {}) {
+    this.baseUrl = config.baseUrl || process.env.OPENSWARM_BASE_URL || 'http://localhost:8000/v1';
+    this.apiKey = config.apiKey || process.env.OPENSWARM_API_KEY || 'dummy-key';
+    this.team = config.team || process.env.OPENSWARM_TEAM || undefined;
   }
 
   supportsChatCompletion(): boolean {
@@ -31,7 +43,7 @@ export class OpenSwarmProvider implements ILlmProvider {
     metadata?: Record<string, any>
   ): Promise<string> {
     try {
-      const teamName = metadata?.team || metadata?.model || 'default-team';
+      const teamName = metadata?.team || metadata?.model || this.team || 'default-team';
       const targetUrl = `${this.baseUrl}/chat/completions`;
 
       const data = await http.post<{ choices: Array<{ message: { content: string } }> }>(

--- a/packages/llm-openswarm/src/index.ts
+++ b/packages/llm-openswarm/src/index.ts
@@ -1,13 +1,27 @@
 import type { PluginManifest } from '../../../src/plugins/PluginLoader';
-import { OpenSwarmProvider } from './OpenSwarmProvider';
+import { OpenSwarmProvider, type OpenSwarmConfig } from './OpenSwarmProvider';
 
-export { OpenSwarmProvider } from './OpenSwarmProvider';
+export { OpenSwarmProvider, type OpenSwarmConfig } from './OpenSwarmProvider';
 export { SwarmInstaller } from './SwarmInstaller';
 export { schema } from './schema';
 
-/** Standard factory — preferred entry point for PluginLoader */
-export function create(_config?: any): OpenSwarmProvider {
-  return new OpenSwarmProvider();
+/**
+ * Standard factory — preferred entry point for PluginLoader.
+ *
+ * Accepts an optional per-bot config so callers can override `baseUrl`,
+ * `apiKey`, and `team`. The PluginLoader passes config in two shapes:
+ * the plain provider keys (`baseUrl`/`apiKey`/`team`) and the raw env-var
+ * names from the schema (`OPENSWARM_BASE_URL`, etc.). Both are honored.
+ */
+export function create(
+  config?: (OpenSwarmConfig & Record<string, unknown>) | null
+): OpenSwarmProvider {
+  const c = (config ?? {}) as Record<string, unknown>;
+  return new OpenSwarmProvider({
+    baseUrl: (c.baseUrl as string) ?? (c.OPENSWARM_BASE_URL as string),
+    apiKey: (c.apiKey as string) ?? (c.OPENSWARM_API_KEY as string),
+    team: (c.team as string) ?? (c.OPENSWARM_TEAM as string),
+  });
 }
 
 export const manifest: PluginManifest = {


### PR DESCRIPTION
## What
`OpenSwarmProvider`'s constructor read only environment variables, and the `create(_config)` factory ignored its argument. As a result, per-bot `baseUrl`/`apiKey`/`team` supplied by the PluginLoader could never take effect — every bot shared the global env-var config.

## Why
The PluginLoader instantiates providers via `mod.create(config)` with per-bot configuration. OpenSwarm silently dropped that config, so multi-bot deployments couldn't point different bots at different OpenSwarm servers or use different API keys.

## Behavior
- Added `OpenSwarmConfig` interface (`baseUrl`, `apiKey`, `team`).
- Constructor now accepts an optional config; each field falls back to its env var, then a built-in default.
- `create()` forwards config to the constructor, honoring both plain keys (`baseUrl`/`apiKey`/`team`) and the raw schema keys (`OPENSWARM_BASE_URL`/`OPENSWARM_API_KEY`/`OPENSWARM_TEAM`).
- Configured `team` is used as the default model when request metadata omits `team`/`model`.
- No behavior change when no config is passed (env vars / defaults still apply), so startup and the default pipeline are unaffected.

## Verification
- `npx tsc --noEmit` — clean.
- `npx jest packages/llm-openswarm/src/OpenSwarmProvider.test.ts` — 11/11 pass, including two new tests asserting per-bot `baseUrl`/`apiKey`/`team` reach the outgoing request (URL + Authorization header + model body). These fail against the old code (which always defaulted to `localhost:8000`).
- README updated to document the now-honored config.