### PR TITLE
fix(pipeline): resolve LLM provider from per-message botConfig

### DIFF
--- a/src/pipeline/InferenceStage.ts
+++ b/src/pipeline/InferenceStage.ts
@@ -43,7 +43,13 @@ export interface LlmInvoker {
     history: IMessage[],
     systemPrompt: string,
 
-    metadata?: Record<string, any>
+    metadata?: Record<string, any>,
+    /**
+     * Per-message bot configuration snapshot. Implementations should use this
+     * to resolve the correct LLM provider for the bot handling the message,
+     * rather than relying on a single config captured at construction time.
+     */
+    botConfig?: Record<string, unknown>
   ): Promise<string>;
 }
 
@@ -115,7 +121,8 @@ export class InferenceStage {
         userMessage,
         ctx.history,
         ctx.systemPrompt,
-        ctx.metadata
+        ctx.metadata,
+        ctx.botConfig
       );
 
       const durationMs = Date.now() - startTime;

--- a/src/pipeline/adapters/LlmInvokerAdapter.ts
+++ b/src/pipeline/adapters/LlmInvokerAdapter.ts
@@ -17,7 +17,13 @@ import type { IMessage } from '@message/interfaces/IMessage';
  * Dependencies required by the LlmInvokerAdapter.
  */
 export interface LlmInvokerDeps {
-  /** The active bot configuration used to resolve the LLM provider. */
+  /**
+   * Fallback bot configuration used to resolve the LLM provider when no
+   * per-message config is supplied to {@link LlmInvokerAdapter.generateResponse}.
+   *
+   * In normal pipeline operation the per-message `ctx.botConfig` is passed
+   * through and takes precedence, so this is only a fallback.
+   */
   botConfig: Record<string, unknown>;
 }
 
@@ -33,9 +39,16 @@ export class LlmInvokerAdapter implements LlmInvoker {
     history: IMessage[],
     systemPrompt: string,
 
-    metadata?: Record<string, any>
+    metadata?: Record<string, any>,
+    botConfig?: Record<string, unknown>
   ): Promise<string> {
-    const provider = await getLlmProviderForBot(this.deps.botConfig);
+    // Prefer the per-message bot config so the pipeline resolves the provider
+    // for the bot actually handling this message. Fall back to the config
+    // captured at construction time only when none is supplied.
+    const resolvedConfig =
+      botConfig && Object.keys(botConfig).length > 0 ? botConfig : this.deps.botConfig;
+
+    const provider = await getLlmProviderForBot(resolvedConfig);
 
     return provider.generateChatCompletion(userMessage, history, {
       ...metadata,

--- a/tests/integration/pipeline/fullPipeline.integration.test.ts
+++ b/tests/integration/pipeline/fullPipeline.integration.test.ts
@@ -335,12 +335,13 @@ describe('Full 5-stage pipeline integration', () => {
       expect(events.enriched?.[0].memories).toEqual(['memory-alpha', 'memory-beta']);
       expect(events.enriched?.[0].systemPrompt).toBe('Custom system prompt.');
 
-      // LLM invoker received the system prompt
+      // LLM invoker received the system prompt and the per-message bot config
       expect(llm.generateResponse).toHaveBeenCalledWith(
         'question',
         expect.any(Array),
         'Custom system prompt.',
-        expect.any(Object)
+        expect.any(Object),
+        expect.objectContaining({ BOT_NAME: 'TestBot' })
       );
     });
   });

--- a/tests/unit/pipeline/LlmInvokerAdapter.test.ts
+++ b/tests/unit/pipeline/LlmInvokerAdapter.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for {@link LlmInvokerAdapter}.
+ *
+ * Focus: the adapter must resolve the LLM provider from the **per-message**
+ * bot config passed to `generateResponse()` (i.e. `ctx.botConfig` flowing from
+ * the pipeline), not the (possibly empty) fallback config captured at
+ * construction time. This guards the pipeline-botconfig regression where
+ * `createPipeline` was wired with `botConfig: {}`.
+ */
+
+import { LlmInvokerAdapter } from '@src/pipeline/adapters/LlmInvokerAdapter';
+import * as getLlmProvider from '@src/llm/getLlmProvider';
+import type { ILlmProvider } from '@llm/interfaces/ILlmProvider';
+
+describe('LlmInvokerAdapter', () => {
+  let provider: ILlmProvider;
+  let spy: jest.SpyInstance;
+
+  beforeEach(() => {
+    provider = {
+      name: 'mock',
+      supportsChatCompletion: true,
+      supportsCompletion: false,
+      supportsHistory: true,
+      generateChatCompletion: jest.fn().mockResolvedValue('mock response'),
+      generateCompletion: jest.fn().mockResolvedValue('mock response'),
+    } as unknown as ILlmProvider;
+
+    spy = jest
+      .spyOn(getLlmProvider, 'getLlmProviderForBot')
+      .mockResolvedValue(provider);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('resolves the provider from the per-message botConfig, not the construction-time fallback', async () => {
+    // Construction-time fallback is empty (mirrors createPipeline's `botConfig: {}`).
+    const adapter = new LlmInvokerAdapter({ botConfig: {} });
+
+    const perMessageConfig = {
+      name: 'BotA',
+      llmProvider: 'openai',
+      openai: { apiKey: 'sk-bot-a', model: 'gpt-4o' },
+    };
+
+    await adapter.generateResponse('hi', [], 'system', {}, perMessageConfig);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(perMessageConfig);
+    // Ensure it did NOT use the empty fallback.
+    expect(spy).not.toHaveBeenCalledWith({});
+  });
+
+  it('falls back to the construction-time botConfig when no per-message config is supplied', async () => {
+    const fallbackConfig = { name: 'FallbackBot', llmProvider: 'openai' };
+    const adapter = new LlmInvokerAdapter({ botConfig: fallbackConfig });
+
+    await adapter.generateResponse('hi', [], 'system');
+
+    expect(spy).toHaveBeenCalledWith(fallbackConfig);
+  });
+
+  it('falls back when an empty per-message config is supplied', async () => {
+    const fallbackConfig = { name: 'FallbackBot' };
+    const adapter = new LlmInvokerAdapter({ botConfig: fallbackConfig });
+
+    await adapter.generateResponse('hi', [], 'system', {}, {});
+
+    expect(spy).toHaveBeenCalledWith(fallbackConfig);
+  });
+
+  it('forwards the system prompt and metadata to the resolved provider', async () => {
+    const adapter = new LlmInvokerAdapter({ botConfig: {} });
+
+    await adapter.generateResponse('hello', [], 'be helpful', { foo: 'bar' }, { name: 'BotB' });
+
+    expect(provider.generateChatCompletion).toHaveBeenCalledWith('hello', [], {
+      foo: 'bar',
+      systemPrompt: 'be helpful',
+    });
+  });
+});


### PR DESCRIPTION
## What
The 5-stage message pipeline (the default message path) ignored per-bot LLM provider configuration. `LlmInvokerAdapter` resolved the provider from the config captured at construction time (`deps.botConfig`), which `initServices.ts` wires as an empty object (`createPipeline(bus, { botConfig: {}, ... })` at src/server/initServices.ts:461-466). Every bot therefore fell back to the system-default provider regardless of its own `llmProvider`/profile config.

## Why
The real per-message bot config flows through the pipeline as `ctx.botConfig` (emitted on `message:incoming` from the messenger's message handler in initServices.ts), but `InferenceStage` never forwarded it to the LLM invoker. Provider resolution must use the per-message `ctx.botConfig`, not the empty fallback.

## Behavior
- `LlmInvoker.generateResponse()` gains an **optional** trailing `botConfig` parameter (backwards-compatible).
- `InferenceStage.process()` forwards `ctx.botConfig` to the invoker.
- `LlmInvokerAdapter` prefers the per-message `botConfig` (when non-empty) and falls back to its construction-time config otherwise. The `botConfig: {}` wiring in `initServices` is now a harmless fallback.
- No change to startup, the default pipeline flow, skip/error paths, or message handling semantics.

## Verification
- `npx tsc --noEmit`: clean.
- `eslint` on changed src files: 0 errors.
- New unit test `tests/unit/pipeline/LlmInvokerAdapter.test.ts` and the extended `tests/integration/pipeline/fullPipeline.integration.test.ts`: **both fail before the change, pass after** (verified via git stash). 14/14 tests pass with the fix.

Do not merge — for review.