### PR TITLE
fix(tool-mcp): use real MCP SDK transport API in McpToolProvider

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -96,6 +96,7 @@ module.exports = {
         ? '<rootDir>/node_modules/discord.js'
         : '<rootDir>/tests/__mocks__/discord.js.ts',
     '^pg$': '<rootDir>/tests/mocks/pg.js',
+    '^@modelcontextprotocol/sdk/client/.*$': '<rootDir>/tests/mocks/modelcontextprotocol-sdk.ts',
     '^@modelcontextprotocol/sdk$': '<rootDir>/tests/mocks/modelcontextprotocol-sdk.ts',
     '^@socket.io/redis-adapter$': '<rootDir>/tests/mocks/redisAdapter.js',
   },

--- a/packages/tool-mcp/src/McpToolProvider.test.ts
+++ b/packages/tool-mcp/src/McpToolProvider.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for McpToolProvider connection wiring.
+ *
+ * These assert the regression fix for `mcp-sdk-require-toolprovider`: the
+ * provider must import the MCP SDK from its real subpath entry points and call
+ * `client.connect(transport)` with a constructed transport object (NOT the old
+ * broken `require('@modelcontextprotocol/sdk')` + `connect({ url, apiKey })`).
+ *
+ * The SDK is mocked via jest.config.js moduleNameMapper -> tests/mocks/
+ * modelcontextprotocol-sdk.ts for both the root and `/client/*` subpaths.
+ */
+import { McpToolProvider } from './McpToolProvider';
+
+// Pull the shared SDK mock spies. Each SDK subpath resolves to this same mock
+// module via jest.config.js, so importing any one of them yields the spies.
+import {
+  Client as MockClient,
+  mockConnect,
+  mockListTools,
+  SSEClientTransport,
+  StreamableHTTPClientTransport,
+  StdioClientTransport,
+} from '@modelcontextprotocol/sdk/client/index.js';
+
+const Client = MockClient as unknown as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('McpToolProvider connection', () => {
+  it('connects using an SSE transport and the constructed transport object', async () => {
+    const provider = new McpToolProvider({
+      name: 'test-sse',
+      serverUrl: 'https://example.com/mcp',
+      transport: 'sse',
+      apiKey: 'secret-key',
+    });
+
+    await provider.listTools();
+
+    // Client constructed with name/version metadata.
+    expect(Client).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Open-Hivemind-test-sse', version: '1.0.0' })
+    );
+
+    // SSE transport built from the server URL with the API key as a Bearer header.
+    expect(SSEClientTransport).toHaveBeenCalledTimes(1);
+    const [urlArg, optsArg] = (SSEClientTransport as unknown as jest.Mock).mock.calls[0];
+    expect(urlArg).toBeInstanceOf(URL);
+    expect((urlArg as URL).href).toBe('https://example.com/mcp');
+    expect(optsArg).toEqual({
+      requestInit: { headers: { Authorization: 'Bearer secret-key' } },
+    });
+
+    // connect() is called with the transport object, not { url, apiKey }.
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+    const connectArg = mockConnect.mock.calls[0][0];
+    expect(connectArg).toMatchObject({ kind: 'sse' });
+    expect(connectArg).not.toHaveProperty('apiKey');
+
+    expect(mockListTools).toHaveBeenCalled();
+  });
+
+  it('uses a streamable-http transport when configured', async () => {
+    const provider = new McpToolProvider({
+      name: 'test-http',
+      serverUrl: 'https://example.com/mcp',
+      transport: 'streamable-http',
+    });
+
+    await provider.listTools();
+
+    expect(StreamableHTTPClientTransport).toHaveBeenCalledTimes(1);
+    expect(SSEClientTransport).not.toHaveBeenCalled();
+    const connectArg = mockConnect.mock.calls[0][0];
+    expect(connectArg).toMatchObject({ kind: 'streamable-http' });
+  });
+
+  it('uses a stdio transport with the configured command', async () => {
+    const provider = new McpToolProvider({
+      name: 'test-stdio',
+      serverUrl: 'stdio://noop',
+      transport: 'stdio',
+      command: 'my-mcp-server',
+    });
+
+    await provider.listTools();
+
+    expect(StdioClientTransport).toHaveBeenCalledWith(
+      expect.objectContaining({ command: 'my-mcp-server' })
+    );
+    const connectArg = mockConnect.mock.calls[0][0];
+    expect(connectArg).toMatchObject({ kind: 'stdio' });
+  });
+
+  it('omits the auth header when no API key is provided', async () => {
+    const provider = new McpToolProvider({
+      name: 'test-noauth',
+      serverUrl: 'https://example.com/mcp',
+      transport: 'sse',
+    });
+
+    await provider.listTools();
+
+    const [, optsArg] = (SSEClientTransport as unknown as jest.Mock).mock.calls[0];
+    expect(optsArg).toEqual({ requestInit: undefined });
+  });
+
+  it('throws a descriptive error when connection fails', async () => {
+    mockConnect.mockRejectedValueOnce(new Error('boom'));
+
+    const provider = new McpToolProvider({
+      name: 'test-fail',
+      serverUrl: 'https://example.com/mcp',
+      transport: 'sse',
+    });
+
+    await expect(provider.listTools()).rejects.toThrow(/Failed to connect to MCP server test-fail/);
+  });
+});

--- a/packages/tool-mcp/src/McpToolProvider.ts
+++ b/packages/tool-mcp/src/McpToolProvider.ts
@@ -124,13 +124,58 @@ export class McpToolProvider implements IToolProvider {
     }
   }
 
+  /**
+   * Build the appropriate MCP transport for the configured protocol.
+   *
+   * Each transport is imported lazily from its dedicated SDK subpath so the
+   * heavy SDK is only loaded when a connection is actually established. The
+   * optional API key is forwarded as a Bearer `Authorization` header for the
+   * HTTP-based transports (`sse` / `streamable-http`).
+   */
+  private async createTransport(): Promise<unknown> {
+    const transport = this.config.transport ?? 'sse';
+
+    const authHeaders = this.config.apiKey
+      ? { Authorization: `Bearer ${this.config.apiKey}` }
+      : undefined;
+
+    if (transport === 'stdio') {
+      if (!this.config.command) {
+        throw new Error(
+          `MCP server ${this.name} uses stdio transport but no command was configured`
+        );
+      }
+      const { StdioClientTransport } = await import(
+        '@modelcontextprotocol/sdk/client/stdio.js'
+      );
+      return new StdioClientTransport({ command: this.config.command, args: [] });
+    }
+
+    const serverUrl = new URL(this.config.serverUrl);
+
+    if (transport === 'streamable-http') {
+      const { StreamableHTTPClientTransport } = await import(
+        '@modelcontextprotocol/sdk/client/streamableHttp.js'
+      );
+      return new StreamableHTTPClientTransport(serverUrl, {
+        requestInit: authHeaders ? { headers: authHeaders } : undefined,
+      });
+    }
+
+    // Default / 'sse'
+    const { SSEClientTransport } = await import('@modelcontextprotocol/sdk/client/sse.js');
+    return new SSEClientTransport(serverUrl, {
+      requestInit: authHeaders ? { headers: authHeaders } : undefined,
+    });
+  }
+
   private async ensureConnected(): Promise<void> {
     if (this.client) {
       return;
     }
 
     try {
-      const { Client } = require('@modelcontextprotocol/sdk');
+      const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
 
       this.client = new Client({
         name: `Open-Hivemind-${this.name}`,
@@ -141,10 +186,8 @@ export class McpToolProvider implements IToolProvider {
         `Connecting to MCP server ${this.name} at ${this.config.serverUrl} (${this.config.transport})`
       );
 
-      await this.client.connect({
-        url: this.config.serverUrl,
-        apiKey: this.config.apiKey,
-      });
+      const transport = await this.createTransport();
+      await this.client.connect(transport);
 
       debug(`Connected to MCP server ${this.name}`);
     } catch (error) {

--- a/tests/mocks/modelcontextprotocol-sdk.ts
+++ b/tests/mocks/modelcontextprotocol-sdk.ts
@@ -1,20 +1,36 @@
 /**
  * Mock for @modelcontextprotocol/sdk
  *
- * The real SDK is an optional dependency that is not installed.
+ * The real SDK is an optional dependency that may not be installed in CI.
  * This mock is wired via moduleNameMapper in jest.config.js so that
- * `require('@modelcontextprotocol/sdk')` inside McpToolProvider resolves
- * here during tests.
+ * imports of the SDK (root or client subpaths) inside McpToolProvider /
+ * MCPService resolve here during tests.
+ *
+ * It deliberately covers both the legacy root entry point and the modern
+ * subpath entry points (`/client/index.js`, `/client/sse.js`, etc.) that the
+ * real SDK exposes, since jest.config.js maps all of them to this file.
  */
 
-const mockConnect = jest.fn().mockResolvedValue(undefined);
-const mockListTools = jest.fn().mockResolvedValue({ tools: [] });
-const mockCallTool = jest.fn().mockResolvedValue({ content: 'ok', isError: false });
+export const mockConnect = jest.fn().mockResolvedValue(undefined);
+export const mockListTools = jest.fn().mockResolvedValue({ tools: [] });
+export const mockCallTool = jest.fn().mockResolvedValue({ content: 'ok', isError: false });
 
-const MockClient = jest.fn().mockImplementation(() => ({
+export const MockClient = jest.fn().mockImplementation(() => ({
   connect: mockConnect,
   listTools: mockListTools,
   callTool: mockCallTool,
 }));
 
-export { MockClient as Client, mockConnect, mockListTools, mockCallTool, MockClient };
+export const SSEClientTransport = jest
+  .fn()
+  .mockImplementation((url: URL, opts?: unknown) => ({ kind: 'sse', url, opts }));
+
+export const StreamableHTTPClientTransport = jest
+  .fn()
+  .mockImplementation((url: URL, opts?: unknown) => ({ kind: 'streamable-http', url, opts }));
+
+export const StdioClientTransport = jest
+  .fn()
+  .mockImplementation((opts?: unknown) => ({ kind: 'stdio', opts }));
+
+export { MockClient as Client };


### PR DESCRIPTION
## What
`McpToolProvider.ensureConnected()` connected via `require('@modelcontextprotocol/sdk')` to destructure `{ Client }` and then called `client.connect({ url, apiKey })`. Neither matches the real SDK:
- The SDK has no root `Client` export — `Client` lives at `@modelcontextprotocol/sdk/client/index.js`.
- `Client.connect()` takes a constructed **Transport** object, not `{ url, apiKey }`.

This PR fixes the import paths and connect call to the real SDK API and adds tests.

## Why
As written, every MCP connection threw (`require` returns a module with no `Client`, and `connect({url,apiKey})` is rejected by the SDK). The MCP tool provider was non-functional.

## Behavior
- Imports `Client` from `@modelcontextprotocol/sdk/client/index.js`.
- Builds the transport from its dedicated subpath based on `config.transport`:
  - `sse` -> `SSEClientTransport(url, { requestInit })`
  - `streamable-http` -> `StreamableHTTPClientTransport(url, { requestInit })`
  - `stdio` -> `StdioClientTransport({ command, args })`
- Forwards `apiKey` as a `Bearer` `Authorization` header for HTTP transports; omits it when absent.
- Calls `client.connect(transport)`.
- Mirrors the existing convention already used in `src/server/routes/mcp/shared.ts` (dynamic `import()` of SDK subpaths, `new Client({name, version})`).

## Verification
- `npx tsc --noEmit`: clean (exit 0).
- `jest packages/tool-mcp/src/McpToolProvider.test.ts`: 5/5 pass. New tests assert the transport is constructed and `connect(transport)` is called (never `connect({url,apiKey})`), covering all three transports, header on/off, and connection-failure wrapping — these fail on the old code.
- Extended the shared SDK jest mock (`tests/mocks/modelcontextprotocol-sdk.ts`) with the transport classes and added a `@modelcontextprotocol/sdk/client/*` moduleNameMapper entry; backward-compatible exports preserved.

## Notes
ESLint could not be run in the worktree — the junctioned `node_modules` has a broken `@eslint/eslintrc`/`ajv` install that crashes eslint on *any* file (including untouched ones), unrelated to this change. Type-check and tests both pass.