### PR TITLE
fix(audit): return real audit events from audit endpoints

### DIFF
--- a/src/server/routes/admin/audit.ts
+++ b/src/server/routes/admin/audit.ts
@@ -1,5 +1,6 @@
 import { Router, type Request, type Response } from 'express';
 import { ApiResponse } from '@src/server/utils/apiResponse';
+import { AuditLogger } from '../../../common/auditLogger';
 import { ErrorUtils } from '../../../common/ErrorUtils';
 import { HTTP_STATUS } from '../../../types/constants';
 import {
@@ -217,9 +218,23 @@ router.post(
   }
 );
 
-// Placeholder for audit log queries
-router.get('/audit-logs', (req, res) => {
-  res.json(ApiResponse.success({ logs: [] }));
+// GET /audit-logs - Return real audit events from the audit logger
+router.get('/audit-logs', async (req, res) => {
+  try {
+    const { limit = '100', offset = '0', search, action, resource, user, dateFrom, dateTo } =
+      req.query as Record<string, string | undefined>;
+
+    const auditLogger = AuditLogger.getInstance();
+    const filter = auditLogger.buildFilter({ search, action, resource, user, dateFrom, dateTo });
+    const auditEvents = await auditLogger.getAuditEvents(Number(limit), Number(offset), filter);
+
+    return res.json(ApiResponse.success({ auditEvents, total: auditEvents.length }));
+  } catch (error: unknown) {
+    const _hivemindError = ErrorUtils.toHivemindError(error);
+    return res
+      .status(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+      .json(ApiResponse.error('Failed to retrieve audit logs'));
+  }
 });
 
 export default router;

--- a/src/server/routes/enterprise.ts
+++ b/src/server/routes/enterprise.ts
@@ -229,10 +229,9 @@ router.get('/audit', async (req, res) => {
       dateTo,
     });
 
-    // eslint-disable-next-line unused-imports/no-unused-vars
     const auditEvents = await auditLogger.getAuditEvents(Number(limit), Number(offset), filter);
 
-    return res.json(ApiResponse.success());
+    return res.json(ApiResponse.success({ auditEvents, total: auditEvents.length }));
   } catch (error) {
     debug('Audit API error:', error);
     return res

--- a/tests/unit/server/routes/auditRoutes.test.ts
+++ b/tests/unit/server/routes/auditRoutes.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Regression tests for audit log endpoints.
+ *
+ * Bug (audit-query-and-page):
+ *  - GET /api/enterprise/audit computed `auditEvents` but returned
+ *    ApiResponse.success() with NO data.
+ *  - GET /api/admin/audit-logs was a hardcoded placeholder returning { logs: [] }.
+ *
+ * Both endpoints must now return the real audit events from AuditLogger.
+ */
+
+import express from 'express';
+import request from 'supertest';
+
+import { AuditLogger, type AuditEvent } from '@src/common/auditLogger';
+import enterpriseRouter from '@src/server/routes/enterprise';
+import adminAuditRouter from '@src/server/routes/admin/audit';
+
+const SAMPLE_EVENTS: AuditEvent[] = [
+  {
+    id: 'audit_1',
+    timestamp: '2026-01-01T00:00:00.000Z',
+    user: 'admin',
+    action: 'CONFIG_UPDATE',
+    resource: 'config',
+    result: 'success',
+    details: 'Updated config',
+  },
+  {
+    id: 'audit_2',
+    timestamp: '2026-01-02T00:00:00.000Z',
+    user: 'admin',
+    action: 'BOT_START',
+    resource: 'bots/test',
+    result: 'success',
+    details: 'Started bot',
+  },
+];
+
+describe('Audit log endpoints', () => {
+  let getAuditEventsSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    const instance = AuditLogger.getInstance();
+    // buildFilter is exercised for real (pure); only the file read is stubbed.
+    getAuditEventsSpy = jest
+      .spyOn(instance, 'getAuditEvents')
+      .mockResolvedValue(SAMPLE_EVENTS);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('GET /api/enterprise/audit', () => {
+    const app = express();
+    app.use('/api/enterprise', enterpriseRouter);
+
+    it('returns the computed audit events in the response data', async () => {
+      const res = await request(app).get('/api/enterprise/audit');
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toBeDefined();
+      expect(res.body.data.auditEvents).toEqual(SAMPLE_EVENTS);
+      expect(res.body.data.total).toBe(SAMPLE_EVENTS.length);
+    });
+
+    it('forwards pagination params to the audit logger', async () => {
+      await request(app).get('/api/enterprise/audit?limit=5&offset=10');
+
+      expect(getAuditEventsSpy).toHaveBeenCalledWith(5, 10, expect.any(Function));
+    });
+  });
+
+  describe('GET /api/admin/audit-logs', () => {
+    const app = express();
+    app.use('/api/admin', adminAuditRouter);
+
+    it('returns real audit events instead of an empty placeholder', async () => {
+      const res = await request(app).get('/api/admin/audit-logs?limit=100');
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toBeDefined();
+      expect(res.body.data.auditEvents).toEqual(SAMPLE_EVENTS);
+      expect(res.body.data.total).toBe(SAMPLE_EVENTS.length);
+      // Must NOT be the old hardcoded placeholder shape.
+      expect(res.body.data.logs).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## What
Fixes two broken audit-log endpoints so the Audit Log page shows real data.

- `GET /api/enterprise/audit` (src/server/routes/enterprise.ts) computed `auditEvents` but returned `ApiResponse.success()` with **no data** (audit #23). Now returns `{ auditEvents, total }`.
- `GET /api/admin/audit-logs` (src/server/routes/admin/audit.ts) was a hardcoded placeholder returning `{ logs: [] }` (audit #24). This is the endpoint `AuditPage.tsx` fetches. It now queries the real `AuditLogger` (with the same composable query-param filters the enterprise endpoint uses) and returns `{ auditEvents, total }`.

## Why
`AuditPage.tsx` fetches `/api/admin/audit-logs` and reads `data?.data?.auditEvents`, so the page always rendered an empty audit log regardless of recorded events. The enterprise endpoint had the data on hand but dropped it on the floor.

## Behavior
- No new endpoints or parallel systems — reuses the existing `AuditLogger` singleton, `buildFilter`, and `getAuditEvents` already used by `/api/enterprise/audit` and `/api/enterprise/audit/export`.
- Response envelope is the standard `ApiResponse.success({ auditEvents, total })`, which `AuditPage` already understands. No frontend change required.

## Verification
- `npx tsc --noEmit` clean.
- New jest test `tests/unit/server/routes/auditRoutes.test.ts` (3 cases) passes; it fails against the pre-fix code (enterprise data was `undefined`; admin returned `{ logs: [] }`).
- Tests mount each router on a bare express app via supertest and stub `AuditLogger.getAuditEvents` (file read), exercising `buildFilter` for real.

## Notes
ESLint could not be run in this environment (pre-existing ajv/eslintrc crash, reproduces on main, unrelated to these changes). `tsc` was used to confirm no unused-var/type issues; the removed `eslint-disable unused-imports/no-unused-vars` comment is no longer needed because `auditEvents` is now consumed.