### PR TITLE
fix(mcp-testing): populate tool list and import Textarea on MCP Tools Testing page

### DIFF
--- a/src/client/src/pages/MCPToolsTestingPage.test.tsx
+++ b/src/client/src/pages/MCPToolsTestingPage.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render, screen, waitFor } from '../test-utils';
+import { MemoryRouter } from 'react-router-dom';
+import MCPToolsTestingPage from './MCPToolsTestingPage';
+import { act } from 'react';
+
+// Mock fetch (authFetch delegates to global fetch)
+global.fetch = jest.fn();
+
+const serversResponse = {
+  success: true,
+  data: {
+    servers: [
+      {
+        name: 'demo-server',
+        connected: true,
+        tools: [
+          {
+            name: 'echo',
+            description: 'Echoes input back',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                items: { type: 'array', description: 'List of items' },
+              },
+              required: ['items'],
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+
+const renderPage = async () => {
+  await act(async () => {
+    render(
+      <MemoryRouter>
+        <MCPToolsTestingPage />
+      </MemoryRouter>
+    );
+  });
+};
+
+describe('MCPToolsTestingPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => serversResponse,
+    });
+  });
+
+  test('populates the tool list from the { data: { servers } } response shape', async () => {
+    await renderPage();
+
+    // Before the fix this read json.servers (undefined) so the list was always
+    // empty and the "No tools available" warning showed instead.
+    await waitFor(() => {
+      expect(screen.getByText('echo')).toBeInTheDocument();
+    });
+    expect(screen.getByText('demo-server')).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No tools available\. Connect MCP servers first\./i)
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders a textarea for array/object schema fields', async () => {
+    await renderPage();
+
+    // Select the tool to render its parameter form.
+    await waitFor(() => {
+      expect(screen.getByText('echo')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      screen.getByText('echo').closest('button')!.click();
+    });
+
+    // The array field renders a <textarea>; before the fix the component used an
+    // undefined <Textarea> which would crash on render.
+    await waitFor(() => {
+      const field = screen.getByPlaceholderText(/Enter array as JSON/i);
+      expect(field).toBeInTheDocument();
+      expect(field.tagName).toBe('TEXTAREA');
+    });
+  });
+});

--- a/src/client/src/pages/MCPToolsTestingPage.tsx
+++ b/src/client/src/pages/MCPToolsTestingPage.tsx
@@ -13,7 +13,7 @@ import {
 import PageHeader from '../components/DaisyUI/PageHeader';
 import { SkeletonGrid } from '../components/DaisyUI/Skeleton';
 import { Alert } from '../components/DaisyUI/Alert';
-import { Card, Badge, Divider, Mockup, Input, Select, Button, LoadingSpinner } from '../components/DaisyUI';
+import { Card, Badge, Divider, Mockup, Input, Select, Button, LoadingSpinner, Textarea } from '../components/DaisyUI';
 import Debug from 'debug';
 
 const debug = Debug('app:client:pages:MCPToolsTestingPage');
@@ -51,7 +51,8 @@ const MCPToolsTestingPage: React.FC = () => {
         const res = await authFetch('/api/mcp/servers');
         if (res.ok) {
           const json = await res.json();
-          const serverList = json.servers || [];
+          // GET /api/mcp/servers responds with { success, data: { servers } }
+          const serverList = json.data?.servers || json.servers || [];
           setServers(serverList);
 
           // Flatten tools from all servers


### PR DESCRIPTION
## What
Fix two bugs on the MCP Tools Testing page (`src/client/src/pages/MCPToolsTestingPage.tsx`):

1. The fetch read `json.servers`, but `GET /api/mcp/servers` responds with `{ success, data: { servers } }` (see `src/server/routes/mcp/servers.ts:36`). The tool list was therefore always empty and the page showed "No tools available".
2. Array/object parameter fields rendered `<Textarea>` without importing it, which would crash on render when a tool exposes an array/object input.

## Why
The page was unusable: no tools ever appeared, and selecting a tool with an array/object parameter would throw a ReferenceError for the undefined `Textarea`.

## Behavior
- Server list is now read from `json.data?.servers` (with a `json.servers` fallback), so tools populate correctly.
- `Textarea` is imported from the DaisyUI barrel (`../components/DaisyUI`), which already exports it. Its props spread to the native `<textarea>`, so the existing usage (placeholder/value/onChange/disabled/rows) is unchanged.

## Verification
- New vitest test `src/client/src/pages/MCPToolsTestingPage.test.tsx` (2 cases): tool list populates from the `data.servers` shape, and array fields render a `<textarea>`. Confirmed FAILS before the fix, PASSES after.
- `cd src/client && npx vitest run src/pages/MCPToolsTestingPage.test.tsx` -> 2 passed.
- `cd src/client && npx tsc --noEmit` -> clean.
- eslint on the changed files -> 0 errors.

Do NOT merge automatically; review requested.