### PR TITLE
fix(mcp): load MCP SDK via real subpath imports in MCPService

### DIFF
--- a/src/mcp/MCPService.ts
+++ b/src/mcp/MCPService.ts
@@ -1,7 +1,14 @@
 import Debug from 'debug';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SlackMessageProvider } from '@hivemind/message-slack';
 import { BotConfigurationManager } from '@config/BotConfigurationManager';
 import { MCPGuard, type MCPGuardConfig } from './MCPGuard';
+
+// The MCP SDK is published as ESM-only with subpath exports (no CJS root
+// export), so it MUST be loaded via a dynamic `import()` of the real entry
+// points — `require('@modelcontextprotocol/sdk')` throws because that root
+// path has no usable export. This mirrors the pattern in
+// src/server/routes/mcp/shared.ts.
 
 // DiscordMessageProvider imported dynamically to avoid ESM require error
 
@@ -23,10 +30,53 @@ export interface MCPTool {
 export class MCPService {
   private static instance: MCPService;
 
-  private clients = new Map<string, any>();
+  private clients = new Map<string, Client>();
   private tools = new Map<string, MCPTool[]>();
 
   private constructor() {}
+
+  /**
+   * Creates and connects an MCP {@link Client} for the given server config.
+   *
+   * Loads the SDK via dynamic `import()` of its real subpath entry points
+   * (the package has no working CJS root export, so `require()` throws), then
+   * selects the correct transport from the server URL scheme:
+   *  - `http(s)://` -> StreamableHTTPClientTransport (remote servers); the
+   *    optional apiKey is sent as a Bearer Authorization header.
+   *  - `stdio://`   -> StdioClientTransport (local command servers).
+   *
+   * @param config - The MCP server configuration.
+   * @param clientName - The client identity reported to the server.
+   * @returns A connected MCP client.
+   */
+  private async createConnectedClient(config: MCPConfig, clientName: string): Promise<Client> {
+    const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+
+    const client = new Client(
+      { name: clientName, version: '1.0.0' },
+      { capabilities: { experimental: {} } }
+    );
+
+    const url = config.serverUrl;
+    if (url.startsWith('stdio://')) {
+      const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
+      const command = url.replace('stdio://', '');
+      const transport = new StdioClientTransport({ command, args: [] });
+      await client.connect(transport);
+      return client;
+    }
+
+    const { StreamableHTTPClientTransport } = await import(
+      '@modelcontextprotocol/sdk/client/streamableHttp.js'
+    );
+    const transport = new StreamableHTTPClientTransport(new URL(url), {
+      requestInit: config.apiKey
+        ? { headers: { Authorization: `Bearer ${config.apiKey}` } }
+        : undefined,
+    });
+    await client.connect(transport);
+    return client;
+  }
 
   /**
    * Gets the singleton instance of MCPService.
@@ -53,27 +103,17 @@ export class MCPService {
     try {
       debug(`Testing connection to MCP server: ${config.name} at ${config.serverUrl}`);
 
-      // Dynamically require the MCP SDK
-      const { Client } = require('@modelcontextprotocol/sdk');
-
-      // Create a new client for this server
-      const client = new Client({
-        name: 'Open-Hivemind-Test',
-        version: '1.0.0',
-      });
-
-      // Connect to the server
-      await client.connect({
-        url: config.serverUrl,
-        apiKey: config.apiKey,
-      });
+      // Establish a client using the real SDK entry points and transport.
+      const client = await this.createConnectedClient(config, 'Open-Hivemind-Test');
 
       // Try to list tools to verify connection works
       const tools = await client.listTools();
 
       // Add server name to each tool for identification
-      const mcpTools: MCPTool[] = tools.tools.map((tool: Record<string, unknown>) => ({
-        ...tool,
+      const mcpTools: MCPTool[] = tools.tools.map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        inputSchema: tool.inputSchema as Record<string, unknown> | undefined,
         serverName: config.name,
       }));
 
@@ -146,20 +186,8 @@ export class MCPService {
     try {
       debug(`Connecting to MCP server: ${config.name} at ${config.serverUrl}`);
 
-      // Dynamically require the MCP SDK
-      const { Client } = require('@modelcontextprotocol/sdk');
-
-      // Create a new client for this server
-      const client = new Client({
-        name: 'Open-Hivemind',
-        version: '1.0.0',
-      });
-
-      // Connect to the server
-      await client.connect({
-        url: config.serverUrl,
-        apiKey: config.apiKey,
-      });
+      // Establish a client using the real SDK entry points and transport.
+      const client = await this.createConnectedClient(config, 'Open-Hivemind');
 
       // Store the client
       this.clients.set(config.name, client);
@@ -168,8 +196,10 @@ export class MCPService {
       const tools = await client.listTools();
 
       // Add server name to each tool for identification
-      const mcpTools: MCPTool[] = tools.tools.map((tool: Record<string, unknown>) => ({
-        ...tool,
+      const mcpTools: MCPTool[] = tools.tools.map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        inputSchema: tool.inputSchema as Record<string, unknown> | undefined,
         serverName: config.name,
       }));
 

--- a/tests/unit/mcp/MCPService.test.ts
+++ b/tests/unit/mcp/MCPService.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Regression test for the MCP SDK import bug (audit #5/#6/#9).
+ *
+ * The SDK (@modelcontextprotocol/sdk) is published ESM-only with subpath
+ * exports and no usable CJS root export. The old code did
+ * `require('@modelcontextprotocol/sdk')` and destructured `{ Client }`, which
+ * throws at runtime, so connectToServer/testConnection/executeTool never
+ * worked. The fix dynamically imports the real subpaths and builds the correct
+ * transport.
+ *
+ * This test mocks the real SDK subpath modules and asserts that the client is
+ * constructed and connected (via a transport) without throwing. Against the
+ * old `require('@modelcontextprotocol/sdk')` code this fails (module not found
+ * / no Client export); against the fix it passes.
+ */
+
+const mockConnect = jest.fn().mockResolvedValue(undefined);
+const mockListTools = jest.fn().mockResolvedValue({ tools: [{ name: 'echo' }] });
+const mockCallTool = jest.fn().mockResolvedValue({ content: 'ok', isError: false });
+const ClientCtor = jest.fn().mockImplementation(() => ({
+  connect: mockConnect,
+  listTools: mockListTools,
+  callTool: mockCallTool,
+}));
+
+const StreamableHTTPCtor = jest.fn().mockImplementation((url: URL) => ({ __kind: 'http', url }));
+const StdioCtor = jest.fn().mockImplementation((opts: unknown) => ({ __kind: 'stdio', opts }));
+
+jest.mock(
+  '@modelcontextprotocol/sdk/client/index.js',
+  () => ({ Client: ClientCtor }),
+  { virtual: true }
+);
+jest.mock(
+  '@modelcontextprotocol/sdk/client/streamableHttp.js',
+  () => ({ StreamableHTTPClientTransport: StreamableHTTPCtor }),
+  { virtual: true }
+);
+jest.mock(
+  '@modelcontextprotocol/sdk/client/stdio.js',
+  () => ({ StdioClientTransport: StdioCtor }),
+  { virtual: true }
+);
+
+import { MCPService } from '../../../src/mcp/MCPService';
+
+describe('MCPService SDK client construction', () => {
+  let service: MCPService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Fresh singleton each test so connect/disconnect state does not leak.
+    // @ts-expect-error - resetting private singleton for isolation
+    MCPService.instance = undefined;
+    service = MCPService.getInstance();
+  });
+
+  it('constructs and connects a Client without throwing for a remote HTTP server', async () => {
+    await expect(
+      service.connectToServer({
+        name: 'remote',
+        serverUrl: 'https://example.com/mcp',
+        apiKey: 'secret',
+      })
+    ).resolves.toEqual([{ name: 'echo', serverName: 'remote' }]);
+
+    // The real SDK Client constructor was used (proves it no longer relies on
+    // the broken `require('@modelcontextprotocol/sdk')` root export).
+    expect(ClientCtor).toHaveBeenCalledTimes(1);
+    // A real transport instance was passed to connect() (not a {url,apiKey}
+    // object, which the old code wrongly used).
+    expect(mockConnect).toHaveBeenCalledWith(
+      expect.objectContaining({ __kind: 'http' })
+    );
+    expect(service.getConnectedServers()).toContain('remote');
+  });
+
+  it('sends the apiKey as a Bearer Authorization header on the HTTP transport', async () => {
+    await service.connectToServer({
+      name: 'remote',
+      serverUrl: 'https://example.com/mcp',
+      apiKey: 'secret',
+    });
+
+    expect(StreamableHTTPCtor).toHaveBeenCalledTimes(1);
+    const [urlArg, optsArg] = StreamableHTTPCtor.mock.calls[0];
+    expect(urlArg).toBeInstanceOf(URL);
+    expect((urlArg as URL).href).toBe('https://example.com/mcp');
+    expect(optsArg).toEqual({
+      requestInit: { headers: { Authorization: 'Bearer secret' } },
+    });
+  });
+
+  it('uses the stdio transport for stdio:// URLs', async () => {
+    await service.connectToServer({
+      name: 'local',
+      serverUrl: 'stdio://my-mcp-binary',
+    });
+
+    expect(StdioCtor).toHaveBeenCalledWith({ command: 'my-mcp-binary', args: [] });
+    expect(mockConnect).toHaveBeenCalledWith(
+      expect.objectContaining({ __kind: 'stdio' })
+    );
+  });
+
+  it('testConnection builds a client and returns discovered tools', async () => {
+    const tools = await service.testConnection({
+      name: 'remote',
+      serverUrl: 'https://example.com/mcp',
+    });
+
+    expect(ClientCtor).toHaveBeenCalledTimes(1);
+    expect(tools).toEqual([{ name: 'echo', serverName: 'remote' }]);
+    // testConnection must NOT store the client.
+    expect(service.getConnectedServers()).not.toContain('remote');
+  });
+});


### PR DESCRIPTION
## What
`src/mcp/MCPService.ts` loaded the MCP SDK with `require('@modelcontextprotocol/sdk')` and destructured `{ Client }`. The installed SDK (v1.29.0) is ESM-only with subpath exports and has **no usable CJS root export** (the `.` export's `require` target `dist/cjs/index.js` does not exist). So the `require()` threw at the top of `connectToServer` / `testConnection`, and combined with `executeTool` depending on a stored client, remote MCP connect + tool execution never worked (audit #5/#6/#9).

The call was also doubly wrong: the SDK `Client.connect(transport)` expects a **Transport instance**, but the old code passed a plain `{ url, apiKey }` object.

## Why
Make remote MCP server connect/executeTool actually establish a client, using the SDK's real public API.

## Behavior
- New private `createConnectedClient()` dynamically `import()`s the real entry points:
  - `@modelcontextprotocol/sdk/client/index.js` -> `Client`
  - `@modelcontextprotocol/sdk/client/streamableHttp.js` -> `StreamableHTTPClientTransport` for `http(s)://` servers (apiKey sent as a `Bearer` Authorization header via `requestInit`)
  - `@modelcontextprotocol/sdk/client/stdio.js` -> `StdioClientTransport` for `stdio://` servers
- This mirrors the existing dynamic-import pattern already used in `src/server/routes/mcp/shared.ts`.
- `clients` map is now typed `Map<string, Client>` instead of `any`; tool mapping projects to the `MCPTool` shape explicitly.
- No change to the guard logic, pipeline, or startup.

## Verification
- `npx tsc --noEmit`: clean (0 errors).
- New unit test `tests/unit/mcp/MCPService.test.ts` (mocks the SDK subpath modules): 4 tests pass — Client constructs/connects without throwing for HTTP, Bearer header is set, stdio transport is selected for `stdio://`, and `testConnection` returns discovered tools without storing the client. These fail against the old `require()`-based code.
- No other unit/integration tests reference MCPService; frontend untouched.

Note: repo-wide `eslint` is currently broken by an unrelated ajv/eslintrc dependency conflict (fails identically on untouched files), so eslint could not be run here.