### PR TITLE
fix(mcp): MCPServerManager reads wrong response shape (table always empty)

### DIFF
--- a/src/client/src/components/MCPServerManager.tsx
+++ b/src/client/src/components/MCPServerManager.tsx
@@ -8,6 +8,7 @@ import {
 import { Alert } from './DaisyUI/Alert';
 import Badge from './DaisyUI/Badge';
 import Button from './DaisyUI/Button';
+import Input from './DaisyUI/Input';
 import { SkeletonList } from './DaisyUI/Skeleton';
 import Card from './DaisyUI/Card';
 import Modal, { ConfirmModal } from './DaisyUI/Modal';
@@ -51,23 +52,29 @@ const MCPServerManager: React.FC = () => {
       setError(null);
       const data: any = await apiService.get('/api/admin/mcp-servers');
 
+      // The endpoint wraps its payload in an envelope: { success, data: { servers, configurations, ... } }.
+      // `servers` is an array of connected servers; `configurations` is an array of stored configs.
+      const payload = data?.data ?? {};
+
       const serverList: MCPServer[] = [];
-      if (data.servers) {
-        Object.entries(data.servers).forEach(([name, server]: [string, unknown]) => {
-          const serverObj = server as { serverUrl?: string; apiKey?: string };
-          serverList.push({
-            name,
-            serverUrl: serverObj.serverUrl || '',
-            apiKey: serverObj.apiKey || '',
-            connected: true,
-          });
+      if (Array.isArray(payload.servers)) {
+        payload.servers.forEach((server: unknown) => {
+          const serverObj = server as { name?: string; serverUrl?: string; apiKey?: string; connected?: boolean };
+          if (serverObj.name) {
+            serverList.push({
+              name: serverObj.name,
+              serverUrl: serverObj.serverUrl || '',
+              apiKey: serverObj.apiKey || '',
+              connected: serverObj.connected ?? true,
+            });
+          }
         });
       }
-      if (data.configurations) {
+      if (Array.isArray(payload.configurations)) {
         // Performance optimization: use Set for O(1) lookups instead of O(N) array search inside loop
         const existingServerNames = new Set(serverList.map(s => s.name));
 
-        data.configurations.forEach((config: unknown) => {
+        payload.configurations.forEach((config: unknown) => {
           const configObj = config as { name?: string; serverUrl?: string; apiKey?: string };
           if (configObj.name && !existingServerNames.has(configObj.name)) {
             serverList.push({
@@ -130,7 +137,7 @@ const MCPServerManager: React.FC = () => {
     setSelectedServer(server);
     try {
       const data: any = await apiService.get(`/api/admin/mcp-servers/${server.name}/tools`);
-      setServerTools(data.tools || []);
+      setServerTools(data?.data?.tools || []);
       setToolsDialogOpen(true);
     } catch (err) {
       setToastMessage(err instanceof Error ? err.message : 'Failed to fetch tools');

--- a/src/client/src/components/__tests__/MCPServerManager.test.tsx
+++ b/src/client/src/components/__tests__/MCPServerManager.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import MCPServerManager from '../MCPServerManager';
+import { apiService } from '../../services/api';
+
+// Mock apiService
+vi.mock('../../services/api', () => ({
+  apiService: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+// Lightweight DataTable mock that surfaces the `data` rows it receives so we can
+// assert the component parsed the API envelope into the right shape.
+vi.mock('../DaisyUI/DataTable', () => ({
+  __esModule: true,
+  default: ({ data }: { data: Array<{ name: string; serverUrl: string; connected: boolean }> }) => (
+    <div data-testid="data-table">
+      {data.map((row) => (
+        <div key={row.name} data-testid="server-row">
+          {row.name}|{row.serverUrl}|{row.connected ? 'connected' : 'disconnected'}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+describe('MCPServerManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders servers from the nested data.data.servers envelope returned by the API', async () => {
+    // This mirrors the real /api/admin/mcp-servers response: an envelope with
+    // `data.servers` as an ARRAY (not an object keyed by name).
+    vi.mocked(apiService.get).mockResolvedValue({
+      success: true,
+      data: {
+        servers: [
+          { name: 'alpha', serverUrl: 'https://alpha.example.com', connected: true },
+        ],
+        configurations: [
+          { name: 'beta', serverUrl: 'https://beta.example.com' },
+        ],
+      },
+      message: 'ok',
+    } as never);
+
+    render(<MCPServerManager />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('data-table')).toBeInTheDocument();
+    });
+
+    const rows = screen.getAllByTestId('server-row').map((el) => el.textContent);
+    // Connected server parsed from data.data.servers
+    expect(rows).toContain('alpha|https://alpha.example.com|connected');
+    // Stored-but-not-connected config parsed from data.data.configurations
+    expect(rows).toContain('beta|https://beta.example.com|disconnected');
+  });
+
+  it('renders no rows when the servers array is empty', async () => {
+    vi.mocked(apiService.get).mockResolvedValue({
+      success: true,
+      data: { servers: [], configurations: [] },
+      message: 'ok',
+    } as never);
+
+    render(<MCPServerManager />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('data-table')).toBeInTheDocument();
+    });
+
+    expect(screen.queryAllByTestId('server-row')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
@
## What
Fix `MCPServerManager.tsx` so the MCP server table at `/admin/mcp` actually populates.

## Why
`GET /api/admin/mcp-servers` returns an envelope:

```json
{ "success": true, "data": { "servers": [...], "configurations": [...], ... }, "message": "..." }
```

`servers` is an **array** of connected servers. The component read `data.servers` (one level too shallow) and iterated it with `Object.entries`, treating it as an object keyed by name. Because `data.servers` was `undefined`, the table was **always empty**. The newer `MCPServersPage` hook (`useMCPServerData.ts`) already reads `data.data.servers` correctly — this component was left behind.

Three issues fixed:
1. Read `data.data.servers` / `data.data.configurations` (correct envelope nesting), iterating `servers` as an array with `Array.isArray` guards — mirroring the canonical `useMCPServerData` hook.
2. `handleViewTools` had the same nesting bug: read `data.data.tools` instead of `data.tools`.
3. Added the missing `import Input from ./DaisyUI/Input` — `<Input>` was used in the Connect dialog JSX but never imported, crashing the dialog at runtime.

## Behavior
- Before: table empty regardless of connected/configured servers; Connect dialog crashed.
- After: connected servers show as "Connected", stored-only configs as "Disconnected"; Connect dialog and View Tools modal render correctly.

## Verification
- `npx tsc --noEmit` (src/client): clean.
- `eslint` on changed files: 0 errors.
- New test `src/components/__tests__/MCPServerManager.test.tsx`: 2 tests pass. Confirmed they **fail** against the pre-fix code (stashed the fix, ran, restored).

Frontend-only change; no backend files touched.
@