### PR TITLE
fix(mattermost): receive incoming messages via WebSocket subscription

### DIFF
--- a/packages/message-mattermost/src/MattermostService.ts
+++ b/packages/message-mattermost/src/MattermostService.ts
@@ -17,6 +17,7 @@ import type { IMessage } from '@message/interfaces/IMessage';
 import type { IMessengerService } from '@message/interfaces/IMessengerService';
 import { computeScore as channelComputeScore } from '@message/routing/ChannelRouter';
 import MattermostClient from './mattermostClient';
+import { MattermostMessage, type MattermostPost } from './MattermostMessage';
 
 const debug = Debug('app:MattermostService:verbose');
 
@@ -28,6 +29,12 @@ export class MattermostService extends EventEmitter implements IMessengerService
   private channels = new Map<string, string>();
   private botConfigs = new Map<string, any>();
   private app?: Application;
+  private messageHandler?: (
+    message: IMessage,
+    historyMessages: IMessage[],
+    botConfig: any
+  ) => Promise<string | null>;
+  private subscribedBots = new Set<string>();
 
   public supportsChannelPrioritization: boolean = true;
 
@@ -103,6 +110,9 @@ export class MattermostService extends EventEmitter implements IMessengerService
           userId: client.getCurrentUserId?.() || botConfig.userId,
           username: client.getCurrentUsername?.() || botConfig.username,
         });
+        // If a handler was registered before connect(), wire the incoming
+        // subscription now that the client (and its WebSocket) is live.
+        this.subscribeBot(botName);
       } catch (error) {
         debug(`Failed to connect to Mattermost for bot ${botName}:`, error);
         throw error;
@@ -116,8 +126,98 @@ export class MattermostService extends EventEmitter implements IMessengerService
     this.app = app;
   }
 
-  public setMessageHandler(): void {
+  public setMessageHandler(
+    handler: (
+      message: IMessage,
+      historyMessages: IMessage[],
+      botConfig: any
+    ) => Promise<string | null>
+  ): void {
     debug('Setting message handler for Mattermost bots');
+    if (typeof handler !== 'function') {
+      throw new Error('Message handler must be a function');
+    }
+    this.messageHandler = handler;
+    for (const botName of this.clients.keys()) {
+      this.subscribeBot(botName);
+    }
+  }
+
+  /**
+   * Subscribes a single bot's client to incoming `posted` WebSocket events and
+   * routes each (non-self) post through the registered message handler.
+   * Idempotent per bot so it can be called from both setMessageHandler() and
+   * initialize() regardless of ordering.
+   */
+  private subscribeBot(botName: string): void {
+    if (!this.messageHandler || this.subscribedBots.has(botName)) {
+      return;
+    }
+    const client = this.clients.get(botName);
+    if (!client || typeof client.onPost !== 'function') {
+      return;
+    }
+
+    this.subscribedBots.add(botName);
+    client.onPost((post) => {
+      void this.handleIncomingPost(botName, post);
+    });
+  }
+
+  private async handleIncomingPost(botName: string, post: MattermostPost): Promise<void> {
+    if (!this.messageHandler) {
+      return;
+    }
+    const botConfig = this.botConfigs.get(botName) || {};
+
+    // Ignore the bot's own posts to avoid feedback loops.
+    const selfUserId = this.clients.get(botName)?.getCurrentUserId?.() || botConfig.userId;
+    if (selfUserId && post.user_id === selfUserId) {
+      return;
+    }
+
+    try {
+      const client = this.clients.get(botName);
+      let username = 'Unknown';
+      let isBot = false;
+      try {
+        const user = post.user_id ? await client?.getUser(post.user_id) : null;
+        if (user) {
+          username =
+            `${user.first_name || ''} ${user.last_name || ''}`.trim() ||
+            user.username ||
+            'Unknown';
+          isBot = Boolean(user.is_bot);
+        }
+      } catch (err: any) {
+        debug(`Failed to resolve Mattermost user ${post.user_id}: ${err?.message}`);
+      }
+
+      const message = new MattermostMessage(post, username, {
+        isBot,
+        botUsername: botConfig.username,
+        botUserId: selfUserId,
+      });
+
+      try {
+        const ws = require('@src/server/services/WebSocketService')
+          .default as typeof import('@src/server/services/WebSocketService').default;
+        ws.getInstance().recordMessageFlow({
+          botName,
+          provider: 'mattermost',
+          llmProvider: botConfig.llmProvider,
+          channelId: post.channel_id,
+          userId: post.user_id,
+          messageType: 'incoming',
+          contentLength: (post.message || '').length,
+          status: 'success',
+        });
+      } catch {}
+
+      await this.messageHandler(message, [], { ...botConfig, BOT_NAME: botName });
+    } catch (error: any) {
+      debug(`Error handling incoming Mattermost post for ${botName}: ${error?.message}`);
+    }
   }
 
   public async sendMessage(channelId: string, text: string, senderName?: string): Promise<string> {
@@ -582,6 +682,15 @@ export class MattermostService extends EventEmitter implements IMessengerService
 
   public async shutdown(): Promise<void> {
     debug('Shutting down MattermostService...');
+    for (const client of this.clients.values()) {
+      try {
+        client.disconnect?.();
+      } catch {
+        /* ignore */
+      }
+    }
+    this.subscribedBots.clear();
+    this.messageHandler = undefined;
     MattermostService.instance = undefined;
   }
 

--- a/packages/message-mattermost/src/mattermostClient.ts
+++ b/packages/message-mattermost/src/mattermostClient.ts
@@ -12,7 +12,27 @@ const logger = Logger.withContext('MattermostClient');
 interface MattermostClientOptions {
   serverUrl: string;
   token: string;
+  /**
+   * Optional WebSocket constructor injection (primarily for testing). Defaults
+   * to the global `WebSocket` available in Node 22+.
+   */
+  webSocketFactory?: WebSocketFactory;
 }
+
+/** Minimal structural subset of the WHATWG WebSocket we rely on. */
+export interface MinimalWebSocket {
+  send(data: string): void;
+  close(): void;
+  onopen: ((this: unknown, ev: unknown) => unknown) | null;
+  onmessage: ((this: unknown, ev: { data: unknown }) => unknown) | null;
+  onerror: ((this: unknown, ev: unknown) => unknown) | null;
+  onclose: ((this: unknown, ev: unknown) => unknown) | null;
+}
+
+export type WebSocketFactory = (url: string) => MinimalWebSocket;
+
+/** Callback invoked for each incoming `posted` event on the WebSocket. */
+export type PostEventHandler = (post: MattermostPost, channelType?: string) => void;
 
 interface PostMessageOptions {
   channel: string;
@@ -57,9 +77,16 @@ export default class MattermostClient {
   private readonly CACHE_TTL = 5 * 60 * 1000;
   private readonly MAX_CACHE_SIZE = 1000;
 
+  private webSocketFactory?: WebSocketFactory;
+  private ws: MinimalWebSocket | null = null;
+  private wsSeq = 1;
+  private postHandlers: Set<PostEventHandler> = new Set();
+  private wsClosedByUser = false;
+
   constructor(options: MattermostClientOptions) {
     this.serverUrl = options.serverUrl.replace(/\/$/, '');
     this.token = options.token;
+    this.webSocketFactory = options.webSocketFactory;
 
     this.api = http.create(`${this.serverUrl}/api/v4`, {
       Authorization: `Bearer ${this.token}`,
@@ -75,6 +102,134 @@ export default class MattermostClient {
     } catch (error: any) {
       logger.error('Failed to connect to Mattermost', { error: error.message });
       throw new Error(`Mattermost connection failed: ${error.message}`);
+    }
+
+    // Open the realtime event stream so the bot can *receive* messages.
+    // Failure here is non-fatal: REST send/fetch still work and we never
+    // want a transient WS issue to crash bot startup.
+    if (this.postHandlers.size > 0) {
+      this.openWebSocket();
+    }
+  }
+
+  /**
+   * Registers a handler invoked for every incoming `posted` event delivered
+   * over the Mattermost WebSocket. Registering the first handler will lazily
+   * open the WebSocket if the client is already connected.
+   *
+   * @returns An unsubscribe function.
+   */
+  onPost(handler: PostEventHandler): () => void {
+    this.postHandlers.add(handler);
+    if (this.connected && !this.ws) {
+      this.openWebSocket();
+    }
+    return () => {
+      this.postHandlers.delete(handler);
+    };
+  }
+
+  /**
+   * Opens (or re-opens) the Mattermost WebSocket and authenticates with the
+   * bot token. Incoming `posted` events are parsed and dispatched to all
+   * registered post handlers. All errors are caught and logged so they can
+   * never propagate into startup.
+   */
+  private openWebSocket(): void {
+    if (this.ws) {
+      return;
+    }
+    this.wsClosedByUser = false;
+
+    const factory: WebSocketFactory =
+      this.webSocketFactory ||
+      ((url: string) => new (globalThis as any).WebSocket(url) as MinimalWebSocket);
+
+    const wsUrl = `${this.serverUrl.replace(/^http/, 'ws')}/api/v4/websocket`;
+
+    let ws: MinimalWebSocket;
+    try {
+      ws = factory(wsUrl);
+    } catch (error: unknown) {
+      logger.error('Failed to open Mattermost WebSocket', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return;
+    }
+    this.ws = ws;
+
+    ws.onopen = () => {
+      try {
+        ws.send(
+          JSON.stringify({
+            seq: this.wsSeq++,
+            action: 'authentication_challenge',
+            data: { token: this.token },
+          })
+        );
+        logger.info('Mattermost WebSocket connected', { url: wsUrl });
+      } catch (error: unknown) {
+        logger.error('Failed to authenticate Mattermost WebSocket', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    };
+
+    ws.onmessage = (ev: { data: unknown }) => {
+      try {
+        this.handleWsMessage(ev.data);
+      } catch (error: unknown) {
+        logger.debug('Failed to handle Mattermost WebSocket message', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    };
+
+    ws.onerror = (ev: unknown) => {
+      logger.error('Mattermost WebSocket error', {
+        error: (ev as any)?.message ?? 'unknown',
+      });
+    };
+
+    ws.onclose = () => {
+      this.ws = null;
+      if (!this.wsClosedByUser) {
+        logger.info('Mattermost WebSocket closed');
+      }
+    };
+  }
+
+  /**
+   * Parses a raw WebSocket frame and, when it is a `posted` event, dispatches
+   * the embedded post to all registered handlers.
+   */
+  private handleWsMessage(raw: unknown): void {
+    if (typeof raw !== 'string') {
+      return;
+    }
+    const event = JSON.parse(raw) as {
+      event?: string;
+      data?: { post?: string; channel_type?: string };
+    };
+    if (event.event !== 'posted' || !event.data?.post) {
+      return;
+    }
+
+    let post: MattermostPost;
+    try {
+      post = JSON.parse(event.data.post) as MattermostPost;
+    } catch {
+      return;
+    }
+
+    for (const handler of this.postHandlers) {
+      try {
+        handler(post, event.data.channel_type);
+      } catch (error: unknown) {
+        logger.debug('Mattermost post handler threw', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
   }
 
@@ -235,6 +390,15 @@ export default class MattermostClient {
     this.teamsCache = null;
     this.channelIdCache.clear();
     this.pendingLookups.clear();
+    this.wsClosedByUser = true;
+    if (this.ws) {
+      try {
+        this.ws.close();
+      } catch {
+        /* ignore */
+      }
+      this.ws = null;
+    }
   }
 
   getCurrentUserId(): string | null {

--- a/packages/message-mattermost/src/mattermostReceive.test.ts
+++ b/packages/message-mattermost/src/mattermostReceive.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Regression test for audit #1 (mattermost-receive):
+ * MattermostService.setMessageHandler() used to be a no-op and MattermostClient
+ * had no WebSocket subscription, so Mattermost bots could send but never receive.
+ *
+ * These tests assert that:
+ *  1. MattermostClient.onPost() subscribes to the WebSocket and dispatches
+ *     parsed `posted` events to its handler.
+ *  2. MattermostService.setMessageHandler() wires that subscription so an
+ *     incoming post invokes the registered handler with a MattermostMessage.
+ */
+
+jest.mock('@src/config/BotConfigurationManager', () => ({
+  __esModule: true,
+  default: {
+    getInstance: jest.fn().mockReturnValue({ getAllBots: jest.fn().mockReturnValue([]) }),
+  },
+}));
+
+import MattermostClient, { type MinimalWebSocket } from './mattermostClient';
+
+/** A controllable fake WebSocket for deterministic tests. */
+class FakeWebSocket implements MinimalWebSocket {
+  public sent: string[] = [];
+  public closed = false;
+  onopen: ((this: unknown, ev: unknown) => unknown) | null = null;
+  onmessage: ((this: unknown, ev: { data: unknown }) => unknown) | null = null;
+  onerror: ((this: unknown, ev: unknown) => unknown) | null = null;
+  onclose: ((this: unknown, ev: unknown) => unknown) | null = null;
+
+  constructor(public url: string) {}
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+  close(): void {
+    this.closed = true;
+    this.onclose?.call(this, {});
+  }
+  // Test helpers
+  open(): void {
+    this.onopen?.call(this, {});
+  }
+  emit(raw: string): void {
+    this.onmessage?.call(this, { data: raw });
+  }
+}
+
+const buildPost = (over: Partial<Record<string, unknown>> = {}) => ({
+  id: 'post123',
+  message: 'hello bot',
+  channel_id: 'chan1',
+  user_id: 'user1',
+  create_at: Date.now(),
+  update_at: 0,
+  edit_at: 0,
+  delete_at: 0,
+  is_pinned: false,
+  type: '',
+  props: {},
+  hashtags: '',
+  pending_post_id: '',
+  reply_count: 0,
+  metadata: {},
+  ...over,
+});
+
+const postedFrame = (post: ReturnType<typeof buildPost>) =>
+  JSON.stringify({ event: 'posted', data: { post: JSON.stringify(post), channel_type: 'O' } });
+
+describe('MattermostClient WebSocket receive', () => {
+  it('authenticates and dispatches posted events to onPost handlers', async () => {
+    let fake: FakeWebSocket | undefined;
+    const client = new MattermostClient({
+      serverUrl: 'https://mm.example.com',
+      token: 'tok',
+      webSocketFactory: (url) => (fake = new FakeWebSocket(url)),
+    });
+
+    // Simulate a successful REST connect without hitting the network.
+    (client as unknown as { connected: boolean }).connected = true;
+
+    const received: any[] = [];
+    client.onPost((post) => received.push(post));
+
+    expect(fake).toBeDefined();
+    expect(fake!.url).toBe('wss://mm.example.com/api/v4/websocket');
+
+    fake!.open();
+    // First frame must be the auth challenge carrying the token.
+    expect(fake!.sent.length).toBe(1);
+    const auth = JSON.parse(fake!.sent[0]);
+    expect(auth.action).toBe('authentication_challenge');
+    expect(auth.data.token).toBe('tok');
+
+    fake!.emit(postedFrame(buildPost({ message: 'hi there' })));
+
+    expect(received).toHaveLength(1);
+    expect(received[0].message).toBe('hi there');
+  });
+
+  it('ignores non-posted events', () => {
+    let fake: FakeWebSocket | undefined;
+    const client = new MattermostClient({
+      serverUrl: 'http://mm.local',
+      token: 'tok',
+      webSocketFactory: (url) => (fake = new FakeWebSocket(url)),
+    });
+    (client as unknown as { connected: boolean }).connected = true;
+
+    const received: any[] = [];
+    client.onPost((post) => received.push(post));
+    fake!.open();
+    fake!.emit(JSON.stringify({ event: 'typing', data: {} }));
+    expect(received).toHaveLength(0);
+    // ws url derived from http -> ws
+    expect(fake!.url).toBe('ws://mm.local/api/v4/websocket');
+  });
+});
+
+describe('MattermostService.setMessageHandler subscribes to incoming posts', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('invokes the registered handler when a post arrives over the WebSocket', async () => {
+    const { MattermostService } = await import('./MattermostService');
+    const service = MattermostService.getInstance();
+
+    let fake: FakeWebSocket | undefined;
+    const client = new MattermostClient({
+      serverUrl: 'https://mm.example.com',
+      token: 'tok',
+      webSocketFactory: (url) => (fake = new FakeWebSocket(url)),
+    });
+    (client as unknown as { connected: boolean }).connected = true;
+    // Avoid a network call for user resolution.
+    jest
+      .spyOn(client, 'getUser')
+      .mockResolvedValue({
+        id: 'user1',
+        username: 'alice',
+        email: '',
+        first_name: 'Alice',
+        last_name: '',
+        is_bot: false,
+      } as any);
+    jest.spyOn(client, 'getCurrentUserId').mockReturnValue('botUser');
+
+    // Inject our client and config into the singleton.
+    (service as any).clients.set('bot1', client);
+    (service as any).botConfigs.set('bot1', { name: 'bot1', userId: 'botUser' });
+
+    const handler = jest.fn().mockResolvedValue('');
+    service.setMessageHandler(handler);
+
+    fake!.open();
+    fake!.emit(postedFrame(buildPost({ message: 'ping', user_id: 'user1' })));
+
+    // Allow the async user-resolution + handler invocation to settle.
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const msgArg = handler.mock.calls[0][0];
+    expect(msgArg.getText()).toBe('ping');
+    expect(msgArg.getChannelId()).toBe('chan1');
+
+    await service.shutdown();
+  });
+
+  it('ignores the bot own posts to avoid feedback loops', async () => {
+    const { MattermostService } = await import('./MattermostService');
+    const service = MattermostService.getInstance();
+
+    let fake: FakeWebSocket | undefined;
+    const client = new MattermostClient({
+      serverUrl: 'https://mm.example.com',
+      token: 'tok',
+      webSocketFactory: (url) => (fake = new FakeWebSocket(url)),
+    });
+    (client as unknown as { connected: boolean }).connected = true;
+    jest.spyOn(client, 'getCurrentUserId').mockReturnValue('botUser');
+
+    (service as any).clients.set('bot1', client);
+    (service as any).botConfigs.set('bot1', { name: 'bot1', userId: 'botUser' });
+
+    const handler = jest.fn().mockResolvedValue('');
+    service.setMessageHandler(handler);
+
+    fake!.open();
+    fake!.emit(postedFrame(buildPost({ user_id: 'botUser' })));
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(handler).not.toHaveBeenCalled();
+
+    await service.shutdown();
+  });
+});


### PR DESCRIPTION
## What
Implements a real Mattermost realtime event subscription so bots can **receive** messages, not just send them.

- `MattermostClient` opens a WebSocket to `/api/v4/websocket`, authenticates with the bot token, and dispatches `posted` events to registered `onPost` handlers. Uses the global `WebSocket` (Node 22+) with an injectable factory for testing. No new dependency.
- `MattermostService.setMessageHandler` now stores the handler and subscribes every client's incoming stream, building a `MattermostMessage` per post and routing it through the handler. Subscription is idempotent and also wired after `connect()`.
- WS is torn down on `disconnect()`/`shutdown()`.

## Why
Audit #1: `setMessageHandler` (~line 119) only logged and never subscribed, and `MattermostClient` had no websocket — so Mattermost bots could send but never receive. Audit #2 (`addBot`) was already fixed by feat/mattermost-stub (#2818) and is left unchanged (verified against latest `origin/main`).

## Behavior
- Incoming posts now flow into the existing message handler (pipeline or legacy), identical to Slack/Discord.
- The bot's own posts are skipped to avoid feedback loops.
- WebSocket open/auth/parse failures are caught and logged: REST send/fetch and bot startup are never affected.

## Verification
- New `mattermostReceive.test.ts`: 4 tests covering WS auth + `posted` dispatch, handler invocation with a `MattermostMessage`, non-`posted` event filtering, and self-message suppression. Confirmed **failing on the pre-fix code** and **passing after**.
- `npx tsc --noEmit`: clean.
- Full `packages/message-mattermost` + `MattermostProvider` jest suites: 11 tests pass.

## Notes
ESLint could not be run in this worktree due to an environmental ajv/eslintrc module conflict that crashes ESLint on *any* file (including unchanged ones); the changes follow existing patterns in this package (e.g. the `require('@src/server/services/WebSocketService')` monitoring hook is copied verbatim from `sendMessageToChannel`).