### PR TITLE
fix(pipeline): wire activity-tracking signals into default pipeline

### DIFF
--- a/src/pipeline/ActivityRecorder.ts
+++ b/src/pipeline/ActivityRecorder.ts
@@ -1,0 +1,74 @@
+/**
+ * Pipeline activity recording collaborator.
+ *
+ * The staged pipeline (the DEFAULT message-processing path) must feed the same
+ * response-scoring signals that the legacy `handleMessage()` path feeds:
+ *
+ *  - {@link GlobalActivityTracker.recordActivity} — drives the global "fatigue"
+ *    penalty consulted by `shouldReplyToMessage()`.
+ *  - `recordBotActivity()` — drives the grace-window / recently-posted /
+ *    crosstalk signals in {@link ChannelActivity}.
+ *  - {@link IdleResponseManager.recordInteraction} / `recordBotResponse` —
+ *    drive idle-response scheduling.
+ *
+ * Without these recordings, fatigue, grace window, and idle response are dead
+ * in pipeline mode. This interface lets the DecisionStage and SendStage emit
+ * those recordings while remaining unit-testable (the default implementation
+ * delegates to the real singletons).
+ *
+ * @module pipeline/ActivityRecorder
+ */
+
+import { recordBotActivity } from '@message/helpers/processing/ChannelActivity';
+import { GlobalActivityTracker } from '@message/helpers/processing/GlobalActivityTracker';
+import { IdleResponseManager } from '@message/management/IdleResponseManager';
+
+/**
+ * Records the response-scoring signals consumed by the reply-decision and
+ * idle-response subsystems.
+ */
+export interface ActivityRecorder {
+  /**
+   * Record an inbound (human) interaction for idle-response tracking.
+   * Mirrors the legacy `replyDecision.ts` recording.
+   */
+  recordInteraction(serviceName: string, channelId: string, messageId?: string): void;
+
+  /**
+   * Record a successfully-sent bot message. Updates the global fatigue score,
+   * the per-channel grace-window/crosstalk activity, and the idle-response
+   * last-bot-response timestamp. Mirrors the legacy `outputProcessor.ts`
+   * recordings (plus the previously-dead `recordActivity` call).
+   */
+  recordBotResponse(serviceName: string, channelId: string, botId: string): void;
+}
+
+/**
+ * Default {@link ActivityRecorder} that delegates to the application
+ * singletons. All calls are defensive: a failure to record must never break
+ * message delivery.
+ */
+export class DefaultActivityRecorder implements ActivityRecorder {
+  recordInteraction(serviceName: string, channelId: string, messageId?: string): void {
+    try {
+      IdleResponseManager.getInstance().recordInteraction(serviceName, channelId, messageId);
+    } catch {
+      // Recording is best-effort; never block the pipeline.
+    }
+  }
+
+  recordBotResponse(serviceName: string, channelId: string, botId: string): void {
+    try {
+      if (botId) {
+        // Global "fatigue" score — previously never recorded in any path.
+        GlobalActivityTracker.getInstance().recordActivity(botId);
+        // Per-channel grace-window / recently-posted / crosstalk signal.
+        recordBotActivity(channelId, botId);
+      }
+      // Idle-response last-bot-response timestamp.
+      IdleResponseManager.getInstance().recordBotResponse(serviceName, channelId);
+    } catch {
+      // Recording is best-effort; never block the pipeline.
+    }
+  }
+}

--- a/src/pipeline/DecisionStage.ts
+++ b/src/pipeline/DecisionStage.ts
@@ -22,9 +22,19 @@ import { container } from 'tsyringe';
 import { type MessageBus } from '@src/events/MessageBus';
 import type { MessageContext, ReplyDecision } from '@src/events/types';
 import { SwarmCoordinator } from '@src/services/SwarmCoordinator';
+import { type ActivityRecorder, DefaultActivityRecorder } from './ActivityRecorder';
 import { PipelineDebuggerService } from '../server/services/PipelineDebuggerService';
 
 const debug = Debug('app:pipeline:decision');
+
+/**
+ * Resolve the idle-response service name from the message context. Mirrors the
+ * legacy `replyDecision.ts` / `outputProcessor.ts` resolution of
+ * `MESSAGE_PROVIDER`, falling back to the platform identifier.
+ */
+function resolveServiceName(ctx: MessageContext): string {
+  return String(ctx.botConfig.MESSAGE_PROVIDER || ctx.platform || 'generic');
+}
 
 // ---------------------------------------------------------------------------
 // Strategy interface
@@ -56,7 +66,8 @@ export interface DecisionStrategy {
 export class DecisionStage {
   constructor(
     private bus: MessageBus,
-    private strategy: DecisionStrategy
+    private strategy: DecisionStrategy,
+    private recorder: ActivityRecorder = new DefaultActivityRecorder()
   ) {}
 
   /**
@@ -99,6 +110,18 @@ export class DecisionStage {
 
       const messageId = ctx.message.getMessageId();
       const botId = (ctx.botConfig.BOT_ID as string) || (ctx.botConfig.botId as string) || '';
+
+      // Record the inbound interaction for idle-response tracking. Mirrors the
+      // legacy `replyDecision.ts` recording so idle response works in pipeline
+      // mode. Only human messages count (skip bot-authored messages).
+      try {
+        if (!ctx.message.isFromBot()) {
+          this.recorder.recordInteraction(resolveServiceName(ctx), ctx.channelId, messageId);
+        }
+      } catch (recordErr) {
+        debug('Failed to record interaction (non-fatal): %O', recordErr);
+      }
+
       const swarm = SwarmCoordinator.getInstance();
       const channelId = ctx.channelId;
       const botName = ctx.botName;

--- a/src/pipeline/SendStage.ts
+++ b/src/pipeline/SendStage.ts
@@ -17,6 +17,7 @@
 import Debug from 'debug';
 import { type MessageBus } from '@src/events/MessageBus';
 import type { MessageContext } from '@src/events/types';
+import { type ActivityRecorder, DefaultActivityRecorder } from './ActivityRecorder';
 
 const debug = Debug('app:pipeline:send');
 
@@ -64,7 +65,9 @@ export class SendStage {
   constructor(
     private bus: MessageBus,
     private sender: MessageSender,
-    private memoryStorer?: MemoryStorer
+    private memoryStorer?: MemoryStorer,
+    private recorder: ActivityRecorder = new DefaultActivityRecorder(),
+    private botId?: string
   ) {}
 
   /**
@@ -102,6 +105,23 @@ export class SendStage {
         totalLength: trimmed.length,
         status: 'sent',
       };
+
+      // Record response-scoring signals (fatigue, grace window, idle response).
+      // Mirrors the legacy `outputProcessor.ts` recordings so these signals are
+      // live in pipeline mode. Best-effort: never block delivery.
+      try {
+        const serviceName = String(
+          ctx.botConfig.MESSAGE_PROVIDER || ctx.platform || 'generic'
+        );
+        const botId =
+          this.botId ||
+          (ctx.botConfig.BOT_ID as string) ||
+          (ctx.botConfig.botId as string) ||
+          '';
+        this.recorder.recordBotResponse(serviceName, ctx.channelId, botId);
+      } catch (recordErr) {
+        debug('SendStage: failed to record bot activity (non-fatal): %O', recordErr);
+      }
 
       await this.bus.emitAsync('message:sent', {
         ...ctx,

--- a/src/pipeline/createPipeline.ts
+++ b/src/pipeline/createPipeline.ts
@@ -25,6 +25,7 @@ import {
   MessageSenderAdapter,
   PromptBuilderAdapter,
 } from '@src/pipeline/adapters';
+import { DefaultActivityRecorder } from '@src/pipeline/ActivityRecorder';
 import { DecisionStage } from '@src/pipeline/DecisionStage';
 import { EnrichStage } from '@src/pipeline/EnrichStage';
 import { InferenceStage } from '@src/pipeline/InferenceStage';
@@ -82,7 +83,9 @@ export function createPipeline(bus: MessageBus, deps: PipelineDependencies): voi
   const send = new SendStage(
     bus,
     new MessageSenderAdapter({ messengerService: deps.messengerService }),
-    new MemoryStorerAdapter()
+    new MemoryStorerAdapter(),
+    new DefaultActivityRecorder(),
+    deps.botId
   );
 
   receive.register();

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -3,3 +3,7 @@ export { DecisionStage, type DecisionStrategy } from './DecisionStage';
 export { EnrichStage, type MemoryRetriever, type PromptBuilder } from './EnrichStage';
 export { InferenceStage, type LlmInvoker } from './InferenceStage';
 export { SendStage, type MessageSender, type MemoryStorer } from './SendStage';
+export {
+  type ActivityRecorder,
+  DefaultActivityRecorder,
+} from './ActivityRecorder';

--- a/tests/unit/pipeline/pipelineActivityTracking.test.ts
+++ b/tests/unit/pipeline/pipelineActivityTracking.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Regression tests for pipeline activity tracking (fatigue / grace window /
+ * idle response).
+ *
+ * Before the fix, the staged pipeline (DecisionStage + SendStage — the DEFAULT
+ * message-processing path) never fed the response-scoring signals:
+ *   - GlobalActivityTracker.recordActivity was never called anywhere.
+ *   - recordBotActivity (grace window) was only called from the legacy path.
+ *   - IdleResponseManager.recordInteraction was only called from legacy
+ *     replyDecision.
+ *
+ * These tests assert the pipeline now wires all three recordings.
+ */
+
+import { MessageBus } from '@src/events/MessageBus';
+import type { ActivityRecorder } from '@src/pipeline/ActivityRecorder';
+import { DefaultActivityRecorder } from '@src/pipeline/ActivityRecorder';
+import { DecisionStage, type DecisionStrategy } from '@src/pipeline/DecisionStage';
+import { SendStage, type MessageSender } from '@src/pipeline/SendStage';
+import { GlobalActivityTracker } from '@src/message/helpers/processing/GlobalActivityTracker';
+import {
+  clearBotActivity,
+  getLastBotActivity,
+} from '@src/message/helpers/processing/ChannelActivity';
+import { SwarmCoordinator } from '@src/services/SwarmCoordinator';
+import { IMessage } from '@message/interfaces/IMessage';
+
+// ---------------------------------------------------------------------------
+// Stub message
+// ---------------------------------------------------------------------------
+
+class StubMessage extends IMessage {
+  constructor(
+    private id = 'msg-1',
+    private fromBot = false
+  ) {
+    super({}, fromBot ? 'assistant' : 'user');
+    this.content = 'hello';
+    this.channelId = 'ch-activity';
+    this.platform = 'discord';
+  }
+  getMessageId(): string {
+    return this.id;
+  }
+  getText(): string {
+    return this.content;
+  }
+  getTimestamp(): Date {
+    return new Date();
+  }
+  setText(t: string): void {
+    this.content = t;
+  }
+  getChannelId(): string {
+    return this.channelId;
+  }
+  getAuthorId(): string {
+    return this.fromBot ? 'bot-author' : 'user-1';
+  }
+  getChannelTopic(): string | null {
+    return null;
+  }
+  getUserMentions(): string[] {
+    return [];
+  }
+  getChannelUsers(): string[] {
+    return [];
+  }
+  mentionsUsers(): boolean {
+    return false;
+  }
+  isFromBot(): boolean {
+    return this.fromBot;
+  }
+  getAuthorName(): string {
+    return 'Tester';
+  }
+}
+
+function makeContext(message: IMessage) {
+  return {
+    message,
+    history: [],
+    botConfig: {},
+    botName: 'TestBot',
+    platform: 'discord',
+    channelId: message.getChannelId(),
+    metadata: {},
+  };
+}
+
+function createRecorderSpy(): ActivityRecorder & {
+  recordInteraction: jest.Mock;
+  recordBotResponse: jest.Mock;
+} {
+  return {
+    recordInteraction: jest.fn(),
+    recordBotResponse: jest.fn(),
+  };
+}
+
+describe('pipeline activity tracking', () => {
+  let bus: MessageBus;
+
+  beforeEach(() => {
+    MessageBus.getInstance().reset();
+    bus = MessageBus.getInstance();
+    SwarmCoordinator.resetInstance();
+    GlobalActivityTracker.getInstance().reset();
+    clearBotActivity();
+  });
+
+  afterEach(() => {
+    bus.reset();
+  });
+
+  // --- DecisionStage: records inbound interaction (idle response) -----------
+
+  it('DecisionStage records an interaction for human messages', async () => {
+    const recorder = createRecorderSpy();
+    const strategy: DecisionStrategy = {
+      shouldReply: jest.fn().mockResolvedValue({ shouldReply: false, reason: 'no' }),
+    };
+    const stage = new DecisionStage(bus, strategy, recorder);
+
+    await stage.process(makeContext(new StubMessage('m-human', false)));
+
+    expect(recorder.recordInteraction).toHaveBeenCalledTimes(1);
+    expect(recorder.recordInteraction).toHaveBeenCalledWith('discord', 'ch-activity', 'm-human');
+  });
+
+  it('DecisionStage does NOT record an interaction for bot-authored messages', async () => {
+    const recorder = createRecorderSpy();
+    const strategy: DecisionStrategy = {
+      shouldReply: jest.fn().mockResolvedValue({ shouldReply: false, reason: 'no' }),
+    };
+    const stage = new DecisionStage(bus, strategy, recorder);
+
+    await stage.process(makeContext(new StubMessage('m-bot', true)));
+
+    expect(recorder.recordInteraction).not.toHaveBeenCalled();
+  });
+
+  // --- SendStage: records bot response (fatigue + grace + idle) -------------
+
+  it('SendStage records a bot response after a successful send', async () => {
+    const recorder = createRecorderSpy();
+    const sender: MessageSender = { sendToChannel: jest.fn().mockResolvedValue(undefined) };
+    const stage = new SendStage(bus, sender, undefined, recorder, 'bot-42');
+
+    const ctx = { ...makeContext(new StubMessage()), responseText: 'a reply' };
+    await stage.process(ctx);
+
+    expect(recorder.recordBotResponse).toHaveBeenCalledTimes(1);
+    expect(recorder.recordBotResponse).toHaveBeenCalledWith('discord', 'ch-activity', 'bot-42');
+  });
+
+  it('SendStage does NOT record when the response is empty', async () => {
+    const recorder = createRecorderSpy();
+    const sender: MessageSender = { sendToChannel: jest.fn().mockResolvedValue(undefined) };
+    const stage = new SendStage(bus, sender, undefined, recorder, 'bot-42');
+
+    const ctx = { ...makeContext(new StubMessage()), responseText: '   ' };
+    await stage.process(ctx);
+
+    expect(recorder.recordBotResponse).not.toHaveBeenCalled();
+  });
+
+  // --- End-to-end with the REAL recorder: previously-dead signals are live --
+
+  it('DefaultActivityRecorder feeds the global fatigue score and grace window', async () => {
+    const sender: MessageSender = { sendToChannel: jest.fn().mockResolvedValue(undefined) };
+    const stage = new SendStage(bus, sender, undefined, new DefaultActivityRecorder(), 'bot-99');
+
+    // Pre-condition: no fatigue, no recent activity.
+    expect(GlobalActivityTracker.getInstance().getScore('bot-99')).toBe(0);
+    expect(getLastBotActivity('ch-activity', 'bot-99')).toBe(0);
+
+    const ctx = { ...makeContext(new StubMessage()), responseText: 'a reply' };
+    await stage.process(ctx);
+
+    // Post-condition: fatigue score incremented and grace-window timestamp set.
+    expect(GlobalActivityTracker.getInstance().getScore('bot-99')).toBeGreaterThan(0);
+    expect(getLastBotActivity('ch-activity', 'bot-99')).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## What
Wires the response-scoring activity signals into the default 5-stage pipeline (`src/pipeline/`), so they fire on the path used when `USE_LEGACY_HANDLER` is unset (the default).

- New `src/pipeline/ActivityRecorder.ts`: `ActivityRecorder` interface + `DefaultActivityRecorder` that delegates to the existing singletons.
- `DecisionStage` now records inbound **human** interactions via `IdleResponseManager.recordInteraction` (skips bot-authored messages), mirroring legacy `replyDecision.ts`.
- `SendStage` now records a successful bot response: `GlobalActivityTracker.recordActivity` (fatigue), `recordBotActivity` (grace window / crosstalk), and `IdleResponseManager.recordBotResponse` (idle), mirroring legacy `outputProcessor.ts`.
- `createPipeline` injects the default recorder and threads the bot id into `SendStage`.

## Why
In pipeline mode these signals were dead:
- `GlobalActivityTracker.recordActivity` was never called **anywhere**, so the fatigue penalty in `shouldReplyToMessage()` always read score 0 (audit #16).
- `recordBotActivity` (grace window / recently-posted) was only called from the legacy path (#17).
- `IdleResponseManager.recordInteraction` was only called from legacy `replyDecision` (#18).

Since the default path is the pipeline, fatigue, grace window, and idle response were effectively disabled in normal operation.

## Behavior
- Reuses existing singletons/functions — no parallel systems.
- All recordings are best-effort (wrapped in try/catch); a recording failure never blocks message delivery.
- Bot-authored messages do not count as interactions (matches legacy).
- Empty/whitespace responses do not record a bot response.
- No change to the legacy path; default pipeline flow/events unchanged.

## Verification
- `npx tsc --noEmit`: clean.
- New test `tests/unit/pipeline/pipelineActivityTracking.test.ts` (5 cases): asserts DecisionStage records human-only interactions, SendStage records on non-empty send only, and that the **real** `DefaultActivityRecorder` raises `GlobalActivityTracker.getScore()` from 0 and sets the grace-window timestamp (the previously-dead behavior).
- Existing `tests/integration/pipeline/fullPipeline.integration.test.ts`: 10/10 still pass.
- Activity suites (GlobalActivity/ChannelActivity/IdleResponse + new): green.

Note: ESLint could not be run locally due to a pre-existing ajv dependency conflict in the installed `node_modules` (crashes identically on untouched files before linting). The changed files follow the existing style/DI patterns of the surrounding pipeline code.