### PR TITLE
fix(admin): wire export/import routes to ConfigurationImportExportService

### DIFF
--- a/src/client/src/pages/ImportExportPage.tsx
+++ b/src/client/src/pages/ImportExportPage.tsx
@@ -73,7 +73,10 @@ const ImportExportPage: React.FC = () => {
   const handleExport = useCallback(async () => {
     setIsExporting(true);
     try {
-      const response = await apiService.post('/api/admin/export', exportOptions);
+      const response = await apiService.post<{ success: boolean; data: any }>(
+        '/api/admin/export',
+        exportOptions
+      );
       const blob = new Blob([JSON.stringify(response.data, null, 2)], { type: 'application/json' });
       const url = window.URL.createObjectURL(blob);
       const link = document.createElement('a');
@@ -97,16 +100,16 @@ const ImportExportPage: React.FC = () => {
     setIsImporting(true);
     setImportResult(null);
 
-    const formData = new FormData();
-    formData.append('file', selectedFile);
-    formData.append('overwrite', String(importOptions.overwrite));
-    formData.append('dryRun', String(importOptions.dryRun));
-
     try {
-      const response = await apiService.post('/api/admin/import', formData, {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-        },
+      const content = await selectedFile.text();
+      const ext = selectedFile.name.split('.').pop()?.toLowerCase();
+      const format = ext === 'yaml' || ext === 'yml' ? 'yaml' : ext === 'csv' ? 'csv' : 'json';
+
+      const response = await apiService.post<{ success: boolean; data: any }>('/api/admin/import', {
+        content,
+        format,
+        overwrite: importOptions.overwrite,
+        dryRun: importOptions.dryRun,
       });
       setImportResult({
         success: true,

--- a/src/server/routes/admin/backup.ts
+++ b/src/server/routes/admin/backup.ts
@@ -1,11 +1,24 @@
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import Debug from 'debug';
 import { Router, type Request, type Response } from 'express';
+import { ApiResponse } from '@src/server/utils/apiResponse';
+import { DatabaseManager } from '../../../database/DatabaseManager';
+import { HTTP_STATUS } from '../../../types/constants';
+import {
+  ConfigurationImportExportService,
+  type ExportOptions,
+  type ImportOptions,
+} from '../../services/ConfigurationImportExportService';
 
 const router = Router();
+const debug = Debug('app:webui:admin:backup');
 
 const isTestEnv = process.env.NODE_ENV === 'test';
 const rateLimit = require('express-rate-limit').default;
 
-const _configRateLimit = isTestEnv
+const configRateLimit = isTestEnv
   ? (_req: Request, _res: Response, next: any) => next()
   : rateLimit({
       windowMs: 15 * 60 * 1000, // 15 minutes
@@ -13,5 +26,133 @@ const _configRateLimit = isTestEnv
       message: 'Too many configuration attempts, please try again later.',
       standardHeaders: true,
     });
+
+const ALLOWED_FORMATS = ['json', 'yaml', 'csv'] as const;
+
+function normalizeFormat(value: unknown): 'json' | 'yaml' | 'csv' {
+  return ALLOWED_FORMATS.includes(value as any) ? (value as 'json' | 'yaml' | 'csv') : 'json';
+}
+
+/**
+ * POST /api/admin/export
+ *
+ * Export bot configurations using ConfigurationImportExportService and return
+ * the exported document as JSON so the WebUI can offer it as a download.
+ *
+ * When no `configIds` are supplied, every stored bot configuration is exported.
+ */
+router.post('/export', configRateLimit, async (req: Request, res: Response) => {
+  try {
+    const service = ConfigurationImportExportService.getInstance();
+
+    let configIds: number[] = Array.isArray(req.body?.configIds)
+      ? req.body.configIds.filter((id: unknown) => typeof id === 'number' && id > 0)
+      : [];
+
+    // Default to exporting all configurations when none are specified.
+    if (configIds.length === 0) {
+      const all = await DatabaseManager.getInstance().getAllBotConfigurations();
+      configIds = all.map((c) => c.id).filter((id): id is number => typeof id === 'number');
+    }
+
+    if (configIds.length === 0) {
+      return res
+        .status(HTTP_STATUS.BAD_REQUEST)
+        .json(ApiResponse.error('No configurations available to export'));
+    }
+
+    // Force JSON + uncompressed/unencrypted output so the WebUI can read the
+    // generated file back and stream it to the browser as a download.
+    const options: ExportOptions = {
+      format: 'json',
+      includeVersions: req.body?.includeVersions !== false,
+      includeAuditLogs: req.body?.includeAuditLogs !== false,
+      includeTemplates: req.body?.includeTemplates !== false,
+      compress: false,
+      encrypt: false,
+    };
+
+    const createdBy = (req as any).user?.username || 'unknown';
+    const result = await service.exportConfigurations(configIds, options, undefined, createdBy);
+
+    if (!result.success || !result.filePath) {
+      return res
+        .status(HTTP_STATUS.BAD_REQUEST)
+        .json(ApiResponse.error(result.error ?? 'Failed to export configurations'));
+    }
+
+    const raw = await fs.readFile(result.filePath, 'utf8');
+    const exportData = JSON.parse(raw);
+
+    return res.json(ApiResponse.success(exportData));
+  } catch (error) {
+    debug('Error exporting configurations:', error);
+    return res
+      .status(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+      .json(ApiResponse.error(error instanceof Error ? error.message : String(error)));
+  }
+});
+
+/**
+ * POST /api/admin/import
+ *
+ * Import bot configurations from a backup document provided in the request
+ * body. The WebUI reads the selected file client-side and sends its text
+ * content as `content`, avoiding multipart handling on this admin route.
+ */
+router.post('/import', configRateLimit, async (req: Request, res: Response) => {
+  let tempFilePath: string | null = null;
+  try {
+    const content = req.body?.content;
+    if (typeof content !== 'string' || content.trim().length === 0) {
+      return res
+        .status(HTTP_STATUS.BAD_REQUEST)
+        .json(ApiResponse.error('No backup content provided'));
+    }
+
+    const format = normalizeFormat(req.body?.format);
+    const dryRun = req.body?.dryRun === true || req.body?.dryRun === 'true';
+    const overwrite = req.body?.overwrite === true || req.body?.overwrite === 'true';
+
+    // Persist the uploaded content to a temp file so the service can read it.
+    tempFilePath = path.join(os.tmpdir(), `hivemind-import-${Date.now()}.${format}`);
+    await fs.writeFile(tempFilePath, content, 'utf8');
+
+    const options: ImportOptions = {
+      format,
+      overwrite,
+      validateOnly: dryRun,
+    };
+
+    if (typeof req.body?.decryptionKey === 'string' && req.body.decryptionKey.length > 0) {
+      options.decryptionKey = req.body.decryptionKey;
+    }
+
+    const importedBy = (req as any).user?.username || 'unknown';
+    const service = ConfigurationImportExportService.getInstance();
+    const result = await service.importConfigurations(tempFilePath, options, importedBy);
+
+    if (!result.success) {
+      return res
+        .status(HTTP_STATUS.BAD_REQUEST)
+        .json(ApiResponse.error(result.errors?.join('; ') || 'Failed to import configurations'));
+    }
+
+    return res.json(ApiResponse.success(result));
+  } catch (error) {
+    debug('Error importing configurations:', error);
+    return res
+      .status(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+      .json(ApiResponse.error(error instanceof Error ? error.message : String(error)));
+  } finally {
+    if (tempFilePath) {
+      try {
+        await fs.unlink(tempFilePath);
+      } catch (cleanupError) {
+        debug('Error cleaning up temp import file:', cleanupError);
+      }
+    }
+  }
+});
 
 export default router;

--- a/tests/unit/server/routes/admin/backup.test.ts
+++ b/tests/unit/server/routes/admin/backup.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for the admin backup router (/api/admin/export, /api/admin/import).
+ *
+ * Regression: ImportExportPage.tsx posts to /api/admin/export and
+ * /api/admin/import, but admin/backup.ts used to be an empty router, so these
+ * endpoints returned 404. These tests assert the routes are now wired to
+ * ConfigurationImportExportService.
+ */
+import { promises as fs } from 'fs';
+import express from 'express';
+import request from 'supertest';
+// Import after mocks are registered.
+
+import backupRouter from '../../../../../src/server/routes/admin/backup';
+
+// --- Mock the service so we exercise the route wiring, not the real DB/IO ---
+const mockExportConfigurations = jest.fn();
+const mockImportConfigurations = jest.fn();
+const mockGetAllBotConfigurations = jest.fn();
+
+jest.mock('../../../../../src/server/services/ConfigurationImportExportService', () => ({
+  ConfigurationImportExportService: {
+    getInstance: () => ({
+      exportConfigurations: mockExportConfigurations,
+      importConfigurations: mockImportConfigurations,
+    }),
+  },
+}));
+
+jest.mock('../../../../../src/database/DatabaseManager', () => ({
+  DatabaseManager: {
+    getInstance: () => ({
+      getAllBotConfigurations: mockGetAllBotConfigurations,
+    }),
+  },
+}));
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/', backupRouter);
+  return app;
+}
+
+describe('admin backup router', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /export', () => {
+    it('is registered (does not 404) and returns exported data via the service', async () => {
+      mockGetAllBotConfigurations.mockResolvedValue([{ id: 1 }, { id: 2 }]);
+
+      // Service writes a file; the route reads it back. Stub fs.readFile.
+      const exportDoc = { metadata: { configCount: 2 }, configurations: [{ id: 1 }] };
+      const readSpy = jest
+        .spyOn(fs, 'readFile')
+        .mockResolvedValue(JSON.stringify(exportDoc) as never);
+
+      mockExportConfigurations.mockResolvedValue({
+        success: true,
+        filePath: '/tmp/export.json',
+        size: 10,
+        checksum: 'abc',
+      });
+
+      const res = await request(buildApp())
+        .post('/export')
+        .send({ format: 'json', includeVersions: true });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toEqual(exportDoc);
+      expect(mockExportConfigurations).toHaveBeenCalledTimes(1);
+      // Defaulted to all configuration ids when none provided.
+      expect(mockExportConfigurations.mock.calls[0][0]).toEqual([1, 2]);
+
+      readSpy.mockRestore();
+    });
+
+    it('returns 400 when there are no configurations to export', async () => {
+      mockGetAllBotConfigurations.mockResolvedValue([]);
+
+      const res = await request(buildApp()).post('/export').send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(mockExportConfigurations).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /import', () => {
+    it('is registered (does not 404) and imports content via the service', async () => {
+      mockImportConfigurations.mockResolvedValue({
+        success: true,
+        importedCount: 1,
+        skippedCount: 0,
+        errorCount: 0,
+        errors: [],
+        warnings: [],
+      });
+
+      const res = await request(buildApp())
+        .post('/import')
+        .send({
+          content: JSON.stringify({ configurations: [{ id: 1, name: 'bot' }] }),
+          format: 'json',
+          dryRun: false,
+          overwrite: true,
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.importedCount).toBe(1);
+      expect(mockImportConfigurations).toHaveBeenCalledTimes(1);
+
+      // Options forwarded: overwrite=true, validateOnly=false (dryRun)
+      const forwardedOptions = mockImportConfigurations.mock.calls[0][1];
+      expect(forwardedOptions.overwrite).toBe(true);
+      expect(forwardedOptions.validateOnly).toBe(false);
+    });
+
+    it('returns 400 when no content is provided', async () => {
+      const res = await request(buildApp()).post('/import').send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(mockImportConfigurations).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## What
Implements the previously-empty `src/server/routes/admin/backup.ts` router with two endpoints the WebUI already calls:

- `POST /api/admin/export` — exports bot configurations via `ConfigurationImportExportService.exportConfigurations`, reads the generated file back, and returns the export document as JSON so the browser can download it. Defaults to exporting **all** configurations when none are specified.
- `POST /api/admin/import` — accepts the backup document as a JSON `content` field, writes it to a temp file, runs `ConfigurationImportExportService.importConfigurations`, and cleans up the temp file.

Also updates `src/client/src/pages/ImportExportPage.tsx` so the import handler reads the selected file client-side and posts JSON, instead of the broken `FormData` upload.

## Why
`ImportExportPage.tsx` posted to `/api/admin/export` and `/api/admin/import`, but `admin/backup.ts` was an empty router (audit #25), so both endpoints returned **404**. The real service (`ConfigurationImportExportService`) already existed and is used by `/api/import-export/*`; this PR reuses it rather than introducing a parallel system.

The page also previously sent `FormData`, which the JSON-only `apiService.post` client serialized with `JSON.stringify`, so the upload could never have worked even if the route existed.

## Behavior
- Admin export/import are reachable under `/api/admin/*` (auth + admin + rate limiting already applied by the admin router index).
- Export with no `configIds` exports every stored configuration; returns 400 when there are none.
- Import requires non-empty `content`; forwards `overwrite` and maps `dryRun` to the service's `validateOnly`; returns 400 on a failed import or missing content.

## Verification
- Backend `npx tsc --noEmit`: clean.
- Frontend `cd src/client && npx tsc --noEmit`: clean.
- `eslint` on changed `src` files: 0 errors.
- `npx jest tests/unit/server/routes/admin/backup.test.ts`: 4 passing. Confirmed the new test **fails against the old empty router** (4x 404) and passes after the fix.

Do not merge — for review.