### PR TITLE
fix(webhooks): serve webhook events with the contract the WebUI expects

### DIFF
--- a/src/server/registerRoutes.ts
+++ b/src/server/registerRoutes.ts
@@ -46,6 +46,7 @@ import templatesRouter from '@src/server/routes/templates';
 import testRouter from '@src/server/routes/testRoutes';
 import usageTrackingRouter from '@src/server/routes/usageTracking';
 import validationRouter from '@src/server/routes/validation';
+import webhookEventsRouter from '@src/server/routes/webhookEvents';
 import webhooksRouter from '@src/server/routes/webhooks';
 import webuiRouter from '@src/server/routes/webui';
 import Logger from '@common/logger';
@@ -149,6 +150,10 @@ export function registerRoutes(app: import('express').Application, ctx: RouteCon
   app.use('/api/providers', authenticateToken, providersRouter);
   app.use('/api/templates', authenticateToken, templatesRouter);
   app.use('/api/usage-tracking', usageTrackingRouter);
+  // webhookEventsRouter serves /events* (list, detail, retry) with the contract
+  // the WebUI expects; webhooksRouter handles /scheduled*. Order matters so the
+  // events routes are matched first.
+  app.use('/api/webhooks', authenticateToken, webhookEventsRouter);
   app.use('/api/webhooks', authenticateToken, webhooksRouter);
   app.use('/api/webui', authenticateToken, webuiRouter);
   app.use('/api/test', authenticateToken, testRouter);

--- a/src/server/routes/webhooks.ts
+++ b/src/server/routes/webhooks.ts
@@ -18,21 +18,10 @@ const router = Router();
 
 const scheduledMessages = new Map<string, any>();
 
-/**
- * GET /api/webhooks/events
- * List webhook events
- */
-router.get('/events', (_req, res) => {
-  res.json({ events: [], count: 0 });
-});
-
-/**
- * GET /api/webhooks/events/:id
- * Get a specific webhook event by ID
- */
-router.get('/events/:id', (req, res) => {
-  res.json({ event: null, id: req.params.id, message: 'Event not found' });
-});
+// Note: /events, /events/:id and /events/:id/retry are served by
+// webhookEventsRouter (src/server/routes/webhookEvents.ts), which is mounted at
+// /api/webhooks ahead of this router. It returns the { success, data } contract
+// the WebUI (WebhookEventsPage) expects.
 
 // ─── Scheduled Messages ───────────────────────────────────────────────
 

--- a/tests/unit/server/routes/webhookEvents.test.ts
+++ b/tests/unit/server/routes/webhookEvents.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Contract tests for the webhook events routes consumed by WebhookEventsPage.
+ *
+ * The WebUI (src/client/src/pages/WebhookEventsPage.tsx) expects:
+ *   - GET  /api/webhooks/events          -> { success, data: { items, total, page, limit, totalPages } }
+ *   - GET  /api/webhooks/events/:id      -> { success, data: { ...event, payload } }
+ *   - POST /api/webhooks/events/:id/retry-> { success, data: { ... } }
+ *
+ * These tests pin that contract against webhookEventsRouter, which is the router
+ * registerRoutes mounts at /api/webhooks.
+ */
+
+import express from 'express';
+import request from 'supertest';
+import webhookEventsRouter, {
+  recordWebhookEvent,
+} from '../../../../src/server/routes/webhookEvents';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/webhooks', webhookEventsRouter);
+  return app;
+}
+
+describe('webhookEvents routes contract', () => {
+  const app = buildApp();
+
+  it('GET /events returns the paginated envelope shape the WebUI expects', async () => {
+    const recorded = recordWebhookEvent({
+      source: 'discord',
+      endpoint: '/webhook/discord',
+      method: 'POST',
+      statusCode: 200,
+      duration: 12,
+      payload: { hello: 'world' },
+    });
+
+    const res = await request(app).get('/api/webhooks/events').expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual(
+      expect.objectContaining({
+        items: expect.any(Array),
+        total: expect.any(Number),
+        page: expect.any(Number),
+        limit: expect.any(Number),
+        totalPages: expect.any(Number),
+      })
+    );
+
+    const item = res.body.data.items.find((e: { id: string }) => e.id === recorded.id);
+    expect(item).toBeDefined();
+    expect(item).toEqual(
+      expect.objectContaining({
+        id: recorded.id,
+        source: 'discord',
+        endpoint: '/webhook/discord',
+        method: 'POST',
+        statusCode: 200,
+        payloadPreview: expect.any(String),
+      })
+    );
+    // List view must NOT leak the full payload.
+    expect(item.payload).toBeUndefined();
+  });
+
+  it('GET /events supports source + status filtering', async () => {
+    recordWebhookEvent({
+      source: 'slack',
+      endpoint: '/webhook/slack',
+      method: 'POST',
+      statusCode: 500,
+      duration: 5,
+      payload: { boom: true },
+      error: 'kaboom',
+    });
+
+    const res = await request(app)
+      .get('/api/webhooks/events?source=slack&status=failed')
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.items.length).toBeGreaterThan(0);
+    for (const item of res.body.data.items) {
+      expect(item.source).toBe('slack');
+      expect(item.statusCode).toBeGreaterThanOrEqual(400);
+    }
+  });
+
+  it('GET /events/:id returns the full event including payload', async () => {
+    const recorded = recordWebhookEvent({
+      source: 'mattermost',
+      endpoint: '/webhook/mattermost',
+      method: 'POST',
+      statusCode: 200,
+      duration: 7,
+      payload: { detail: 'value' },
+    });
+
+    const res = await request(app)
+      .get(`/api/webhooks/events/${recorded.id}`)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.id).toBe(recorded.id);
+    expect(res.body.data.payload).toEqual({ detail: 'value' });
+  });
+
+  it('GET /events/:id returns 404 for an unknown id', async () => {
+    const res = await request(app)
+      .get('/api/webhooks/events/does-not-exist')
+      .expect(404);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('POST /events/:id/retry replays a failed event', async () => {
+    const failed = recordWebhookEvent({
+      source: 'telegram',
+      endpoint: '/webhook/telegram',
+      method: 'POST',
+      statusCode: 502,
+      duration: 9,
+      payload: { retry: 'me' },
+      error: 'bad gateway',
+    });
+
+    const res = await request(app)
+      .post(`/api/webhooks/events/${failed.id}/retry`)
+      .send({})
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.originalId).toBe(failed.id);
+    expect(res.body.data.retryId).toBeDefined();
+    expect(typeof res.body.data.message).toBe('string');
+  });
+
+  it('POST /events/:id/retry rejects retrying a successful event', async () => {
+    const ok = recordWebhookEvent({
+      source: 'discord',
+      endpoint: '/webhook/discord',
+      method: 'POST',
+      statusCode: 200,
+      duration: 3,
+      payload: {},
+    });
+
+    const res = await request(app)
+      .post(`/api/webhooks/events/${ok.id}/retry`)
+      .send({})
+      .expect(400);
+
+    expect(res.body.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## What
`registerRoutes.ts` (the active route registration used by the real entrypoint `src/index.ts`) mounted the **stub** `webhooks.ts` router at `/api/webhooks`. Its `/events` and `/events/:id` handlers returned ad-hoc shapes (`{events,count}` / `{event,...,message}`) and there was **no** `POST /events/:id/retry` route at all.

`src/client/src/pages/WebhookEventsPage.tsx` consumes:
- `GET /api/webhooks/events` -> `{ success, data: { items, total, page, limit, totalPages } }`
- `GET /api/webhooks/events/:id` -> `{ success, data: { ...event, payload } }`
- `POST /api/webhooks/events/:id/retry` -> `{ success, data: { ... } }`

So the page could not list events, expand payloads, or retry failed events (audit #27).

## Why
A fully-correct `webhookEventsRouter` (`src/server/routes/webhookEvents.ts`) already existed with exactly the expected envelope, pagination, filtering, detail payload, and retry endpoint — but it was only wired into the **unused** `HivemindServer` in `server.ts`, never into the live `registerRoutes` path. This reuses that existing router rather than inventing a parallel system.

## Behavior
- Mount `webhookEventsRouter` at `/api/webhooks` in `registerRoutes.ts`, ahead of the scheduled-messages router so `/events*` is matched first; `webhooks.ts` continues to serve `/scheduled*`.
- Remove the dead `/events` and `/events/:id` stubs from `webhooks.ts` (left a pointer comment).
- No change to the default pipeline, startup, or other routes.

## Verification
- `npx tsc --noEmit` clean.
- `eslint` on the 3 changed source files: 0 errors.
- New `tests/unit/server/routes/webhookEvents.test.ts` (supertest) pins list envelope, source/status filtering, detail-with-payload, 404, retry, and retry-rejection — 6/6 pass.
- `npm run dev` boots through route registration into service startup with no errors.