### PR TITLE
fix(mcp): unblock pipeline — make MCPService SDK loading test-mockable

### DIFF
--- a/src/mcp/MCPService.ts
+++ b/src/mcp/MCPService.ts
@@ -49,8 +49,29 @@ export class MCPService {
    * @param clientName - The client identity reported to the server.
    * @returns A connected MCP client.
    */
+  /**
+   * Loads the MCP SDK entry points via dynamic `import()`.
+   *
+   * Extracted as a seam so tests can stub the SDK (the package is ESM-only
+   * with no CJS root export, which makes module-level mocking of the dynamic
+   * imports unreliable in jest); tests spy on this method instead.
+   */
+  protected async loadSdk(): Promise<{
+    Client: typeof import('@modelcontextprotocol/sdk/client/index.js').Client;
+    StreamableHTTPClientTransport: typeof import('@modelcontextprotocol/sdk/client/streamableHttp.js').StreamableHTTPClientTransport;
+    StdioClientTransport: typeof import('@modelcontextprotocol/sdk/client/stdio.js').StdioClientTransport;
+  }> {
+    const [{ Client }, { StreamableHTTPClientTransport }, { StdioClientTransport }] =
+      await Promise.all([
+        import('@modelcontextprotocol/sdk/client/index.js'),
+        import('@modelcontextprotocol/sdk/client/streamableHttp.js'),
+        import('@modelcontextprotocol/sdk/client/stdio.js'),
+      ]);
+    return { Client, StreamableHTTPClientTransport, StdioClientTransport };
+  }
+
   private async createConnectedClient(config: MCPConfig, clientName: string): Promise<Client> {
-    const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+    const { Client, StreamableHTTPClientTransport, StdioClientTransport } = await this.loadSdk();
 
     const client = new Client(
       { name: clientName, version: '1.0.0' },
@@ -59,16 +80,12 @@ export class MCPService {
 
     const url = config.serverUrl;
     if (url.startsWith('stdio://')) {
-      const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
       const command = url.replace('stdio://', '');
       const transport = new StdioClientTransport({ command, args: [] });
       await client.connect(transport);
       return client;
     }
 
-    const { StreamableHTTPClientTransport } = await import(
-      '@modelcontextprotocol/sdk/client/streamableHttp.js'
-    );
     const transport = new StreamableHTTPClientTransport(new URL(url), {
       requestInit: config.apiKey
         ? { headers: { Authorization: `Bearer ${config.apiKey}` } }

--- a/tests/unit/mcp/MCPService.test.ts
+++ b/tests/unit/mcp/MCPService.test.ts
@@ -26,22 +26,6 @@ const ClientCtor = jest.fn().mockImplementation(() => ({
 const StreamableHTTPCtor = jest.fn().mockImplementation((url: URL) => ({ __kind: 'http', url }));
 const StdioCtor = jest.fn().mockImplementation((opts: unknown) => ({ __kind: 'stdio', opts }));
 
-jest.mock(
-  '@modelcontextprotocol/sdk/client/index.js',
-  () => ({ Client: ClientCtor }),
-  { virtual: true }
-);
-jest.mock(
-  '@modelcontextprotocol/sdk/client/streamableHttp.js',
-  () => ({ StreamableHTTPClientTransport: StreamableHTTPCtor }),
-  { virtual: true }
-);
-jest.mock(
-  '@modelcontextprotocol/sdk/client/stdio.js',
-  () => ({ StdioClientTransport: StdioCtor }),
-  { virtual: true }
-);
-
 import { MCPService } from '../../../src/mcp/MCPService';
 
 describe('MCPService SDK client construction', () => {
@@ -49,6 +33,18 @@ describe('MCPService SDK client construction', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // The SDK is ESM-only with no CJS root export, so module-level mocking of
+    // the dynamic import() calls is unreliable in jest. Instead we stub the
+    // `loadSdk` seam on MCPService, which is the single place the SDK entry
+    // points are imported. This keeps the regression intent (Client constructs
+    // + connects via the right transport) without ESM module mocking.
+    jest
+      .spyOn(MCPService.prototype as unknown as { loadSdk: () => Promise<unknown> }, 'loadSdk')
+      .mockResolvedValue({
+        Client: ClientCtor,
+        StreamableHTTPClientTransport: StreamableHTTPCtor,
+        StdioClientTransport: StdioCtor,
+      });
     // Fresh singleton each test so connect/disconnect state does not leak.
     // @ts-expect-error - resetting private singleton for isolation
     MCPService.instance = undefined;


### PR DESCRIPTION
Regression fix: MCPService.test.ts (from #2833) failed on main ('Client is not a constructor') because jest can't mock the ESM SDK's native dynamic import(), breaking unit-tests-core for every PR. Adds a loadSdk() seam the test spies on. tsc clean, 4/4 tests pass. Behavior unchanged.