### PR TITLE
🔒 Fix command injection risk in versionTracking.ts

### DIFF
--- a/src/server/utils/versionTracking.ts
+++ b/src/server/utils/versionTracking.ts
@@ -1,10 +1,10 @@
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { promisify } from 'util';
 import Debug from 'debug';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 const debug = Debug('app:version-tracking');
 
@@ -104,10 +104,13 @@ export async function fetchLatestVersionFromGit(
       if (gitExists) {
         try {
           // ⚡ Bolt Optimization: Converted from execSync to execAsync to prevent event loop blocking.
-          await execAsync('git fetch --tags --quiet', { cwd: pluginPath, timeout: GIT_TIMEOUT_MS });
+          await execFileAsync('git', ['fetch', '--tags', '--quiet'], {
+            cwd: pluginPath,
+            timeout: GIT_TIMEOUT_MS,
+          });
 
           // Try to get the latest tag
-          const { stdout: tags } = await execAsync('git tag --sort=-v:refname', {
+          const { stdout: tags } = await execFileAsync('git', ['tag', '--sort=-v:refname'], {
             cwd: pluginPath,
             encoding: 'utf-8',
             timeout: GIT_TIMEOUT_MS,
@@ -124,10 +127,14 @@ export async function fetchLatestVersionFromGit(
           for (const branch of branches) {
             try {
               const safeBranch = sanitizeGitArg(branch, 'branch');
-              const { stdout: pkgJson } = await execAsync(`git show ${safeBranch}:package.json`, {
-                cwd: pluginPath,
-                encoding: 'utf-8',
-              });
+              const { stdout: pkgJson } = await execFileAsync(
+                'git',
+                ['show', `${safeBranch}:package.json`],
+                {
+                  cwd: pluginPath,
+                  encoding: 'utf-8',
+                }
+              );
               const pkg = JSON.parse(pkgJson);
               if (pkg.version) {
                 debug('Latest version from %s package.json: %s', branch, pkg.version);
@@ -173,22 +180,25 @@ export async function fetchChangelog(
 
     // Fetch latest changes
     // ⚡ Bolt Optimization: Converted from execSync to execAsync to prevent event loop blocking.
-    await execAsync('git fetch --quiet', { cwd: pluginPath, timeout: GIT_TIMEOUT_MS });
+    await execFileAsync('git', ['fetch', '--quiet'], { cwd: pluginPath, timeout: GIT_TIMEOUT_MS });
 
     // Get commits since current version tag (if it exists) or recent commits
-    let gitCommand = 'git log --pretty=format:"%H|%ai|%an|%s" -n 10 origin/HEAD';
+    let gitArgs = ['log', '--pretty=format:%H|%ai|%an|%s', '-n', '10', 'origin/HEAD'];
 
     try {
       // Try to find commits since current version
       const safeVersion = sanitizeGitArg(currentVersion, 'currentVersion');
       const currentTag = sanitizeGitArg(`v${safeVersion}`, 'version tag');
-      await execAsync(`git rev-parse ${currentTag}`, { cwd: pluginPath, timeout: GIT_TIMEOUT_MS });
-      gitCommand = `git log --pretty=format:"%H|%ai|%an|%s" ${currentTag}..origin/HEAD`;
+      await execFileAsync('git', ['rev-parse', currentTag], {
+        cwd: pluginPath,
+        timeout: GIT_TIMEOUT_MS,
+      });
+      gitArgs = ['log', '--pretty=format:%H|%ai|%an|%s', `${currentTag}..origin/HEAD`];
     } catch {
       // Tag doesn't exist, fall back to recent commits
     }
 
-    const { stdout: output } = await execAsync(gitCommand, {
+    const { stdout: output } = await execFileAsync('git', gitArgs, {
       cwd: pluginPath,
       encoding: 'utf-8',
       timeout: GIT_TIMEOUT_MS,

--- a/tests/unit/server/utils/versionTracking.test.ts
+++ b/tests/unit/server/utils/versionTracking.test.ts
@@ -1,0 +1,112 @@
+import * as child_process from 'child_process';
+import * as fs from 'fs';
+import {
+  compareVersions,
+  isNewerVersion,
+  fetchLatestVersionFromGit,
+  fetchChangelog,
+} from '../../../../src/server/utils/versionTracking';
+
+jest.mock('child_process');
+jest.mock('fs', () => ({
+  promises: {
+    access: jest.fn(),
+  },
+}));
+
+const mockedExecFile = child_process.execFile as unknown as jest.Mock;
+const mockedAccess = fs.promises.access as jest.Mock;
+
+describe('versionTracking', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('compareVersions', () => {
+    it('should correctly compare versions', () => {
+      expect(compareVersions('1.2.3', '1.2.4')).toBe(-1);
+      expect(compareVersions('1.2.4', '1.2.3')).toBe(1);
+      expect(compareVersions('1.2.3', '1.2.3')).toBe(0);
+      expect(compareVersions('v1.2.3', '1.2.4')).toBe(-1);
+      expect(compareVersions('1.3.0', '1.2.9')).toBe(1);
+      expect(compareVersions('2.0.0', '1.9.9')).toBe(1);
+    });
+  });
+
+  describe('isNewerVersion', () => {
+    it('should correctly identify newer versions', () => {
+      expect(isNewerVersion('1.2.3', '1.2.4')).toBe(true);
+      expect(isNewerVersion('1.2.4', '1.2.3')).toBe(false);
+      expect(isNewerVersion('1.2.3', '1.2.3')).toBe(false);
+    });
+  });
+
+  describe('fetchLatestVersionFromGit', () => {
+    it('should fetch latest version from tags', async () => {
+      mockedAccess.mockResolvedValue(undefined);
+      mockedExecFile.mockImplementation((cmd, args, options, callback) => {
+        if (args.includes('tag')) {
+          callback(null, 'v1.2.5\nv1.2.4\n', '');
+        } else {
+          callback(null, '', '');
+        }
+      });
+
+      const version = await fetchLatestVersionFromGit('http://repo.com', '/path/to/plugin');
+      expect(version).toBe('1.2.5');
+      expect(mockedExecFile).toHaveBeenCalledWith(
+        'git',
+        ['fetch', '--tags', '--quiet'],
+        expect.any(Object),
+        expect.any(Function)
+      );
+    });
+
+    it('should fall back to package.json if no tags', async () => {
+      mockedAccess.mockResolvedValue(undefined);
+      mockedExecFile.mockImplementation((cmd, args, options, callback) => {
+        if (args.includes('tag')) {
+          callback(null, '', '');
+        } else if (
+          args.includes('show') &&
+          args.some((a: string) => a.includes('origin/main:package.json'))
+        ) {
+          callback(null, JSON.stringify({ version: '1.2.6' }), '');
+        } else {
+          callback(null, '', '');
+        }
+      });
+
+      const version = await fetchLatestVersionFromGit('http://repo.com', '/path/to/plugin');
+      expect(version).toBe('1.2.6');
+    });
+  });
+
+  describe('fetchChangelog', () => {
+    it('should fetch changelog entries', async () => {
+      mockedAccess.mockResolvedValue(undefined);
+      mockedExecFile.mockImplementation((cmd, args, options, callback) => {
+        if (args.includes('log')) {
+          callback(
+            null,
+            'sha1|2023-01-01T00:00:00Z|Author|Commit message with 1.2.7\n' +
+              'sha2|2023-01-02T00:00:00Z|Author|Another message 1.2.6\n',
+            ''
+          );
+        } else {
+          callback(null, '', '');
+        }
+      });
+
+      const changelog = await fetchChangelog('/path/to/plugin', '1.2.5');
+      expect(changelog).toHaveLength(2);
+      expect(changelog[0]).toEqual({
+        version: '1.2.7',
+        date: expect.any(String),
+        message: 'Commit message with 1.2.7',
+        author: 'Author',
+        sha: 'sha1',
+      });
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** Replaced `exec` with `execFile` in `src/server/utils/versionTracking.ts` to prevent command injection.
⚠️ **Risk:** Using `exec` with string concatenation could allow an attacker to execute arbitrary shell commands if they control the branch names or version strings, even with basic sanitization.
🛡️ **Solution:** Switched to `execFile` (promisified as `execFileAsync`) which accepts arguments as an array. This avoids the shell interpreter entirely, ensuring that arguments are never parsed as part of a shell command.

I have also added a new unit test at `tests/unit/server/utils/versionTracking.test.ts` to verify that `git` is called with the correct argument arrays.

---
*PR created automatically by Jules for task [691462727052889622](https://jules.google.com/task/691462727052889622) started by @matthewhand*