### PR TITLE
🧪 [testing improvement] Add failure test for AuthManager.verifyAccessToken

### DIFF
--- a/tests/auth/AuthManager.test.ts
+++ b/tests/auth/AuthManager.test.ts
@@ -1,3 +1,4 @@
+import jwt from 'jsonwebtoken';
 import { AuthManager } from '../../src/auth/AuthManager';
 import { User, UserRole } from '../../src/auth/types';
 
@@ -187,6 +188,18 @@ describe('AuthManager', () => {
       expect(() => {
         authManager.verifyAccessToken('invalid-token');
       }).toThrow('Invalid access token');
+    });
+
+    it('should throw "Invalid access token" when jwt.verify fails', () => {
+      const spy = jest.spyOn(jwt, 'verify').mockImplementationOnce(() => {
+        throw new Error('JWT failure');
+      });
+
+      expect(() => {
+        authManager.verifyAccessToken('any-token');
+      }).toThrow('Invalid access token');
+
+      spy.mockRestore();
     });
 
     it('should refresh access token with valid refresh token', async () => {


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
- Missing failure test for `AuthManager.verifyAccessToken`.

📊 **Coverage:** What scenarios are now tested
- Success path for `verifyAccessToken` (existing).
- Failure path when an invalid token string is provided (existing).
- **New:** Failure path when `jwt.verify` internal execution fails/throws (mocked).

✨ **Result:** The improvement in test coverage
- Explicitly tests the `catch` block in `AuthManager.verifyAccessToken`, ensuring robust error handling and consistent error messaging to callers.

---
*PR created automatically by Jules for task [2889677814080450974](https://jules.google.com/task/2889677814080450974) started by @matthewhand*