### PR TITLE
fix(command-palette): point stale targets at canonical routes

### DIFF
--- a/src/client/src/components/CommandPalette.tsx
+++ b/src/client/src/components/CommandPalette.tsx
@@ -14,19 +14,19 @@ interface PaletteItem {
   section?: string;
 }
 
-const PALETTE_ITEMS: PaletteItem[] = [
+export const PALETTE_ITEMS: PaletteItem[] = [
   { id: 'overview', label: 'Overview', path: '/admin/overview', icon: <LayoutDashboard className="w-4 h-4" />, section: 'Pages' },
   { id: 'bots', label: 'Bots', path: '/admin/bots', icon: <Bot className="w-4 h-4" />, section: 'Pages' },
   { id: 'create-bot', label: 'Create New Bot', path: '/admin/bots/create', icon: <Bot className="w-4 h-4" />, section: 'Actions' },
   { id: 'personas', label: 'Personas', path: '/admin/personas', icon: <Users className="w-4 h-4" />, section: 'Pages' },
   { id: 'guards', label: 'Guards', path: '/admin/guards', icon: <Shield className="w-4 h-4" />, section: 'Pages' },
-  { id: 'llm-providers', label: 'LLM Providers', path: '/admin/providers/llm', icon: <Brain className="w-4 h-4" />, section: 'Pages' },
-  { id: 'message-providers', label: 'Message Providers', path: '/admin/providers/message', icon: <MessageSquare className="w-4 h-4" />, section: 'Pages' },
-  { id: 'monitoring', label: 'Monitoring', path: '/admin/monitoring', icon: <Activity className="w-4 h-4" />, section: 'Pages' },
+  { id: 'llm-providers', label: 'LLM Providers', path: '/admin/llm', icon: <Brain className="w-4 h-4" />, section: 'Pages' },
+  { id: 'message-providers', label: 'Message Providers', path: '/admin/message', icon: <MessageSquare className="w-4 h-4" />, section: 'Pages' },
+  { id: 'monitoring', label: 'Monitoring', path: '/admin/overview?tab=monitoring', icon: <Activity className="w-4 h-4" />, section: 'Pages' },
   { id: 'settings', label: 'Settings', path: '/admin/settings', icon: <Settings className="w-4 h-4" />, section: 'Pages' },
   { id: 'configuration', label: 'Global Defaults', path: '/admin/configuration', icon: <Settings className="w-4 h-4" />, section: 'Pages' },
-  { id: 'showcase', label: 'UI Components', path: '/admin/showcase', icon: <Component className="w-4 h-4" />, section: 'Developer' },
-  { id: 'sitemap', label: 'Sitemap', path: '/admin/sitemap', icon: <Map className="w-4 h-4" />, section: 'Developer' },
+  { id: 'showcase', label: 'UI Components', path: '/admin/developer?tab=showcase', icon: <Component className="w-4 h-4" />, section: 'Developer' },
+  { id: 'sitemap', label: 'Sitemap', path: '/admin/developer?tab=sitemap', icon: <Map className="w-4 h-4" />, section: 'Developer' },
 ];
 
 interface CommandPaletteProps {

--- a/src/client/src/components/__tests__/CommandPalette.routes.test.tsx
+++ b/src/client/src/components/__tests__/CommandPalette.routes.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { matchPath } from 'react-router-dom';
+import { PALETTE_ITEMS } from '../CommandPalette';
+
+/**
+ * Guards against stale Command Palette targets.
+ *
+ * Every palette item navigates the user to a path. If that path is not a real
+ * route (or a route that redirects), the user lands on the catch-all `*` route
+ * which bounces them back to `/`. This test asserts each palette target matches
+ * a concrete route pattern declared in AppRouter.tsx.
+ *
+ * The pattern list below mirrors the admin `<Route>` declarations in
+ * src/client/src/router/AppRouter.tsx. Routes are nested under `/admin`.
+ */
+const ADMIN_ROUTE_PATTERNS = [
+  '/admin/overview',
+  '/admin/bots',
+  '/admin/bots/create',
+  '/admin/bots/templates',
+  '/admin/llm',
+  '/admin/message',
+  '/admin/memory',
+  '/admin/tool',
+  '/admin/config/response-profiles',
+  '/admin/personas',
+  '/admin/guards',
+  '/admin/marketplace',
+  '/admin/mcp',
+  '/admin/mcp/servers',
+  '/admin/mcp/tools',
+  '/admin/analytics',
+  '/admin/system-management',
+  '/admin/export',
+  '/admin/settings',
+  '/admin/configuration',
+  '/admin/config',
+  '/admin/developer',
+  '/admin/specs/:id',
+  '/admin/audit',
+  '/admin/health',
+  '/admin/health/providers',
+  '/admin/webhooks',
+  '/admin/api-docs',
+  '/admin/help',
+  '/admin/about',
+];
+
+const isValidRoute = (target: string): boolean => {
+  // Drop any query string / hash — routing matches on pathname only.
+  const pathname = target.split('?')[0].split('#')[0];
+  return ADMIN_ROUTE_PATTERNS.some((pattern) => matchPath(pattern, pathname) !== null);
+};
+
+describe('CommandPalette route targets', () => {
+  it('exposes palette items', () => {
+    expect(PALETTE_ITEMS.length).toBeGreaterThan(0);
+  });
+
+  it.each(PALETTE_ITEMS.map((item) => [item.id, item.path] as const))(
+    'palette item "%s" navigates to a real route (%s)',
+    (_id, path) => {
+      expect(isValidRoute(path)).toBe(true);
+    }
+  );
+
+  it('does not navigate through the legacy /admin/providers/* redirects', () => {
+    const legacyTargets = PALETTE_ITEMS.filter((item) =>
+      item.path.startsWith('/admin/providers/')
+    );
+    expect(legacyTargets).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What
Fixes stale hardcoded paths in `CommandPalette.tsx` `PALETTE_ITEMS` and adds a test guarding palette targets against the router.

| Item | Before | After |
|------|--------|-------|
| LLM Providers | `/admin/providers/llm` | `/admin/llm` |
| Message Providers | `/admin/providers/message` | `/admin/message` |
| Monitoring | `/admin/monitoring` | `/admin/overview?tab=monitoring` |
| UI Components | `/admin/showcase` | `/admin/developer?tab=showcase` |
| Sitemap | `/admin/sitemap` | `/admin/developer?tab=sitemap` |

## Why
The old targets only resolved by bouncing through legacy `<Navigate>` redirects in `AppRouter.tsx` (e.g. `providers/llm` -> `/admin/llm`). The `/admin/providers/*` routes are explicitly marked "Legacy redirects" in the router. Pointing the palette at the canonical routes (matching `src/client/src/config/navigation.tsx`) avoids the redirect hop and keeps targets aligned with the nav config.

## Behavior
Selecting any Command Palette entry now navigates directly to the live route. No user-visible regression — the same destinations load, without an intermediate redirect.

## Verification
- `PALETTE_ITEMS` exported and a new vitest suite `src/client/src/components/__tests__/CommandPalette.routes.test.tsx` asserts every palette path matches a concrete `/admin` route pattern from `AppRouter.tsx` (and that no item uses the legacy `/admin/providers/*` prefix).
- `cd src/client && npx tsc --noEmit` -> clean
- `vitest run src/components/__tests__/` -> 34 passed / 4 skipped (14 in the new suite)

Note: repo-wide `eslint` currently crashes at module load due to a pre-existing ajv/eslintrc version conflict in the shared install, unrelated to this change (no new lint-relevant constructs introduced).