### PR TITLE
fix(metrics): wire real event-loop and request metrics into JSON /metrics endpoint

### DIFF
--- a/src/server/routes/health/index.ts
+++ b/src/server/routes/health/index.ts
@@ -3,8 +3,13 @@ import basicRouter from './basic';
 import detailedRouter from './detailed';
 import diagnosticsRouter from './diagnostics';
 import metricsRouter from './metrics';
+import { requestCounterMiddleware } from './runtimeMetrics';
 
 const router = Router();
+
+// Count every request flowing through the health router so the JSON metrics
+// endpoint can report a real request total and rate.
+router.use(requestCounterMiddleware);
 
 // Basic health routes (/health/, /health/ready, /health/live)
 router.use('/', basicRouter);

--- a/src/server/routes/health/metrics.ts
+++ b/src/server/routes/health/metrics.ts
@@ -2,6 +2,7 @@ import process from 'process';
 import { Router, type Request, type Response } from 'express';
 import { MetricsCollector } from '../../../monitoring/MetricsCollector';
 import { ProviderMetricsCollector } from '../../../monitoring/ProviderMetricsCollector';
+import { getRuntimeMetrics } from './runtimeMetrics';
 
 const router = Router();
 
@@ -10,6 +11,7 @@ router.get('/', (req, res) => {
   const uptime = process.uptime();
   const memoryUsage = process.memoryUsage();
   const cpuUsage = process.cpuUsage();
+  const runtime = getRuntimeMetrics();
 
   const metricsData = {
     timestamp: new Date().toISOString(),
@@ -24,12 +26,12 @@ router.get('/', (req, res) => {
       system: Math.round(cpuUsage.system / 1000),
     },
     eventLoop: {
-      delay: 0, // Would need actual event loop delay measurement
-      utilization: 0, // Would need actual utilization calculation
+      delay: runtime.eventLoopDelayMs, // mean event loop delay (ms)
+      utilization: runtime.eventLoopUtilization, // 0..1 since last read
     },
     requests: {
-      total: 0, // Would need to implement request counter
-      rate: 0, // Would need to implement rate calculation
+      total: runtime.requestsTotal, // counted by requestCounterMiddleware
+      rate: runtime.requestsRate, // requests/second since process start
     },
   };
 

--- a/src/server/routes/health/runtimeMetrics.ts
+++ b/src/server/routes/health/runtimeMetrics.ts
@@ -1,0 +1,75 @@
+import { monitorEventLoopDelay, performance, type EventLoopUtilization } from 'perf_hooks';
+import type { NextFunction, Request, Response } from 'express';
+
+/**
+ * Runtime metrics shared by the JSON `/metrics` endpoint.
+ *
+ * Provides real (non-hardcoded) values for:
+ *  - event loop delay (ms) via {@link monitorEventLoopDelay}
+ *  - event loop utilization (0..1) via {@link performance.eventLoopUtilization}
+ *  - total HTTP requests counted by {@link requestCounterMiddleware}
+ *  - request rate (requests/second) computed since process start
+ */
+
+// Histogram resolution of 10ms is plenty for a coarse health delay metric and
+// keeps overhead negligible.
+const eventLoopDelayMonitor = monitorEventLoopDelay({ resolution: 10 });
+eventLoopDelayMonitor.enable();
+
+// Baseline utilization sample captured at module load so the first reading is
+// relative to process start rather than undefined.
+let lastEluSample: EventLoopUtilization = performance.eventLoopUtilization();
+
+let requestCount = 0;
+const startTimeMs = Date.now();
+
+/** Express middleware that increments the total request counter. */
+export function requestCounterMiddleware(_req: Request, _res: Response, next: NextFunction): void {
+  requestCount += 1;
+  next();
+}
+
+export interface RuntimeMetrics {
+  /** Mean event loop delay in milliseconds since the last reset. */
+  eventLoopDelayMs: number;
+  /** Event loop utilization in the range 0..1 since the previous read. */
+  eventLoopUtilization: number;
+  /** Total HTTP requests observed by the counter middleware. */
+  requestsTotal: number;
+  /** Average request rate in requests per second since process start. */
+  requestsRate: number;
+}
+
+/**
+ * Snapshot the current runtime metrics. The event loop delay histogram is
+ * reset after reading so each call reports the interval since the previous one.
+ */
+export function getRuntimeMetrics(): RuntimeMetrics {
+  // `mean` is in nanoseconds; convert to milliseconds. Guard against NaN when
+  // no samples have been collected yet.
+  const meanNs = eventLoopDelayMonitor.mean;
+  const eventLoopDelayMs = Number.isFinite(meanNs) ? meanNs / 1e6 : 0;
+  eventLoopDelayMonitor.reset();
+
+  const current = performance.eventLoopUtilization();
+  const delta = performance.eventLoopUtilization(current, lastEluSample);
+  lastEluSample = current;
+  const eventLoopUtilization = Number.isFinite(delta.utilization) ? delta.utilization : 0;
+
+  const elapsedSeconds = Math.max((Date.now() - startTimeMs) / 1000, 1e-9);
+  const requestsRate = requestCount / elapsedSeconds;
+
+  return {
+    eventLoopDelayMs,
+    eventLoopUtilization,
+    requestsTotal: requestCount,
+    requestsRate,
+  };
+}
+
+/** Test-only helper to reset counters and samples between cases. */
+export function __resetRuntimeMetricsForTests(): void {
+  requestCount = 0;
+  eventLoopDelayMonitor.reset();
+  lastEluSample = performance.eventLoopUtilization();
+}

--- a/tests/unit/observability/metricsRoute.runtimeMetrics.test.ts
+++ b/tests/unit/observability/metricsRoute.runtimeMetrics.test.ts
@@ -1,0 +1,47 @@
+import express from 'express';
+import request from 'supertest';
+import metricsRouter from '@src/server/routes/health/metrics';
+import {
+  requestCounterMiddleware,
+  __resetRuntimeMetricsForTests,
+} from '@src/server/routes/health/runtimeMetrics';
+
+/**
+ * Verifies the JSON `/metrics` endpoint reports real runtime values for the
+ * event loop and request counter rather than the previously hardcoded zeros.
+ */
+describe('GET /metrics runtime metrics wiring', () => {
+  const app = express();
+  app.use(requestCounterMiddleware);
+  app.use('/metrics', metricsRouter);
+
+  beforeEach(() => {
+    __resetRuntimeMetricsForTests();
+  });
+
+  it('counts requests and exposes a non-zero total and rate', async () => {
+    // Make a couple of warm-up requests so the counter is clearly non-zero.
+    await request(app).get('/metrics');
+    await request(app).get('/metrics');
+
+    const res = await request(app).get('/metrics');
+
+    expect(res.status).toBe(200);
+    expect(res.body.requests.total).toBe(3);
+    expect(res.body.requests.rate).toBeGreaterThan(0);
+  });
+
+  it('reports event loop metrics as finite numbers', async () => {
+    const res = await request(app).get('/metrics');
+
+    expect(res.status).toBe(200);
+    expect(typeof res.body.eventLoop.delay).toBe('number');
+    expect(Number.isFinite(res.body.eventLoop.delay)).toBe(true);
+    expect(res.body.eventLoop.delay).toBeGreaterThanOrEqual(0);
+
+    expect(typeof res.body.eventLoop.utilization).toBe('number');
+    expect(Number.isFinite(res.body.eventLoop.utilization)).toBe(true);
+    expect(res.body.eventLoop.utilization).toBeGreaterThanOrEqual(0);
+    expect(res.body.eventLoop.utilization).toBeLessThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
## What
The JSON `/health/metrics` endpoint (`src/server/routes/health/metrics.ts`) hardcoded `eventLoop.delay=0`, `eventLoop.utilization=0`, `requests.total=0` and `requests.rate=0`. This wires in real values.

## Why
These fields were placeholders (`// Would need actual ... measurement`). The Prometheus text endpoint already exposes real process metrics, but the JSON endpoint reported zeros for event-loop health and request throughput, making the data misleading for dashboards.

## Behavior
- New `src/server/routes/health/runtimeMetrics.ts`:
  - `eventLoopDelayMs` from `perf_hooks.monitorEventLoopDelay()` (mean, ns to ms; histogram reset per read).
  - `eventLoopUtilization` (0..1) from `performance.eventLoopUtilization()` deltas.
  - `requestCounterMiddleware` increments a total counter; `requestsRate` = total / seconds since process start.
  - All values guarded against `NaN`/non-finite.
- `requestCounterMiddleware` mounted on the health router (`index.ts`) so requests are actually counted.
- `metrics.ts` JSON endpoint now reads these real values instead of literal zeros.
- The Prometheus endpoints and provider metrics are unchanged.

## Verification
- `npx tsc --noEmit` clean.
- New test `tests/unit/observability/metricsRoute.runtimeMetrics.test.ts` asserts a non-zero request total/rate and finite, in-range event-loop values; existing `metricsRoute.providerMetrics.test.ts` still passes (3 tests, 2 suites green).
- ESLint could not run due to a pre-existing ajv/eslintrc loading crash in the shared node_modules (reproduces on unmodified files); code follows existing style conventions.