### PR TITLE
perf(memory-postgres): direct indexed getMemory(id) lookup

### DIFF
--- a/packages/memory-postgres/src/PostgresMemoryProvider.test.ts
+++ b/packages/memory-postgres/src/PostgresMemoryProvider.test.ts
@@ -16,6 +16,7 @@ describe('PostgresMemoryProvider (Mocked)', () => {
           { id: 1, content: 'test memory', score: 0.9, metadata: { foo: 'bar' } },
         ]),
       getMemories: jest.fn().mockResolvedValue([]),
+      getMemoryById: jest.fn().mockResolvedValue(null),
       deleteMemory: jest.fn().mockResolvedValue(true),
       deleteAllMemories: jest.fn().mockResolvedValue(undefined),
       isConnected: jest.fn().mockReturnValue(true),
@@ -58,5 +59,41 @@ describe('PostgresMemoryProvider (Mocked)', () => {
       expect.any(Object)
     );
     expect(result.results[0].metadata).toEqual({ foo: 'bar' });
+  });
+
+  it('should fetch a single memory via a direct indexed lookup, not a full scan', async () => {
+    mockDbManager.getMemoryById.mockResolvedValue({
+      id: 42,
+      content: 'single memory',
+      metadata: { foo: 'bar' },
+      userId: 'u1',
+      agentId: 'a1',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    const result = await provider.getMemory('42');
+
+    // Uses the direct WHERE id = ? query, not getMemories({ limit: 1000 }).
+    expect(mockDbManager.getMemoryById).toHaveBeenCalledWith('42');
+    expect(mockDbManager.getMemories).not.toHaveBeenCalled();
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: '42',
+        content: 'single memory',
+        metadata: { foo: 'bar' },
+        userId: 'u1',
+        agentId: 'a1',
+      })
+    );
+  });
+
+  it('should return null when the memory id is not found', async () => {
+    mockDbManager.getMemoryById.mockResolvedValue(null);
+
+    const result = await provider.getMemory('does-not-exist');
+
+    expect(mockDbManager.getMemoryById).toHaveBeenCalledWith('does-not-exist');
+    expect(mockDbManager.getMemories).not.toHaveBeenCalled();
+    expect(result).toBeNull();
   });
 });

--- a/packages/memory-postgres/src/PostgresMemoryProvider.ts
+++ b/packages/memory-postgres/src/PostgresMemoryProvider.ts
@@ -136,10 +136,9 @@ export class PostgresMemoryProvider implements IMemoryProvider {
 
   async getMemory(id: string): Promise<MemoryEntry | null> {
     this.ensureInitialized();
-    // Implementation for getting single memory from dbManager
-    // For now we use getMemories and find
-    const memories = await this.dbManager.getMemories({ limit: 1000 });
-    const found = memories.find((m: any) => String(m.id) === id);
+    // Direct indexed lookup (SELECT ... WHERE id = $1) — O(1) on the primary
+    // key, instead of fetching up to 1000 rows and scanning them in JS.
+    const found = await this.dbManager.getMemoryById(id);
     if (!found) return null;
 
     return {

--- a/src/database/DatabaseManager.ts
+++ b/src/database/DatabaseManager.ts
@@ -554,6 +554,10 @@ export class DatabaseManager {
     return this.memoryRepo.getMemories(options);
   }
 
+  async getMemoryById(id: string | number): Promise<MemoryRecord | null> {
+    return this.memoryRepo.getMemoryById(id);
+  }
+
   async deleteMemory(id: string | number): Promise<boolean> {
     return this.memoryRepo.deleteMemory(id);
   }

--- a/src/database/repositories/MemoryRepository.ts
+++ b/src/database/repositories/MemoryRepository.ts
@@ -170,6 +170,24 @@ export class MemoryRepository {
     }
   }
 
+  async getMemoryById(id: string | number): Promise<MemoryRecord | null> {
+    if (!this.isConnected()) return null;
+    const db = this.getDb();
+    if (!db) return null;
+
+    try {
+      const row = await db.get('SELECT * FROM memories WHERE id = ?', [id]);
+      if (!row) return null;
+      return {
+        ...row,
+        metadata: row.metadata ? JSON.parse(row.metadata) : undefined,
+      };
+    } catch (error) {
+      debug('Error getting memory by id:', error);
+      return null;
+    }
+  }
+
   async deleteMemory(id: string | number): Promise<boolean> {
     if (!this.isConnected()) return false;
     const db = this.getDb();

--- a/tests/unit/repositories/MemoryRepository.getById.test.ts
+++ b/tests/unit/repositories/MemoryRepository.getById.test.ts
@@ -1,0 +1,77 @@
+import { MemoryRepository } from '../../../src/database/repositories/MemoryRepository';
+import type { IDatabase } from '../../../src/database/types';
+
+/**
+ * Focused tests for MemoryRepository.getMemoryById, which performs a direct
+ * indexed lookup (SELECT ... WHERE id = ?) rather than scanning many rows.
+ */
+function makeRepo(
+  getImpl: (sql: string, params: any[]) => Promise<any>,
+  opts: { connected?: boolean } = {}
+) {
+  const get = jest.fn(getImpl);
+  const db = {
+    run: jest.fn(),
+    get,
+    all: jest.fn(),
+    exec: jest.fn(),
+    transaction: jest.fn(),
+    close: jest.fn(),
+  } as unknown as IDatabase;
+  const repo = new MemoryRepository(
+    () => db,
+    () => opts.connected ?? true,
+    () => false
+  );
+  return { repo, get };
+}
+
+describe('MemoryRepository.getMemoryById', () => {
+  it('issues a single indexed WHERE id = ? query and parses metadata', async () => {
+    const { repo, get } = makeRepo(async () => ({
+      id: 7,
+      content: 'hello',
+      metadata: JSON.stringify({ foo: 'bar' }),
+      userId: 'u1',
+      agentId: 'a1',
+    }));
+
+    const row = await repo.getMemoryById('7');
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledWith('SELECT * FROM memories WHERE id = ?', ['7']);
+    expect(row).toEqual(
+      expect.objectContaining({
+        id: 7,
+        content: 'hello',
+        metadata: { foo: 'bar' },
+        userId: 'u1',
+        agentId: 'a1',
+      })
+    );
+  });
+
+  it('returns null when no row matches the id', async () => {
+    const { repo } = makeRepo(async () => undefined);
+    expect(await repo.getMemoryById('does-not-exist')).toBeNull();
+  });
+
+  it('returns undefined metadata when the column is empty', async () => {
+    const { repo } = makeRepo(async () => ({ id: 1, content: 'x', metadata: null }));
+    const row = await repo.getMemoryById(1);
+    expect(row?.metadata).toBeUndefined();
+  });
+
+  it('returns null and does not throw when not connected', async () => {
+    const { repo, get } = makeRepo(async () => ({ id: 1 }), { connected: false });
+    expect(await repo.getMemoryById(1)).toBeNull();
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the underlying query throws', async () => {
+    const { repo } = makeRepo(async () => {
+      throw new Error('db boom');
+    });
+    expect(await repo.getMemoryById(1)).toBeNull();
+  });
+});


### PR DESCRIPTION
@
## What
`PostgresMemoryProvider.getMemory(id)` previously fetched `getMemories({ limit: 1000 })` and ran `Array.find` in JS to locate a single row. This is O(n) and silently returns `null` for any memory beyond the newest 1000 rows in a scope.

This PR replaces it with a direct indexed lookup:
- New `MemoryRepository.getMemoryById(id)` runs `SELECT * FROM memories WHERE id = ?` (primary-key indexed, works for both Postgres and SQLite via the shared `IDatabase`).
- New `DatabaseManager.getMemoryById(id)` delegates to the repository, matching the existing delegation pattern for `getMemories` / `deleteMemory`.
- `PostgresMemoryProvider.getMemory` now calls `dbManager.getMemoryById(id)`.

## Why
The previous approach degraded linearly with table size and was correctness-broken past 1000 rows (a valid id outside the first 1000 returned `null`). The new path is O(1) on the primary key and always correct regardless of row count.

## Behavior
- Found id -> returns the mapped `MemoryEntry`.
- Missing id -> returns `null`.
- `getMemories` is no longer called from `getMemory` (verified by test).
- Not connected / query error -> repository returns `null` safely (no throw).

## Verification
- `npx tsc --noEmit` clean (backend).
- `jest packages/memory-postgres/src/PostgresMemoryProvider.test.ts` — 4 passed (added hit + miss + no-full-scan cases).
- `jest tests/unit/repositories/MemoryRepository.getById.test.ts` — 5 passed (indexed query shape, miss, null metadata, not-connected, query-throws).
- ESLint could not run in this environment due to a pre-existing ajv/eslintrc loader error that also fails on unrelated files (`src/index.ts`); changes follow the existing style of neighbouring methods.

No changes to startup, the default pipeline, auth, or the live DB path.
@