### PR TITLE
feat(activity): compute summary metrics from real activity events

### DIFF
--- a/src/server/routes/activity.ts
+++ b/src/server/routes/activity.ts
@@ -7,6 +7,7 @@ import { asyncErrorHandler } from '../../middleware/errorHandler';
 import { HTTP_STATUS } from '../../types/constants';
 import { ActivityFilterSchema, LogActivitySchema } from '../../validation/schemas/activitySchema';
 import { validateRequest } from '../../validation/validateRequest';
+import { ActivityLogger } from '../services/ActivityLogger';
 
 const debug = Debug('app:webui:activity');
 const router = Router();
@@ -124,16 +125,57 @@ router.get(
 
     const stats = await dbManager.getStats();
 
+    const timeRangeStart =
+      startDate || new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    const timeRangeEnd = endDate || new Date().toISOString();
+
+    // Derive response-time, error-rate, per-agent and per-LLM-provider metrics
+    // from the recorded activity events for the requested time range.
+    const events = await ActivityLogger.getInstance().getEvents({
+      startTime: new Date(timeRangeStart),
+      endTime: new Date(timeRangeEnd),
+      limit: Number.MAX_SAFE_INTEGER,
+    });
+
+    const messagesByAgent: Record<string, number> = {};
+    const llmUsageByProvider: Record<string, number> = {};
+    let processingTimeTotal = 0;
+    let processingTimeSamples = 0;
+    let errorCount = 0;
+
+    for (const event of events) {
+      if (event.botName) {
+        messagesByAgent[event.botName] = (messagesByAgent[event.botName] || 0) + 1;
+      }
+      if (event.llmProvider) {
+        llmUsageByProvider[event.llmProvider] =
+          (llmUsageByProvider[event.llmProvider] || 0) + 1;
+      }
+      if (typeof event.processingTime === 'number') {
+        processingTimeTotal += event.processingTime;
+        processingTimeSamples += 1;
+      }
+      if (event.status === 'error' || event.status === 'timeout') {
+        errorCount += 1;
+      }
+    }
+
+    const averageResponseTime =
+      processingTimeSamples > 0
+        ? Math.round(processingTimeTotal / processingTimeSamples)
+        : 0;
+    const errorRate = events.length > 0 ? errorCount / events.length : 0;
+
     const summary: ActivitySummary = {
       totalMessages: stats.totalMessages,
       totalAgents: stats.totalChannels,
-      averageResponseTime: 250,
-      errorRate: 0.02,
+      averageResponseTime,
+      errorRate,
       messagesByProvider: stats.providers,
-      messagesByAgent: {},
-      llmUsageByProvider: {},
-      timeRangeStart: startDate || new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
-      timeRangeEnd: endDate || new Date().toISOString(),
+      messagesByAgent,
+      llmUsageByProvider,
+      timeRangeStart,
+      timeRangeEnd,
     };
 
     return res.json(ApiResponse.success({ summary }));

--- a/tests/unit/server/routes/activitySummary.test.ts
+++ b/tests/unit/server/routes/activitySummary.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for GET /api/activity/summary.
+ *
+ * Regression: the handler previously hardcoded averageResponseTime (250) and
+ * errorRate (0.02) and returned empty messagesByAgent / llmUsageByProvider.
+ * These metrics are now derived from real recorded activity events via
+ * ActivityLogger, alongside the DB-backed totals from DatabaseManager.getStats().
+ */
+import express from 'express';
+import request from 'supertest';
+// Import after mocks are registered.
+import activityRouter from '../../../../src/server/routes/activity';
+
+const mockGetStats = jest.fn();
+const mockGetEvents = jest.fn();
+
+jest.mock('../../../../src/database/DatabaseManager', () => ({
+  DatabaseManager: {
+    getInstance: () => ({
+      isConnected: () => true,
+      getStats: mockGetStats,
+    }),
+  },
+}));
+
+jest.mock('../../../../src/server/services/ActivityLogger', () => ({
+  ActivityLogger: {
+    getInstance: () => ({
+      getEvents: mockGetEvents,
+    }),
+  },
+}));
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/activity', activityRouter);
+  return app;
+}
+
+describe('GET /api/activity/summary', () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetStats.mockResolvedValue({
+      totalMessages: 10,
+      totalChannels: 3,
+      totalAuthors: 5,
+      providers: { discord: 7, slack: 3 },
+    });
+  });
+
+  it('derives response time, error rate, per-agent and per-LLM-provider metrics from recorded events', async () => {
+    mockGetEvents.mockResolvedValue([
+      {
+        id: '1',
+        timestamp: new Date().toISOString(),
+        botName: 'Bot A',
+        provider: 'discord',
+        llmProvider: 'openai',
+        channelId: 'c1',
+        userId: 'u1',
+        messageType: 'incoming',
+        contentLength: 10,
+        processingTime: 100,
+        status: 'success',
+      },
+      {
+        id: '2',
+        timestamp: new Date().toISOString(),
+        botName: 'Bot A',
+        provider: 'discord',
+        llmProvider: 'openai',
+        channelId: 'c1',
+        userId: 'u2',
+        messageType: 'outgoing',
+        contentLength: 20,
+        processingTime: 300,
+        status: 'error',
+      },
+      {
+        id: '3',
+        timestamp: new Date().toISOString(),
+        botName: 'Bot B',
+        provider: 'slack',
+        llmProvider: 'anthropic',
+        channelId: 'c2',
+        userId: 'u3',
+        messageType: 'incoming',
+        contentLength: 5,
+        processingTime: 500,
+        status: 'success',
+      },
+    ]);
+
+    const res = await request(app).get('/api/activity/summary').expect(200);
+
+    expect(res.body.success).toBe(true);
+    const { summary } = res.body.data;
+
+    // DB-backed totals are passed through unchanged.
+    expect(summary.totalMessages).toBe(10);
+    expect(summary.totalAgents).toBe(3);
+    expect(summary.messagesByProvider).toEqual({ discord: 7, slack: 3 });
+
+    // Average of 100, 300, 500 = 300.
+    expect(summary.averageResponseTime).toBe(300);
+    // 1 error out of 3 events.
+    expect(summary.errorRate).toBeCloseTo(1 / 3);
+    // Per-agent counts.
+    expect(summary.messagesByAgent).toEqual({ 'Bot A': 2, 'Bot B': 1 });
+    // Per-LLM-provider counts.
+    expect(summary.llmUsageByProvider).toEqual({ openai: 2, anthropic: 1 });
+  });
+
+  it('returns zeroed derived metrics when there are no recorded events', async () => {
+    mockGetEvents.mockResolvedValue([]);
+
+    const res = await request(app).get('/api/activity/summary').expect(200);
+
+    const { summary } = res.body.data;
+    expect(summary.averageResponseTime).toBe(0);
+    expect(summary.errorRate).toBe(0);
+    expect(summary.messagesByAgent).toEqual({});
+    expect(summary.llmUsageByProvider).toEqual({});
+  });
+
+  it('passes the requested time range to the activity logger', async () => {
+    mockGetEvents.mockResolvedValue([]);
+    const startDate = '2026-01-01T00:00:00.000Z';
+    const endDate = '2026-01-02T00:00:00.000Z';
+
+    const res = await request(app)
+      .get('/api/activity/summary')
+      .query({ startDate, endDate })
+      .expect(200);
+
+    expect(res.body.data.summary.timeRangeStart).toBe(startDate);
+    expect(res.body.data.summary.timeRangeEnd).toBe(endDate);
+
+    expect(mockGetEvents).toHaveBeenCalledTimes(1);
+    const passedFilter = mockGetEvents.mock.calls[0][0];
+    expect(passedFilter.startTime.toISOString()).toBe(startDate);
+    expect(passedFilter.endTime.toISOString()).toBe(endDate);
+  });
+});


### PR DESCRIPTION
@
## What
Completes `GET /api/activity/summary` so it returns real metrics instead of placeholders.

Previously the handler:
- hardcoded `averageResponseTime: 250` and `errorRate: 0.02`
- returned empty `messagesByAgent: {}` and `llmUsageByProvider: {}`

Now all four are computed from the recorded activity events via `ActivityLogger.getInstance().getEvents(...)` for the requested time range. The DB-backed totals (`totalMessages`, `totalAgents`, `messagesByProvider`) from `DatabaseManager.getStats()` are unchanged.

## Why
The summary endpoint shipped partially implemented: the response-time/error-rate figures were fixed constants and the per-agent / per-LLM-provider breakdowns were always empty, so the dashboard could not show real activity.

## Behavior
- `averageResponseTime` = rounded mean of `processingTime` across events that report it (0 when none).
- `errorRate` = fraction of events with status `error` or `timeout` (0 when no events).
- `messagesByAgent` = event count keyed by `botName`.
- `llmUsageByProvider` = event count keyed by `llmProvider`.
- Time range honors `startDate`/`endDate` query params (defaults: last 24h to now), and that same range is passed to the activity logger.

## Verification
- `npx tsc --noEmit` — clean.
- `npx jest tests/unit/server/routes/activitySummary.test.ts` — 3/3 pass (derived metrics, empty-events zeroing, time-range pass-through).

Note: repo-wide `eslint` currently fails to start due to a corrupted `ajv` dependency in the shared pnpm store (`TypeError: Cannot set properties of undefined (setting defaultMeta)`); this reproduces identically on `main` and is unrelated to this change.
@