### PR TITLE
fix(config): make CSV import/export robust and round-trippable

### DIFF
--- a/src/server/services/configImportExport/formatConverters.ts
+++ b/src/server/services/configImportExport/formatConverters.ts
@@ -57,41 +57,79 @@ export function convertToYAML(data: any): string {
 }
 
 /**
- * Convert data to CSV (simplified implementation)
- // eslint-disable-next-line @typescript-eslint/no-explicit-any
- // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+ * Encode a single value into a CSV cell string.
+ *
+ * Scalars (string/number/boolean) are stored verbatim; `null`/`undefined`
+ * become empty cells. Nested objects and arrays are JSON-encoded so they can
+ * be losslessly reconstructed on import (the naive converter previously
+ * rendered them as the literal "[object Object]").
  */
+function encodeCsvValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
 
+/**
+ * Quote a CSV field per RFC 4180. A field is wrapped in double quotes when it
+ * contains a comma, double quote, CR or LF, and embedded double quotes are
+ * doubled.
+ */
+function escapeCsvField(field: string): string {
+  if (/[",\r\n]/.test(field)) {
+    return `"${field.replace(/"/g, '""')}"`;
+  }
+  return field;
+}
+
+/**
+ * Convert configuration export data to RFC 4180-compliant CSV.
+ *
+ * - Headers are the union of every configuration's keys (not just the first),
+ *   so heterogeneous rows are not silently truncated.
+ * - Nested objects/arrays are JSON-encoded inside their cell and round-trip
+ *   back to structured values via {@link parseCSV}.
+ * - All fields are quoted/escaped so embedded commas, quotes and newlines
+ *   survive a round trip.
+ */
 export function convertToCSV(data: any): string {
-  // This is a simplified CSV converter for configurations
-  // In production, use a proper CSV library
-  if (!data.configurations || !Array.isArray(data.configurations)) {
+  if (!data || !data.configurations || !Array.isArray(data.configurations)) {
     throw new Error('Cannot convert non-configuration data to CSV');
   }
 
-  const configs = data.configurations;
+  const configs: Record<string, unknown>[] = data.configurations;
   if (configs.length === 0) {
     return '';
   }
 
-  // Get headers from first configuration
-  const headers = Object.keys(configs[0]);
-  let csv = headers.join(',') + '\n';
-
-  // Add data rows
+  // Build a stable header set from the union of all configuration keys so that
+  // rows with extra/missing fields are still represented correctly.
+  const headers: string[] = [];
+  const seen = new Set<string>();
   for (const config of configs) {
-    const row = headers.map((header) => {
-      const value = config[header];
-      // Escape quotes and wrap in quotes if contains comma or quote
-      if (typeof value === 'string' && (value.includes(',') || value.includes('"'))) {
-        return `"${value.replace(/"/g, '""')}"`;
+    for (const key of Object.keys(config ?? {})) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        headers.push(key);
       }
-      return value;
-    });
-    csv += row.join(',') + '\n';
+    }
   }
 
-  return csv;
+  const rows = [headers.map(escapeCsvField).join(',')];
+  for (const config of configs) {
+    const row = headers.map((header) =>
+      escapeCsvField(encodeCsvValue((config ?? {})[header]))
+    );
+    rows.push(row.join(','));
+  }
+
+  // RFC 4180 uses CRLF; many tools accept LF too. We emit LF for consistency
+  // with the rest of the codebase and a trailing newline for POSIX-friendliness.
+  return rows.join('\n') + '\n';
 }
 
 /**
@@ -106,36 +144,135 @@ export function parseYAML(_yamlString: string): any {
 }
 
 /**
- * Parse CSV (simplified implementation)
+ * Tokenize an RFC 4180 CSV document into a matrix of string cells.
+ *
+ * Correctly handles quoted fields containing commas, escaped double quotes
+ * (`""`) and embedded CR/LF newlines, none of which the previous naive
+ * `split(',')`/`split('\n')` implementation could survive.
  */
+function tokenizeCsv(input: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = '';
+  let inQuotes = false;
+  let i = 0;
 
+  const pushField = (): void => {
+    row.push(field);
+    field = '';
+  };
+  const pushRow = (): void => {
+    pushField();
+    rows.push(row);
+    row = [];
+  };
+
+  while (i < input.length) {
+    const char = input[i];
+
+    if (inQuotes) {
+      if (char === '"') {
+        if (input[i + 1] === '"') {
+          field += '"';
+          i += 2;
+          continue;
+        }
+        inQuotes = false;
+        i += 1;
+        continue;
+      }
+      field += char;
+      i += 1;
+      continue;
+    }
+
+    if (char === '"') {
+      inQuotes = true;
+      i += 1;
+      continue;
+    }
+    if (char === ',') {
+      pushField();
+      i += 1;
+      continue;
+    }
+    if (char === '\r') {
+      // Treat CRLF (and lone CR) as a single record separator.
+      pushRow();
+      if (input[i + 1] === '\n') {
+        i += 2;
+      } else {
+        i += 1;
+      }
+      continue;
+    }
+    if (char === '\n') {
+      pushRow();
+      i += 1;
+      continue;
+    }
+    field += char;
+    i += 1;
+  }
+
+  // Flush the final field/row unless the input ended exactly on a separator
+  // (i.e. a trailing newline produced an empty trailing record we should drop).
+  if (field !== '' || row.length > 0) {
+    pushRow();
+  }
+
+  return rows;
+}
+
+/**
+ * Decode a CSV cell back into a JS value, reversing {@link encodeCsvValue}.
+ *
+ * Empty cells become empty strings (preserving the import contract that fields
+ * are present), and cells that hold a JSON object/array are parsed back into
+ * the structured value they were exported from. Plain scalars are returned as
+ * strings, since CSV is untyped.
+ */
+function decodeCsvValue(cell: string): unknown {
+  if (cell === '') {
+    return '';
+  }
+  const first = cell[0];
+  // Only attempt JSON parsing for object/array payloads to avoid coercing
+  // ordinary numeric/boolean-looking strings (e.g. provider names) unexpectedly.
+  if (first === '{' || first === '[') {
+    try {
+      return JSON.parse(cell);
+    } catch {
+      return cell;
+    }
+  }
+  return cell;
+}
+
+/**
+ * Parse RFC 4180-compliant CSV produced by {@link convertToCSV} back into
+ * configuration export data. Round-trips quoting/escaping and nested
+ * objects/arrays.
+ */
 export function parseCSV(csvString: string): any {
-  // This is a simplified CSV parser
-  // In production, use a proper CSV library
-  const lines = csvString.trim().split('\n');
-  if (lines.length < 2) {
+  const matrix = tokenizeCsv(csvString).filter(
+    // Drop blank lines that tokenize to a single empty cell.
+    (cols) => !(cols.length === 1 && cols[0] === '')
+  );
+
+  if (matrix.length < 1) {
     throw new Error('Invalid CSV format');
   }
 
-  const headers = lines[0].split(',');
-  const configurations = [];
+  const headers = matrix[0].map((h) => h.trim());
+  const configurations: Record<string, unknown>[] = [];
 
-  for (let i = 1; i < lines.length; i++) {
-    const values = lines[i].split(',');
-    const config: Record<string, string> = {};
-
-    for (let j = 0; j < headers.length; j++) {
-      const header = headers[j].trim();
-      let value = values[j] || '';
-
-      // Remove quotes if present
-      if (value.startsWith('"') && value.endsWith('"')) {
-        value = value.substring(1, value.length - 1).replace(/""/g, '"');
-      }
-
-      config[header] = value;
+  for (let r = 1; r < matrix.length; r++) {
+    const values = matrix[r];
+    const config: Record<string, unknown> = {};
+    for (let c = 0; c < headers.length; c++) {
+      config[headers[c]] = decodeCsvValue(values[c] ?? '');
     }
-
     configurations.push(config);
   }
 

--- a/tests/config/formatConvertersCsv.test.ts
+++ b/tests/config/formatConvertersCsv.test.ts
@@ -1,0 +1,165 @@
+import {
+  convertToCSV,
+  parseCSV,
+} from '@src/server/services/configImportExport/formatConverters';
+
+describe('formatConverters CSV (robust quoting/escaping + nested round-trip)', () => {
+  describe('convertToCSV', () => {
+    it('throws on non-configuration data', () => {
+      expect(() => convertToCSV({})).toThrow('Cannot convert non-configuration data to CSV');
+      expect(() => convertToCSV({ configurations: 'nope' })).toThrow(
+        'Cannot convert non-configuration data to CSV'
+      );
+    });
+
+    it('returns empty string for an empty configurations array', () => {
+      expect(convertToCSV({ configurations: [] })).toBe('');
+    });
+
+    it('quotes fields containing commas, quotes and newlines', () => {
+      const csv = convertToCSV({
+        configurations: [
+          {
+            name: 'with,comma',
+            systemInstruction: 'has "quotes" inside',
+            persona: 'line1\nline2',
+          },
+        ],
+      });
+      const lines = csv.trimEnd().split('\n');
+      expect(lines[0]).toBe('name,systemInstruction,persona');
+      // commas/quotes/newlines force quoting; embedded quotes are doubled.
+      expect(csv).toContain('"with,comma"');
+      expect(csv).toContain('"has ""quotes"" inside"');
+      expect(csv).toContain('"line1\nline2"');
+    });
+
+    it('JSON-encodes nested objects/arrays instead of [object Object]', () => {
+      const csv = convertToCSV({
+        configurations: [
+          {
+            name: 'bot',
+            discord: { token: 'abc', channels: ['a', 'b'] },
+            mcpServers: [{ name: 'srv', serverUrl: 'http://x' }],
+          },
+        ],
+      });
+      expect(csv).not.toContain('[object Object]');
+      // The JSON payload contains commas/quotes so the whole cell is quoted.
+      expect(csv).toContain('"{""token"":""abc""');
+    });
+
+    it('uses the union of keys across heterogeneous rows', () => {
+      const csv = convertToCSV({
+        configurations: [
+          { name: 'a', llmProvider: 'openai' },
+          { name: 'b', messageProvider: 'discord' },
+        ],
+      });
+      const header = csv.split('\n')[0];
+      expect(header.split(',').sort()).toEqual(
+        ['llmProvider', 'messageProvider', 'name'].sort()
+      );
+    });
+
+    it('renders null/undefined as empty cells', () => {
+      const csv = convertToCSV({
+        configurations: [{ name: 'a', persona: null, systemInstruction: undefined }],
+      });
+      const dataRow = csv.trimEnd().split('\n')[1];
+      expect(dataRow).toBe('a,,');
+    });
+  });
+
+  describe('parseCSV', () => {
+    it('throws on empty input', () => {
+      expect(() => parseCSV('')).toThrow('Invalid CSV format');
+    });
+
+    it('parses a header-only CSV into an empty configurations array', () => {
+      expect(parseCSV('name,llmProvider\n')).toEqual({ configurations: [] });
+    });
+
+    it('parses quoted fields with embedded commas/quotes/newlines', () => {
+      const csv =
+        'name,systemInstruction,persona\n' +
+        '"with,comma","has ""quotes"" inside","line1\nline2"\n';
+      const result = parseCSV(csv);
+      expect(result.configurations).toEqual([
+        {
+          name: 'with,comma',
+          systemInstruction: 'has "quotes" inside',
+          persona: 'line1\nline2',
+        },
+      ]);
+    });
+
+    it('decodes JSON object/array cells back into structured values', () => {
+      const csv =
+        'name,discord\n' + 'bot,"{""token"":""abc"",""channels"":[""a"",""b""]}"\n';
+      const result = parseCSV(csv);
+      expect(result.configurations[0].discord).toEqual({
+        token: 'abc',
+        channels: ['a', 'b'],
+      });
+    });
+
+    it('leaves malformed JSON-looking cells as raw strings', () => {
+      const csv = 'name,blob\n' + 'bot,"{not valid json"\n';
+      const result = parseCSV(csv);
+      expect(result.configurations[0].blob).toBe('{not valid json');
+    });
+
+    it('handles CRLF line endings', () => {
+      const csv = 'name,llmProvider\r\nbot,openai\r\n';
+      const result = parseCSV(csv);
+      expect(result.configurations).toEqual([{ name: 'bot', llmProvider: 'openai' }]);
+    });
+  });
+
+  describe('round-trip', () => {
+    it('survives a convert -> parse round trip for realistic config data', () => {
+      const data = {
+        configurations: [
+          {
+            id: 1,
+            name: 'Support, Bot',
+            messageProvider: 'discord',
+            llmProvider: 'openai',
+            systemInstruction: 'Be helpful.\nUse "quotes" carefully.',
+            discord: { token: 'tok,en', channels: ['general', 'help'] },
+            mcpServers: [{ name: 'srv', serverUrl: 'http://x:1/api' }],
+            persona: '',
+            isActive: true,
+          },
+          {
+            id: 2,
+            name: 'Plain',
+            messageProvider: 'slack',
+            llmProvider: 'flowise',
+            systemInstruction: 'Short.',
+            discord: { token: 'b', channels: [] },
+            mcpServers: [],
+            persona: 'cheerful',
+            isActive: false,
+          },
+        ],
+      };
+
+      const csv = convertToCSV(data);
+      const parsed = parseCSV(csv);
+
+      // Objects/arrays round-trip structurally; scalars round-trip as strings
+      // because CSV is untyped (numbers/booleans come back as strings).
+      const expected = data.configurations.map((cfg) => {
+        const out: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(cfg)) {
+          out[k] = typeof v === 'object' && v !== null ? v : String(v);
+        }
+        return out;
+      });
+
+      expect(parsed.configurations).toEqual(expected);
+    });
+  });
+});


### PR DESCRIPTION
## What
Replace the naive CSV converter (`convertToCSV`/`parseCSV` in `src/server/services/configImportExport/formatConverters.ts`) with an RFC 4180-compliant, round-trippable implementation, and add tests.

## Why
The previous implementation used `split(',')` / `split('\n')`, which:
- broke on quoted fields containing commas, double quotes, or embedded newlines;
- only emitted the keys of the *first* configuration, silently dropping fields from heterogeneous rows;
- serialized nested objects/arrays (`discord`, `slack`, `mcpServers`, …) as the literal string `[object Object]`, so CSV export was lossy and import could not reconstruct nested provider config.

These converters are consumed by `ConfigurationImportExportService`, `ConfigImporter`, and `ConfigSerializer` for the CSV export/import path.

## Behavior
- **Export**: every field is quoted/escaped per RFC 4180 (commas, quotes, CR/LF). Headers are the union of all configuration keys. Nested objects/arrays are JSON-encoded per cell; `null`/`undefined` become empty cells.
- **Import**: a proper tokenizer handles quoted fields with embedded commas, doubled quotes (`""`) and CR/LF newlines. Object/array cells (`{…}`/`[…]`) are JSON-parsed back into structured values; malformed JSON falls back to the raw string; plain scalars stay strings (CSV is untyped). Header-only CSV now parses to an empty `configurations` array.
- Export → import now round-trips structured configuration losslessly (objects/arrays preserved; scalars come back as strings).

## Verification
- `npx tsc --noEmit`: clean.
- `npx jest tests/config/formatConvertersCsv.test.ts`: 13/13 pass (quoting/escaping, nested round-trip, union-of-keys headers, CRLF, malformed-JSON fallback, realistic config round-trip).
- ESLint could not run in this environment due to a pre-existing ajv/@eslint/eslintrc breakage in node_modules that fails identically on unrelated existing files (not introduced by this change).
- Backend-only change; no frontend, pipeline, auth, startup, or DB-path impact.