### PR TITLE
feat(bot-config): make /templates data-driven from a template store

### DIFF
--- a/src/config/botConfigTemplates.ts
+++ b/src/config/botConfigTemplates.ts
@@ -1,0 +1,132 @@
+import { loadProfiles, saveProfiles } from './profileUtils';
+
+/**
+ * A quick-start bot-configuration template surfaced by
+ * `GET /webui/api/bot-config/templates`. Each template pairs a message
+ * provider with an LLM provider and ships a skeleton config with empty
+ * credentials for the user to fill in.
+ */
+export interface BotConfigTemplate {
+  name: string;
+  description: string;
+  messageProvider: string;
+  llmProvider: string;
+
+  config: Record<string, unknown>;
+}
+
+/**
+ * Map of template id -> template. Kept as a keyed object (not an array) to
+ * preserve the existing `/templates` endpoint response shape.
+ */
+export type BotConfigTemplateMap = Record<string, BotConfigTemplate>;
+
+export const BOT_CONFIG_TEMPLATES_FILE = 'bot-config-templates.json';
+
+/**
+ * Shippable default templates. These are written to
+ * `config/bot-config-templates.json` on first load; afterwards the file is the
+ * source of truth, so new templates can be added without code changes.
+ */
+const DEFAULT_BOT_CONFIG_TEMPLATES: BotConfigTemplateMap = {
+  discord_openai: {
+    name: 'Discord + OpenAI Bot',
+    description: 'A Discord bot using OpenAI for responses',
+    messageProvider: 'discord',
+    llmProvider: 'openai',
+    config: {
+      discord: {
+        token: '',
+        voiceChannelId: '',
+      },
+      openai: {
+        apiKey: '',
+        model: 'gpt-3.5-turbo',
+      },
+    },
+  },
+  slack_flowise: {
+    name: 'Slack + Flowise Bot',
+    description: 'A Slack bot using Flowise for AI responses',
+    messageProvider: 'slack',
+    llmProvider: 'flowise',
+    config: {
+      slack: {
+        botToken: '',
+        signingSecret: '',
+        appToken: '',
+      },
+      flowise: {
+        apiKey: '',
+        endpoint: '',
+      },
+    },
+  },
+  mattermost_openwebui: {
+    name: 'Mattermost + OpenWebUI Bot',
+    description: 'A Mattermost bot using OpenWebUI for responses',
+    messageProvider: 'mattermost',
+    llmProvider: 'openwebui',
+    config: {
+      mattermost: {
+        serverUrl: '',
+        token: '',
+      },
+      openwebui: {
+        apiKey: '',
+        endpoint: '',
+      },
+    },
+  },
+};
+
+const isTemplate = (value: unknown): value is BotConfigTemplate => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const t = value as Record<string, unknown>;
+  return (
+    typeof t.name === 'string' &&
+    typeof t.description === 'string' &&
+    typeof t.messageProvider === 'string' &&
+    typeof t.llmProvider === 'string' &&
+    typeof t.config === 'object' &&
+    t.config !== null
+  );
+};
+
+/**
+ * Load bot-configuration templates. Defaults are scaffolded into
+ * `config/bot-config-templates.json` on first run; subsequent edits to that
+ * file are picked up without code changes. Invalid files fall back to the
+ * shipped defaults.
+ */
+export const loadBotConfigTemplates = (): BotConfigTemplateMap => {
+  return loadProfiles<BotConfigTemplateMap>({
+    filename: BOT_CONFIG_TEMPLATES_FILE,
+    defaultData: DEFAULT_BOT_CONFIG_TEMPLATES,
+    profileType: 'bot-config-template',
+    validateAndMigrate: (parsed) => {
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        throw new Error('bot-config templates must be a keyed object');
+      }
+      const entries = Object.entries(parsed as Record<string, unknown>);
+      const valid: BotConfigTemplateMap = {};
+      for (const [id, template] of entries) {
+        if (!isTemplate(template)) {
+          throw new Error(`Invalid bot-config template for id "${id}"`);
+        }
+        valid[id] = template;
+      }
+      return valid;
+    },
+  });
+};
+
+export const saveBotConfigTemplates = (templates: BotConfigTemplateMap): void => {
+  saveProfiles(BOT_CONFIG_TEMPLATES_FILE, templates);
+};
+
+export const getDefaultBotConfigTemplates = (): BotConfigTemplateMap => ({
+  ...DEFAULT_BOT_CONFIG_TEMPLATES,
+});

--- a/src/server/routes/botConfig.ts
+++ b/src/server/routes/botConfig.ts
@@ -3,6 +3,7 @@ import Debug from 'debug';
 import { Router } from 'express';
 import { authenticate, requireAdmin, requireRole } from '../../auth/middleware';
 import { type AuthMiddlewareRequest } from '../../auth/types';
+import { loadBotConfigTemplates } from '../../config/botConfigTemplates';
 import { BotConfigurationManager } from '../../config/BotConfigurationManager';
 import { SecureConfigManager } from '../../config/SecureConfigManager';
 import { UserConfigStore } from '../../config/UserConfigStore';
@@ -99,57 +100,7 @@ router.get(
     try {
       // eslint-disable-next-line unused-imports/no-unused-vars
       const authReq = req as AuthMiddlewareRequest;
-      const templates = {
-        discord_openai: {
-          name: 'Discord + OpenAI Bot',
-          description: 'A Discord bot using OpenAI for responses',
-          messageProvider: 'discord',
-          llmProvider: 'openai',
-          config: {
-            discord: {
-              token: '',
-              voiceChannelId: '',
-            },
-            openai: {
-              apiKey: '',
-              model: 'gpt-3.5-turbo',
-            },
-          },
-        },
-        slack_flowise: {
-          name: 'Slack + Flowise Bot',
-          description: 'A Slack bot using Flowise for AI responses',
-          messageProvider: 'slack',
-          llmProvider: 'flowise',
-          config: {
-            slack: {
-              botToken: '',
-              signingSecret: '',
-              appToken: '',
-            },
-            flowise: {
-              apiKey: '',
-              endpoint: '',
-            },
-          },
-        },
-        mattermost_openwebui: {
-          name: 'Mattermost + OpenWebUI Bot',
-          description: 'A Mattermost bot using OpenWebUI for responses',
-          messageProvider: 'mattermost',
-          llmProvider: 'openwebui',
-          config: {
-            mattermost: {
-              serverUrl: '',
-              token: '',
-            },
-            openwebui: {
-              apiKey: '',
-              endpoint: '',
-            },
-          },
-        },
-      };
+      const templates = loadBotConfigTemplates();
 
       res.json(ApiResponse.success(templates));
     } catch (error: unknown) {

--- a/tests/unit/config/botConfigTemplates.test.ts
+++ b/tests/unit/config/botConfigTemplates.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for the data-driven bot-config template store.
+ *
+ * Regression coverage for bot-config-templates-store: the
+ * `GET /webui/api/bot-config/templates` endpoint previously returned three
+ * hardcoded inline templates. They are now loaded from
+ * `config/bot-config-templates.json`, scaffolded from shippable defaults, so
+ * templates can be added without code changes.
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  BOT_CONFIG_TEMPLATES_FILE,
+  getDefaultBotConfigTemplates,
+  loadBotConfigTemplates,
+} from '@src/config/botConfigTemplates';
+
+describe('botConfigTemplates store', () => {
+  let tmpDir: string;
+  let originalConfigDir: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bot-tpl-'));
+    originalConfigDir = process.env.NODE_CONFIG_DIR;
+    process.env.NODE_CONFIG_DIR = tmpDir;
+  });
+
+  afterEach(() => {
+    if (originalConfigDir === undefined) {
+      delete process.env.NODE_CONFIG_DIR;
+    } else {
+      process.env.NODE_CONFIG_DIR = originalConfigDir;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const templatesPath = () => path.join(tmpDir, BOT_CONFIG_TEMPLATES_FILE);
+
+  it('returns the shippable defaults when no file exists', () => {
+    const templates = loadBotConfigTemplates();
+    expect(templates).toEqual(getDefaultBotConfigTemplates());
+    // The three original built-in pairings remain available by default.
+    expect(Object.keys(templates)).toEqual(
+      expect.arrayContaining(['discord_openai', 'slack_flowise', 'mattermost_openwebui'])
+    );
+    expect(templates.discord_openai.config).toEqual({
+      discord: { token: '', voiceChannelId: '' },
+      openai: { apiKey: '', model: 'gpt-3.5-turbo' },
+    });
+  });
+
+  it('scaffolds the defaults to a JSON file on first load', () => {
+    expect(fs.existsSync(templatesPath())).toBe(false);
+    loadBotConfigTemplates();
+    expect(fs.existsSync(templatesPath())).toBe(true);
+
+    const written = JSON.parse(fs.readFileSync(templatesPath(), 'utf8'));
+    expect(written).toEqual(getDefaultBotConfigTemplates());
+  });
+
+  it('loads templates added to the file without code changes', () => {
+    const custom = {
+      ...getDefaultBotConfigTemplates(),
+      telegram_anthropic: {
+        name: 'Telegram + Anthropic Bot',
+        description: 'A Telegram bot using Anthropic for responses',
+        messageProvider: 'telegram',
+        llmProvider: 'anthropic',
+        config: {
+          telegram: { token: '' },
+          anthropic: { apiKey: '', model: 'claude-3' },
+        },
+      },
+    };
+    fs.writeFileSync(templatesPath(), JSON.stringify(custom, null, 2), 'utf8');
+
+    const templates = loadBotConfigTemplates();
+    expect(templates.telegram_anthropic).toBeDefined();
+    expect(templates.telegram_anthropic.messageProvider).toBe('telegram');
+    expect(Object.keys(templates)).toContain('telegram_anthropic');
+  });
+
+  it('falls back to defaults when the file is malformed', () => {
+    fs.writeFileSync(templatesPath(), '{ not valid json', 'utf8');
+    const templates = loadBotConfigTemplates();
+    expect(templates).toEqual(getDefaultBotConfigTemplates());
+  });
+
+  it('falls back to defaults when a template entry is invalid', () => {
+    fs.writeFileSync(
+      templatesPath(),
+      JSON.stringify({ broken: { name: 'no config' } }),
+      'utf8'
+    );
+    const templates = loadBotConfigTemplates();
+    expect(templates).toEqual(getDefaultBotConfigTemplates());
+  });
+});


### PR DESCRIPTION
## What
Replaces the three hardcoded inline templates returned by `GET /webui/api/bot-config/templates` (`src/server/routes/botConfig.ts`) with a data-driven template store: `src/config/botConfigTemplates.ts`.

## Why
The endpoint previously embedded the template list inline in the route handler, so adding or editing a quick-start template required a code change. The gap (partial feature `bot-config-templates-store`) asked for data-driven templates that ship sensible defaults but can be extended without code changes.

## Behavior
- Built on the existing `profileUtils` loader (`loadProfiles`/`saveProfiles`), same pattern as `guardrailProfiles.ts`.
- Shippable defaults (the original three provider pairings) live in code and are scaffolded to `config/bot-config-templates.json` on first load.
- After scaffolding, that JSON file is the source of truth, so templates can be added/edited without code changes.
- Malformed JSON or invalid entries fall back to the shipped defaults.
- The HTTP response shape is unchanged (same keyed object: `discord_openai`, `slack_flowise`, `mattermost_openwebui`), so no client changes are needed.

## Verification
- `npx tsc --noEmit` — clean (0 errors)
- `eslint` on changed files — 0 errors
- `jest tests/unit/config/botConfigTemplates.test.ts` — 5/5 pass (defaults, scaffolding, file-driven additions, malformed fallback, invalid-entry fallback)
- No frontend changes; startup, pipeline, auth, and DB paths untouched.