### PR TITLE
feat(bots): complete scheduled-task CRUD (list + delete routes)

### DIFF
--- a/src/server/routes/bots.ts
+++ b/src/server/routes/bots.ts
@@ -12,6 +12,7 @@ import {
   BotIdParamSchema,
   BotImportSchema,
   BotTaskCreateSchema,
+  BotTaskDeleteSchema,
   BotTestChatSchema,
   BotVersionParamSchema,
   CloneBotSchema,
@@ -734,6 +735,66 @@ router.post(
       intervalMinutes
     );
     return res.json(ApiResponse.success(task));
+  })
+);
+
+/**
+ * @openapi
+ * /api/bots/{id}/tasks:
+ *   get:
+ *     summary: List scheduled tasks for a bot
+ *     tags: [Bots]
+ */
+router.get(
+  '/:id/tasks',
+  validateRequest(BotIdParamSchema),
+  asyncErrorHandler(async (req: Request, res: Response) => {
+    const { id } = req.params;
+
+    const manager = await managerPromise;
+    const bot = await manager.getBot(id);
+    if (!bot) {
+      return res
+        .status(HTTP_STATUS.NOT_FOUND)
+        .json(ApiResponse.error('Bot not found', ERROR_CODES.NOT_FOUND));
+    }
+
+    const tasks = BotTaskScheduler.getInstance().getTasksForBot(bot.id);
+    return res.json(ApiResponse.success(tasks));
+  })
+);
+
+/**
+ * @openapi
+ * /api/bots/{id}/tasks/{taskId}:
+ *   delete:
+ *     summary: Delete a scheduled task for a bot
+ *     tags: [Bots]
+ */
+router.delete(
+  '/:id/tasks/:taskId',
+  validateRequest(BotTaskDeleteSchema),
+  asyncErrorHandler(async (req: Request, res: Response) => {
+    const { id, taskId } = req.params;
+
+    const manager = await managerPromise;
+    const bot = await manager.getBot(id);
+    if (!bot) {
+      return res
+        .status(HTTP_STATUS.NOT_FOUND)
+        .json(ApiResponse.error('Bot not found', ERROR_CODES.NOT_FOUND));
+    }
+
+    const scheduler = BotTaskScheduler.getInstance();
+    const task = scheduler.getTasksForBot(bot.id).find((t) => t.id === taskId);
+    if (!task) {
+      return res
+        .status(HTTP_STATUS.NOT_FOUND)
+        .json(ApiResponse.error('Task not found', ERROR_CODES.NOT_FOUND));
+    }
+
+    scheduler.deleteTask(taskId);
+    return res.json(ApiResponse.success({ id: taskId, deleted: true }));
   })
 );
 

--- a/src/validation/schemas/botsSchema.ts
+++ b/src/validation/schemas/botsSchema.ts
@@ -113,6 +113,13 @@ export const BotTaskCreateSchema = z.object({
   }),
 });
 
+export const BotTaskDeleteSchema = z.object({
+  params: z.object({
+    id: z.string().min(1),
+    taskId: z.string().min(1, { message: 'Task ID is required' }),
+  }),
+});
+
 export const BotMessageSchema = z.object({
   params: z.object({
     id: z.string().min(1),

--- a/tests/unit/server/routes/botsTasks.test.ts
+++ b/tests/unit/server/routes/botsTasks.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for the bot scheduled-task CRUD routes:
+ *   GET    /api/bots/:id/tasks          - list tasks for a bot
+ *   DELETE /api/bots/:id/tasks/:taskId  - delete a scheduled task
+ *
+ * The router already exposed POST /:id/tasks (scheduleTask) but had no
+ * list/get/delete endpoints, leaving task management incomplete. These tests
+ * cover the new GET (list) and DELETE routes, which reuse the existing
+ * BotTaskScheduler.getTasksForBot / deleteTask methods.
+ */
+
+import express from 'express';
+import request from 'supertest';
+
+// --- Mock BotManager so the route uses a controllable in-memory manager ---
+const getBot = jest.fn();
+
+const mockManager = {
+  getBot,
+};
+
+jest.mock('@src/managers/BotManager', () => ({
+  BotManager: {
+    getInstance: jest.fn(async () => mockManager),
+  },
+}));
+
+// --- Mock BotTaskScheduler singleton ---
+const getTasksForBot = jest.fn();
+const deleteTask = jest.fn();
+
+jest.mock('@src/server/services/BotTaskScheduler', () => ({
+  BotTaskScheduler: {
+    getInstance: jest.fn(() => ({
+      getTasksForBot,
+      deleteTask,
+    })),
+  },
+}));
+
+// Avoid pulling heavy singletons during router import.
+jest.mock('@src/server/services/WebSocketService', () => ({
+  WebSocketService: {
+    getInstance: jest.fn(() => {
+      throw new Error('DI not ready');
+    }),
+  },
+}));
+
+// Import the router AFTER the mocks are registered.
+import botsRouter from '@src/server/routes/bots';
+import { globalErrorHandler } from '@src/middleware/errorHandler';
+
+function createApp(): express.Application {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/bots', botsRouter);
+  app.use(globalErrorHandler);
+  return app;
+}
+
+const sampleTask = {
+  id: 'task_1',
+  botId: 'bot-1',
+  botName: 'Bot One',
+  prompt: 'do a thing',
+  intervalMs: 60000,
+  nextRun: Date.now() + 60000,
+  enabled: true,
+};
+
+describe('GET /api/bots/:id/tasks', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    app = createApp();
+  });
+
+  it('returns the scheduled tasks for an existing bot', async () => {
+    getBot.mockResolvedValue({ id: 'bot-1', name: 'Bot One' });
+    getTasksForBot.mockReturnValue([sampleTask]);
+
+    const res = await request(app).get('/api/bots/bot-1/tasks');
+
+    expect(res.status).toBe(200);
+    expect(getTasksForBot).toHaveBeenCalledWith('bot-1');
+    expect(res.body).toMatchObject({
+      success: true,
+      data: [{ id: 'task_1', botId: 'bot-1' }],
+    });
+  });
+
+  it('returns an empty list when the bot has no tasks', async () => {
+    getBot.mockResolvedValue({ id: 'bot-1', name: 'Bot One' });
+    getTasksForBot.mockReturnValue([]);
+
+    const res = await request(app).get('/api/bots/bot-1/tasks');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ success: true, data: [] });
+  });
+
+  it('returns 404 when the bot does not exist', async () => {
+    getBot.mockResolvedValue(null);
+
+    const res = await request(app).get('/api/bots/missing/tasks');
+
+    expect(res.status).toBe(404);
+    expect(getTasksForBot).not.toHaveBeenCalled();
+  });
+});
+
+describe('DELETE /api/bots/:id/tasks/:taskId', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    app = createApp();
+  });
+
+  it('deletes an existing task and returns the deleted id', async () => {
+    getBot.mockResolvedValue({ id: 'bot-1', name: 'Bot One' });
+    getTasksForBot.mockReturnValue([sampleTask]);
+
+    const res = await request(app).delete('/api/bots/bot-1/tasks/task_1');
+
+    expect(res.status).toBe(200);
+    expect(deleteTask).toHaveBeenCalledWith('task_1');
+    expect(res.body).toMatchObject({
+      success: true,
+      data: { id: 'task_1', deleted: true },
+    });
+  });
+
+  it('returns 404 when the bot does not exist', async () => {
+    getBot.mockResolvedValue(null);
+
+    const res = await request(app).delete('/api/bots/missing/tasks/task_1');
+
+    expect(res.status).toBe(404);
+    expect(deleteTask).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the task does not belong to the bot', async () => {
+    getBot.mockResolvedValue({ id: 'bot-1', name: 'Bot One' });
+    getTasksForBot.mockReturnValue([sampleTask]);
+
+    const res = await request(app).delete('/api/bots/bot-1/tasks/unknown-task');
+
+    expect(res.status).toBe(404);
+    expect(deleteTask).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What
Adds the missing read/delete endpoints for bot scheduled tasks:
- `GET /api/bots/:id/tasks` — list scheduled tasks for a bot
- `DELETE /api/bots/:id/tasks/:taskId` — delete a scheduled task

## Why
The router already exposed `POST /api/bots/:id/tasks` (BotTaskScheduler.scheduleTask) but had no way to list or remove tasks, leaving task management incomplete. `BotTaskScheduler` already provided `getTasksForBot(botId)` and `deleteTask(taskId)` — these routes simply surface them.

## Behavior
- GET returns the bot's tasks (empty array when none); 404 when the bot does not exist.
- DELETE removes a task scoped to the bot and returns `{ id, deleted: true }`; 404 when the bot does not exist or the task does not belong to the bot.
- Reuses existing patterns: `validateRequest`, `BotIdParamSchema`, new `BotTaskDeleteSchema`, `ApiResponse`, `asyncErrorHandler`, `managerPromise.getBot`.

## Verification
- `npx tsc --noEmit` clean (backend).
- New test `tests/unit/server/routes/botsTasks.test.ts` — 6 tests pass (list, empty, 404; delete, 404 bot, 404 task).
- Existing `botsToggle.test.ts` still passes (no regression).
- Note: repo-wide eslint currently fails to start due to a pre-existing ajv/@eslint/eslintrc version conflict in node_modules (reproduces on unmodified files); changes follow the surrounding lint conventions.