### PR TITLE
feat(tools): route function-calling through ILlmProvider abstraction

### DIFF
--- a/packages/llm-openai/src/openAiProvider.ts
+++ b/packages/llm-openai/src/openAiProvider.ts
@@ -10,7 +10,13 @@ import {
   TimeoutError,
 } from '@src/types/errorClasses';
 import openaiConfig from '@config/openaiConfig';
-import type { ILlmProvider } from '@llm/interfaces/ILlmProvider';
+import type {
+  ILlmProvider,
+  LlmChatMessage,
+  LlmToolCall,
+  LlmToolCompletionResult,
+  LlmToolDefinition,
+} from '@llm/interfaces/ILlmProvider';
 import type { IMessage } from '@message/interfaces/IMessage';
 import { getCircuitBreaker } from '@common/CircuitBreaker';
 import { withTimeout } from '@common/withTimeout';
@@ -278,6 +284,98 @@ export class OpenAiProvider implements ILlmProvider {
         debug('Streaming LLM returned empty content, failing silently');
       }
       return full;
+    });
+  }
+
+  /**
+   * Tool-aware chat completion using OpenAI native function calling.
+   *
+   * Receives a pre-built messages array (system/user/assistant/tool turns)
+   * and tool definitions, and returns the assistant turn — which may contain
+   * tool calls for the caller to execute. Reuses the same config resolution,
+   * URL safety checks, and circuit breaker as the standard chat path.
+   */
+  async generateChatCompletionWithTools(
+    messages: LlmChatMessage[],
+    tools: LlmToolDefinition[],
+    metadata?: Record<string, any>
+  ): Promise<LlmToolCompletionResult> {
+    debug('Starting tool-aware chat completion generation');
+
+    const apiKey =
+      this.config.apiKey || openaiConfig.get('OPENAI_API_KEY') || process.env.OPENAI_API_KEY;
+    let baseURL =
+      this.config.baseUrl ||
+      openaiConfig.get('OPENAI_BASE_URL') ||
+      process.env.OPENAI_BASE_URL ||
+      DEFAULT_BASE_URL;
+    const timeout = this.config.timeout || openaiConfig.get('OPENAI_TIMEOUT') || 10000;
+    const organization =
+      this.config.organization || openaiConfig.get('OPENAI_ORGANIZATION') || undefined;
+    const model =
+      metadata?.modelOverride ||
+      metadata?.model ||
+      this.config.model ||
+      process.env.OPENAI_MODEL ||
+      openaiConfig.get('OPENAI_MODEL') ||
+      'gpt-4o';
+
+    if (!apiKey) {
+      throw new ConfigurationError('OpenAI API key is missing', 'OPENAI_API_KEY_MISSING');
+    }
+
+    try {
+      new URL(baseURL);
+      if (baseURL !== DEFAULT_BASE_URL && !(await isSafeUrl(baseURL))) {
+        throw new Error('Unsafe URL');
+      }
+    } catch {
+      baseURL = DEFAULT_BASE_URL;
+    }
+
+    const openai = new OpenAI({ apiKey, baseURL, timeout, organization });
+
+    const baseTemperature =
+      this.config.temperature || openaiConfig.get('OPENAI_TEMPERATURE') || 0.7;
+    const temperatureBoost = metadata?.temperatureBoost || 0;
+    const effectiveTemperature = Math.min(1.5, baseTemperature + temperatureBoost);
+
+    const maxTokens =
+      metadata?.maxTokensOverride ||
+      this.config.maxTokens ||
+      openaiConfig.get('OPENAI_MAX_TOKENS') ||
+      150;
+
+    const llmTimeoutMs = typeof timeout === 'number' ? timeout : DEFAULT_LLM_TIMEOUT_MS;
+
+    return circuitBreaker.execute(async () => {
+      const requestBody: Record<string, unknown> = {
+        model,
+        messages,
+        max_tokens: maxTokens,
+        temperature: effectiveTemperature,
+      };
+      if (tools.length > 0) {
+        requestBody.tools = tools;
+        requestBody.tool_choice = 'auto';
+      }
+
+      const response = await withTimeout(
+        (signal) =>
+          openai.chat.completions.create(requestBody as any, { signal }),
+        llmTimeoutMs,
+        'OpenAI tool-aware chat completion'
+      );
+
+      const choice = (response as any).choices?.[0];
+      if (!choice) {
+        return { content: '' };
+      }
+
+      return {
+        content: choice.message?.content ?? null,
+        tool_calls: choice.message?.tool_calls as LlmToolCall[] | undefined,
+      };
     });
   }
 

--- a/src/llm/interfaces/ILlmProvider.ts
+++ b/src/llm/interfaces/ILlmProvider.ts
@@ -1,5 +1,43 @@
 import type { IMessage } from '@src/message/interfaces/IMessage';
 
+/** A single tool call as returned by an LLM during function calling. */
+export interface LlmToolCall {
+  id: string;
+  type: 'function';
+  function: {
+    name: string;
+    arguments: string;
+  };
+}
+
+/**
+ * Minimal chat message shape used for multi-turn tool conversations.
+ * This mirrors the OpenAI chat message structure but stays provider-neutral.
+ */
+export interface LlmChatMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string | null;
+  tool_calls?: LlmToolCall[];
+  tool_call_id?: string;
+  name?: string;
+}
+
+/** Provider-neutral tool definition (OpenAI function-calling shape). */
+export interface LlmToolDefinition {
+  type: 'function';
+  function: {
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+  };
+}
+
+/** The assistant turn returned from a tool-aware completion. */
+export interface LlmToolCompletionResult {
+  content: string | null;
+  tool_calls?: LlmToolCall[];
+}
+
 /**
  * Interface for Large Language Model (LLM) providers.
  *
@@ -113,6 +151,29 @@ export interface ILlmProvider {
 
     metadata?: Record<string, any>
   ) => Promise<string>;
+
+  /**
+   * Generates a tool-aware chat completion using native function calling.
+   *
+   * Providers that support OpenAI-compatible function calling can implement
+   * this to receive a fully-built messages array plus tool definitions and
+   * return the assistant turn (which may contain tool calls). The caller
+   * (toolAugmentedCompletion) drives the multi-turn tool loop.
+   *
+   * Providers that do not implement this method are routed through the
+   * caller's direct fallback path, preserving existing behavior.
+   *
+   * @param {LlmChatMessage[]} messages - The full conversation so far
+   * @param {LlmToolDefinition[]} tools - Tool definitions; empty for a final text turn
+   * @param {Record<string, any>} [metadata] - Optional metadata for additional context
+   * @returns {Promise<LlmToolCompletionResult>} The assistant turn
+   */
+  generateChatCompletionWithTools?: (
+    messages: LlmChatMessage[],
+    tools: LlmToolDefinition[],
+
+    metadata?: Record<string, any>
+  ) => Promise<LlmToolCompletionResult>;
 
   /**
    * Generates a non-chat text completion.

--- a/src/services/toolAugmentedCompletion.ts
+++ b/src/services/toolAugmentedCompletion.ts
@@ -129,19 +129,40 @@ export async function toolAugmentedCompletion(opts: {
 // ---------------------------------------------------------------------------
 
 /**
- * Calls the LLM using the OpenAI SDK (via the provider's existing OpenAI
- * client configuration). Because ILlmProvider doesn't expose tool calling,
- * we dynamically detect if the provider is OpenAI-compatible and reconstruct
- * the call.
+ * Calls the LLM with tool definitions.
+ *
+ * Routes through the provider abstraction (`generateChatCompletionWithTools`)
+ * when the provider implements native function calling, so non-OpenAI
+ * providers can participate. Providers that do not implement it fall through
+ * to the direct OpenAI-SDK path below, preserving the original behavior.
  */
 async function callLLMWithTools(
-  _llmProvider: ILlmProvider,
+  llmProvider: ILlmProvider,
   messages: ChatMessage[],
   tools: OpenAITool[],
 
   metadata: Record<string, any>
 ): Promise<ChatMessage> {
-  // Strategy: Try to use the OpenAI SDK directly. We load it dynamically
+  // Preferred path: route through the provider abstraction when supported.
+  if (typeof llmProvider.generateChatCompletionWithTools === 'function') {
+    try {
+      const result = await llmProvider.generateChatCompletionWithTools(
+        messages,
+        tools,
+        metadata
+      );
+      return {
+        role: 'assistant',
+        content: result.content ?? null,
+        tool_calls: result.tool_calls as LLMToolCall[] | undefined,
+      };
+    } catch (error) {
+      debug('Provider tool-aware completion failed, falling back to direct path:', error);
+      // Fall through to the direct OpenAI path below.
+    }
+  }
+
+  // Fallback path: use the OpenAI SDK directly. We load it dynamically
   // to avoid hard coupling. The provider's config tells us the API key
   // and base URL.
   try {

--- a/tests/services/toolAugmentedCompletion.test.ts
+++ b/tests/services/toolAugmentedCompletion.test.ts
@@ -1,0 +1,150 @@
+import type {
+  ILlmProvider,
+  LlmChatMessage,
+  LlmToolCompletionResult,
+  LlmToolDefinition,
+} from '@src/llm/interfaces/ILlmProvider';
+import type { IMessage } from '@src/message/interfaces/IMessage';
+
+// --- Mock ToolManager so the tool loop is fully controllable -----------------
+
+const mockGetToolsForBot = jest.fn();
+const mockFormatToolsForLLM = jest.fn();
+const mockGetMaxToolCalls = jest.fn();
+const mockExecuteTool = jest.fn();
+
+jest.mock('@src/services/ToolManager', () => ({
+  ToolManager: {
+    getInstance: () => ({
+      getToolsForBot: mockGetToolsForBot,
+      formatToolsForLLM: mockFormatToolsForLLM,
+      getMaxToolCalls: mockGetMaxToolCalls,
+      executeTool: mockExecuteTool,
+    }),
+  },
+}));
+
+// Import after the mock is registered.
+import { toolAugmentedCompletion } from '@src/services/toolAugmentedCompletion';
+
+const sampleTool: LlmToolDefinition = {
+  type: 'function',
+  function: { name: 'get_weather', description: 'Get weather', parameters: { type: 'object' } },
+};
+
+function makeProvider(
+  impl?: jest.Mock<Promise<LlmToolCompletionResult>, [LlmChatMessage[], LlmToolDefinition[], any?]>
+): ILlmProvider {
+  const provider: ILlmProvider = {
+    name: 'mock',
+    supportsChatCompletion: () => true,
+    supportsCompletion: () => true,
+    generateChatCompletion: jest.fn(async () => 'standard-reply'),
+    generateCompletion: jest.fn(async () => 'completion'),
+  };
+  if (impl) {
+    provider.generateChatCompletionWithTools = impl;
+  }
+  return provider;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetMaxToolCalls.mockReturnValue(5);
+  mockFormatToolsForLLM.mockReturnValue([sampleTool]);
+});
+
+describe('toolAugmentedCompletion', () => {
+  it('falls back to plain generateChatCompletion when the bot has no tools', async () => {
+    mockGetToolsForBot.mockResolvedValue([]);
+    const provider = makeProvider();
+
+    const result = await toolAugmentedCompletion({
+      botName: 'bot',
+      llmProvider: provider,
+      userMessage: 'hi',
+      historyMessages: [],
+      metadata: {},
+      systemPrompt: 'sys',
+    });
+
+    expect(result).toBe('standard-reply');
+    expect(provider.generateChatCompletion).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes through the provider abstraction when generateChatCompletionWithTools exists', async () => {
+    mockGetToolsForBot.mockResolvedValue([{ name: 'get_weather' }]);
+
+    // First turn requests a tool call; second turn returns final text.
+    const toolAware = jest
+      .fn<Promise<LlmToolCompletionResult>, [LlmChatMessage[], LlmToolDefinition[], any?]>()
+      .mockResolvedValueOnce({
+        content: null,
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'get_weather', arguments: '{"city":"NYC"}' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ content: 'It is sunny in NYC.' });
+
+    mockExecuteTool.mockResolvedValue({ toolName: 'get_weather', success: true, result: 'sunny' });
+
+    const provider = makeProvider(toolAware);
+
+    const result = await toolAugmentedCompletion({
+      botName: 'bot',
+      llmProvider: provider,
+      userMessage: 'weather in NYC?',
+      historyMessages: [],
+      metadata: { model: 'gpt-4o' },
+      systemPrompt: 'sys',
+      toolContext: { userId: 'u1', channelId: 'c1' },
+    });
+
+    expect(result).toBe('It is sunny in NYC.');
+    // Provider abstraction was used for both turns; direct OpenAI path never touched.
+    expect(toolAware).toHaveBeenCalledTimes(2);
+    expect(mockExecuteTool).toHaveBeenCalledWith(
+      'bot',
+      'get_weather',
+      { city: 'NYC' },
+      { userId: 'u1', channelId: 'c1' }
+    );
+
+    // The tool result must be appended into the messages passed on the 2nd call.
+    const secondCallMessages = toolAware.mock.calls[1][0];
+    const toolMsg = secondCallMessages.find((m) => m.role === 'tool');
+    expect(toolMsg).toMatchObject({
+      role: 'tool',
+      tool_call_id: 'call_1',
+      name: 'get_weather',
+      content: 'sunny',
+    });
+  });
+
+  it('forwards tools to the provider on the first turn and an empty list is fine on final text turn', async () => {
+    mockGetToolsForBot.mockResolvedValue([{ name: 'get_weather' }]);
+
+    const toolAware = jest
+      .fn<Promise<LlmToolCompletionResult>, [LlmChatMessage[], LlmToolDefinition[], any?]>()
+      .mockResolvedValue({ content: 'no tools needed' });
+
+    const provider = makeProvider(toolAware);
+
+    const result = await toolAugmentedCompletion({
+      botName: 'bot',
+      llmProvider: provider,
+      userMessage: 'hello',
+      historyMessages: [],
+      metadata: {},
+      systemPrompt: 'sys',
+    });
+
+    expect(result).toBe('no tools needed');
+    // The tool definitions from formatToolsForLLM were forwarded.
+    expect(toolAware.mock.calls[0][1]).toEqual([sampleTool]);
+  });
+});


### PR DESCRIPTION
@
## What
`toolAugmentedCompletion`'s internal `callLLMWithTools` previously **always** constructed a direct OpenAI client (ignoring its `_llmProvider` argument), so non-OpenAI providers could never do native function-calling. This routes tool-calling through the `ILlmProvider` abstraction when the provider supports it, with the direct OpenAI path kept as a fallback.

## Why
The tool-augmented completion loop was hard-coded to OpenAI. Any provider that implements OpenAI-compatible function calling (or a custom backend) had no way to participate — the abstraction was bypassed entirely.

## Behavior
- Added an optional `generateChatCompletionWithTools(messages, tools, metadata)` method to `ILlmProvider`, plus provider-neutral types (`LlmChatMessage`, `LlmToolCall`, `LlmToolDefinition`, `LlmToolCompletionResult`).
- Implemented it in `OpenAiProvider`, reusing the existing config resolution, URL-safety checks, temperature/token handling, and circuit breaker.
- `callLLMWithTools` now prefers `provider.generateChatCompletionWithTools` when present; if a provider does not implement it (or it throws), it falls through to the original direct OpenAI-SDK path. The working OpenAI behavior is unchanged.

## Verification
- `npx tsc --noEmit` — clean.
- New test `tests/services/toolAugmentedCompletion.test.ts` (3 cases: no-tools fallback, provider-abstraction tool loop with execution + final text, tool-definition forwarding) — passes.
- Existing `packages/llm-openai/src/openAiProvider.test.ts` (7 cases) — still passes.
- Note: repo `eslint` crashes on load in this environment (pre-existing ajv/eslintrc conflict, unrelated to these changes).
@