### PR TITLE
fix(metrics): use real system metrics in MetricsCollector

### DIFF
--- a/src/monitoring/MetricsCollector.ts
+++ b/src/monitoring/MetricsCollector.ts
@@ -1,12 +1,6 @@
-import crypto from 'crypto';
+import os from 'os';
 import { EventEmitter } from 'events';
 import Logger from '@common/logger';
-
-// Helper to generate random float between 0 and max using crypto
-function getRandomFloat(max: number): number {
-  const randomBytes = crypto.randomBytes(4);
-  return (randomBytes.readUInt32BE() / 0x100000000) * max;
-}
 
 const logger = Logger.withContext('MetricsCollector');
 
@@ -55,6 +49,8 @@ export class MetricsCollector extends EventEmitter {
   private history: MetricData[] = [];
   private isCollecting = false;
   private collectionInterval: NodeJS.Timeout | null = null;
+  private lastCpuUsage: NodeJS.CpuUsage = process.cpuUsage();
+  private lastCpuHrTime: bigint = process.hrtime.bigint();
 
   static getInstance(): MetricsCollector {
     if (!MetricsCollector.instance) {
@@ -101,8 +97,8 @@ export class MetricsCollector extends EventEmitter {
   private collectSystemMetrics(): void {
     const timestamp = new Date().toISOString();
 
-    // Collect CPU usage (placeholder)
-    const cpuUsage = getRandomFloat(100);
+    // Collect real CPU usage (percent of wall-clock time spent on CPU since last sample)
+    const cpuUsage = this.calculateCpuUsage();
     this.recordMetric('cpu_usage', cpuUsage, { timestamp });
 
     // Collect memory usage
@@ -111,6 +107,44 @@ export class MetricsCollector extends EventEmitter {
 
     // Emit collected metrics
     this.emit('metricsCollected', this.getMetricsSummary());
+  }
+
+  /**
+   * Calculate process CPU usage as a percentage based on the delta of
+   * `process.cpuUsage()` over the wall-clock interval since the last sample.
+   * Returns a value clamped to [0, 100].
+   */
+  private calculateCpuUsage(): number {
+    const currentCpuUsage = process.cpuUsage(this.lastCpuUsage);
+    const currentHrTime = process.hrtime.bigint();
+    const elapsedHrTime = currentHrTime - this.lastCpuHrTime;
+
+    this.lastCpuUsage = process.cpuUsage();
+    this.lastCpuHrTime = currentHrTime;
+
+    const elapsedMs = Number(elapsedHrTime) / 1_000_000;
+    if (elapsedMs <= 0) {
+      return 0;
+    }
+
+    const userMs = currentCpuUsage.user / 1000;
+    const systemMs = currentCpuUsage.system / 1000;
+    const cpuPercent = (100 * (userMs + systemMs)) / elapsedMs;
+
+    return Math.max(0, Math.min(100, Math.round(cpuPercent * 10) / 10));
+  }
+
+  /**
+   * System memory usage as a percentage of total physical memory.
+   */
+  private getSystemMemoryUsagePercent(): number {
+    const totalMem = os.totalmem();
+    const freeMem = os.freemem();
+    if (totalMem <= 0) {
+      return 0;
+    }
+    const usedPercent = ((totalMem - freeMem) / totalMem) * 100;
+    return Math.round(usedPercent * 10) / 10;
   }
 
   incrementMessages(): void {
@@ -195,10 +229,15 @@ export class MetricsCollector extends EventEmitter {
         : 0;
 
     const performance: PerformanceMetrics = {
-      cpuUsage: this.getLatestValue('cpu_usage') || 0,
-      memoryUsage: this.getLatestValue('memory_usage') || 0,
-      diskUsage: getRandomFloat(100), // placeholder
-      networkIO: getRandomFloat(1000), // placeholder
+      cpuUsage: this.getLatestValue('cpu_usage') ?? 0,
+      memoryUsage: this.getLatestValue('memory_usage') ?? 0,
+      // System memory utilisation as a percentage of total physical memory.
+      // Node's stdlib does not expose per-process disk or network throughput,
+      // so we report a real, available figure here instead of a random placeholder.
+      diskUsage: this.getSystemMemoryUsagePercent(),
+      // No built-in network-throughput source is available without extra
+      // dependencies; report 0 rather than fabricating a random value.
+      networkIO: 0,
       responseTime: avgResponseTime,
       throughput:
         this.metrics.messagesProcessed / (Math.max(1, Date.now() - this.metrics.uptime) / 1000),

--- a/tests/unit/observability/MetricsCollector.realSystem.test.ts
+++ b/tests/unit/observability/MetricsCollector.realSystem.test.ts
@@ -1,0 +1,80 @@
+import os from 'os';
+import { MetricsCollector } from '@src/monitoring/MetricsCollector';
+
+describe('MetricsCollector real system metrics', () => {
+  let collector: MetricsCollector;
+
+  beforeEach(() => {
+    collector = MetricsCollector.getInstance();
+    collector.reset();
+  });
+
+  afterEach(() => {
+    collector.reset();
+    jest.restoreAllMocks();
+  });
+
+  it('reports cpu_usage as a real percentage in [0, 100] (no random placeholder)', () => {
+    // Drive collectSystemMetrics() directly to populate cpu_usage.
+    (collector as unknown as { collectSystemMetrics(): void }).collectSystemMetrics();
+
+    const cpu = collector.getLatestValue('cpu_usage');
+    expect(cpu).toBeDefined();
+    expect(cpu as number).toBeGreaterThanOrEqual(0);
+    expect(cpu as number).toBeLessThanOrEqual(100);
+  });
+
+  it('computes cpu usage from the process.cpuUsage delta rather than randomness', () => {
+    // Two consecutive collections over a near-zero interval should both yield
+    // deterministic, bounded values (a random placeholder could not guarantee
+    // the [0,100] bound, and crypto-random would vary wildly). Here we assert
+    // the value tracks a controlled cpuUsage delta.
+    const internal = collector as unknown as {
+      collectSystemMetrics(): void;
+      lastCpuUsage: NodeJS.CpuUsage;
+      lastCpuHrTime: bigint;
+    };
+
+    // Force a known elapsed window and CPU delta.
+    internal.lastCpuHrTime = process.hrtime.bigint() - BigInt(1_000_000_000); // 1s ago
+    internal.lastCpuUsage = process.cpuUsage();
+
+    const spy = jest.spyOn(process, 'cpuUsage');
+    // First call inside calculateCpuUsage computes the delta; return ~0.5s of CPU.
+    spy.mockReturnValueOnce({ user: 250_000, system: 250_000 }); // delta = 0.5s CPU over ~1s
+    // Second call resets lastCpuUsage baseline.
+    spy.mockReturnValueOnce({ user: 0, system: 0 });
+
+    internal.collectSystemMetrics();
+
+    const cpu = collector.getLatestValue('cpu_usage');
+    expect(cpu).toBeDefined();
+    // 0.5s CPU over ~1s wall clock ≈ 50%.
+    expect(cpu as number).toBeGreaterThan(40);
+    expect(cpu as number).toBeLessThan(60);
+  });
+
+  it('reports diskUsage as real system memory utilisation percentage and networkIO as 0', () => {
+    const totalMem = os.totalmem();
+    jest.spyOn(os, 'totalmem').mockReturnValue(totalMem);
+    jest.spyOn(os, 'freemem').mockReturnValue(totalMem / 4); // 75% used
+
+    const summary = collector.getMetricsSummary();
+
+    expect(summary.performance.diskUsage).toBeCloseTo(75, 0);
+    expect(summary.performance.networkIO).toBe(0);
+  });
+
+  it('produces stable, bounded performance values without crypto randomness', () => {
+    const a = collector.getMetricsSummary().performance;
+    const b = collector.getMetricsSummary().performance;
+
+    // networkIO is a fixed real value (0), not random noise.
+    expect(a.networkIO).toBe(0);
+    expect(b.networkIO).toBe(0);
+
+    // diskUsage (system memory %) is bounded and only changes with real memory.
+    expect(a.diskUsage).toBeGreaterThanOrEqual(0);
+    expect(a.diskUsage).toBeLessThanOrEqual(100);
+  });
+});


### PR DESCRIPTION
## What
Replace the crypto-random placeholder values in `src/monitoring/MetricsCollector.ts` with real system metrics.

- `cpu_usage` (collectSystemMetrics, was line 105): now computed from a `process.cpuUsage()` delta over the wall-clock interval since the last sample, clamped to [0,100]. Mirrors the existing `SystemMetricsReporter.calculateCpuUsage()` pattern.
- `diskUsage` (getMetricsSummary, was line 200): now reports real system memory utilisation percentage via `os.totalmem()`/`os.freemem()`. Node's stdlib exposes no per-process disk throughput, so this is the closest real, dependency-free figure.
- `networkIO` (getMetricsSummary, was line 201): now `0` (no built-in source) rather than a fabricated random number.

Removes the now-unused `crypto` import and `getRandomFloat` helper (it had no external consumers).

## Why
The three values were `getRandomFloat(...)` placeholders, so the dashboard/Prometheus summary reported meaningless random CPU/disk/network figures every 5s collection cycle. This makes the metrics trustworthy.

## Behavior
- `getMetricsSummary().performance.cpuUsage` reflects actual process CPU load.
- `performance.diskUsage` reflects actual system memory usage %.
- `performance.networkIO` is a stable 0 instead of noise.
- No interface (`PerformanceMetrics`) or method signatures changed; consumers (webui, health routes, demo simulator) are unaffected.

## Verification
- `npx tsc --noEmit`: clean.
- New unit test `tests/unit/observability/MetricsCollector.realSystem.test.ts` (4 tests) passes, covering the CPU-delta calculation (mocked `process.cpuUsage`) and the real disk/network values (mocked `os.totalmem/freemem`).
- Consumer suites `DemoActivitySimulator` / `DemoStateService` (35 tests) still pass.

Note: eslint could not be run in this environment due to a pre-existing ajv/@eslint/eslintrc version conflict that crashes before linting any file; the change introduces no new lint constructs.