### PR TITLE
feat(pipeline): track persona usage count on inference response

### DIFF
--- a/src/pipeline/InferenceStage.ts
+++ b/src/pipeline/InferenceStage.ts
@@ -23,6 +23,7 @@ import type { IMessage } from '@message/interfaces/IMessage';
 import { DatabaseManager } from '../database/DatabaseManager';
 import { sendErrorAlertMessage } from '../managers/botLifecycle';
 import { BotManager } from '../managers/BotManager';
+import { PersonaManager } from '../managers/PersonaManager';
 import { TokenBudgetService } from '../server/services/TokenBudgetService';
 
 const debug = Debug('app:pipeline:inference');
@@ -177,6 +178,12 @@ export class InferenceStage {
         provider: (ctx.botConfig.llmProvider as string) || 'unknown',
       });
 
+      // Record that the bot's configured persona was actually used to produce a
+      // response. Best-effort: a missing/unknown persona (e.g. the literal
+      // 'default' placeholder) increments nothing, and any failure here must
+      // never abort the pipeline.
+      await this.recordPersonaUsage(ctx.botConfig);
+
       await this.bus.emitAsync('message:response', { ...ctx, responseText });
       debug('Inference complete: bot=%s responseLength=%d', ctx.botName, responseText.length);
     } catch (err) {
@@ -194,6 +201,29 @@ export class InferenceStage {
       });
 
       await this.bus.emitAsync('message:error', { ...ctx, error, stage: 'inference' });
+    }
+  }
+
+  /**
+   * Increment the usage counter for the persona configured on the bot that
+   * just produced a response.
+   *
+   * `botConfig.persona` is a persona ID string. When it is absent, empty, or
+   * does not resolve to a known persona (e.g. the `'default'` placeholder used
+   * by bots with no custom persona), this is a no-op. All errors are swallowed
+   * so persona bookkeeping can never break the message pipeline.
+   */
+  private async recordPersonaUsage(botConfig: Record<string, unknown>): Promise<void> {
+    const personaId = botConfig?.persona;
+    if (typeof personaId !== 'string' || !personaId) {
+      return;
+    }
+
+    try {
+      const manager = await PersonaManager.getInstance();
+      await manager.incrementUsageCount(personaId);
+    } catch (err) {
+      debug('Failed to increment persona usage count for %s: %O', personaId, err);
     }
   }
 }

--- a/tests/unit/pipeline/inferencePersonaUsage.test.ts
+++ b/tests/unit/pipeline/inferencePersonaUsage.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Regression tests for persona usage tracking in the InferenceStage.
+ *
+ * Before the fix, PersonaManager.incrementUsageCount existed but was never
+ * invoked anywhere in the message flow, so every persona's usageCount stayed
+ * at 0. The InferenceStage now increments the configured persona's usage count
+ * each time the bot actually produces a (non-empty) LLM response.
+ *
+ * These tests assert:
+ *   - a successful response increments the configured persona exactly once,
+ *   - an empty response does NOT increment,
+ *   - a missing/blank persona ID is a no-op,
+ *   - failures in usage tracking never break the pipeline.
+ */
+
+import { MessageBus } from '@src/events/MessageBus';
+import { InferenceStage, type LlmInvoker } from '@src/pipeline/InferenceStage';
+import { IMessage } from '@message/interfaces/IMessage';
+
+// --- Mock external singletons the stage touches ---------------------------
+
+const incrementUsageCount = jest.fn().mockResolvedValue(true);
+
+jest.mock('@src/managers/PersonaManager', () => ({
+  PersonaManager: {
+    getInstance: jest.fn().mockResolvedValue({
+      incrementUsageCount: (...args: unknown[]) => incrementUsageCount(...args),
+    }),
+  },
+}));
+
+jest.mock('@src/database/DatabaseManager', () => ({
+  DatabaseManager: {
+    getInstance: jest.fn().mockReturnValue({
+      logInference: jest.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+
+jest.mock('@src/server/services/TokenBudgetService', () => ({
+  TokenBudgetService: {
+    getInstance: jest.fn().mockReturnValue({
+      isOverBudget: jest.fn().mockReturnValue(false),
+      incrementUsage: jest.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Stub message
+// ---------------------------------------------------------------------------
+
+class StubMessage extends IMessage {
+  constructor() {
+    super({}, 'user');
+    this.content = 'hello';
+    this.channelId = 'ch-persona';
+    this.platform = 'discord';
+  }
+  getMessageId(): string {
+    return 'msg-1';
+  }
+  getText(): string {
+    return this.content;
+  }
+  getTimestamp(): Date {
+    return new Date();
+  }
+  setText(t: string): void {
+    this.content = t;
+  }
+  getChannelId(): string {
+    return this.channelId;
+  }
+  getAuthorId(): string {
+    return 'user-1';
+  }
+  getChannelTopic(): string | null {
+    return null;
+  }
+  getUserMentions(): string[] {
+    return [];
+  }
+  getChannelUsers(): string[] {
+    return [];
+  }
+  mentionsUsers(): boolean {
+    return false;
+  }
+  isFromBot(): boolean {
+    return false;
+  }
+  getAuthorName(): string {
+    return 'Tester';
+  }
+}
+
+function makeContext(botConfig: Record<string, unknown>) {
+  return {
+    message: new StubMessage(),
+    history: [],
+    botConfig,
+    botName: 'TestBot',
+    platform: 'discord',
+    channelId: 'ch-persona',
+    metadata: {},
+    memories: [],
+    systemPrompt: 'You are a test bot.',
+  };
+}
+
+describe('InferenceStage persona usage tracking', () => {
+  let bus: MessageBus;
+
+  beforeEach(() => {
+    MessageBus.getInstance().reset();
+    bus = MessageBus.getInstance();
+    incrementUsageCount.mockClear();
+    incrementUsageCount.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    bus.reset();
+  });
+
+  it('increments the configured persona usage count after a successful response', async () => {
+    const llm: LlmInvoker = { generateResponse: jest.fn().mockResolvedValue('a reply') };
+    const stage = new InferenceStage(bus, llm);
+
+    await stage.process(makeContext({ persona: 'persona-123' }));
+
+    expect(incrementUsageCount).toHaveBeenCalledTimes(1);
+    expect(incrementUsageCount).toHaveBeenCalledWith('persona-123');
+  });
+
+  it('does NOT increment when the LLM returns an empty response', async () => {
+    const llm: LlmInvoker = { generateResponse: jest.fn().mockResolvedValue('') };
+    const stage = new InferenceStage(bus, llm);
+
+    await stage.process(makeContext({ persona: 'persona-123' }));
+
+    expect(incrementUsageCount).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when no persona is configured', async () => {
+    const llm: LlmInvoker = { generateResponse: jest.fn().mockResolvedValue('a reply') };
+    const stage = new InferenceStage(bus, llm);
+
+    await stage.process(makeContext({}));
+
+    expect(incrementUsageCount).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the persona ID is blank', async () => {
+    const llm: LlmInvoker = { generateResponse: jest.fn().mockResolvedValue('a reply') };
+    const stage = new InferenceStage(bus, llm);
+
+    await stage.process(makeContext({ persona: '' }));
+
+    expect(incrementUsageCount).not.toHaveBeenCalled();
+  });
+
+  it('still emits message:response when usage tracking throws', async () => {
+    incrementUsageCount.mockRejectedValueOnce(new Error('persistence failure'));
+    const llm: LlmInvoker = { generateResponse: jest.fn().mockResolvedValue('a reply') };
+    const stage = new InferenceStage(bus, llm);
+
+    const responses: unknown[] = [];
+    bus.on('message:response', (ctx) => {
+      responses.push(ctx);
+    });
+
+    await stage.process(makeContext({ persona: 'persona-123' }));
+
+    expect(incrementUsageCount).toHaveBeenCalledTimes(1);
+    expect(responses).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## What
Wire `PersonaManager.incrementUsageCount` into the message pipeline. The method existed (`src/managers/PersonaManager.ts:317`) but was never invoked anywhere in the message flow, so every persona's `usageCount` stayed permanently at 0.

The increment now happens in `InferenceStage` immediately after the bot produces a non-empty LLM response, reading the configured persona ID from `ctx.botConfig.persona`. This mirrors the existing `TokenBudgetService.incrementUsage` call in the same stage.

## Why
`usageCount` is surfaced in the Personas UI and is intended to reflect how often each persona is actually used. Without this wiring the field was dead — always 0 — making the UI metric meaningless. The inference stage is the most accurate "persona was actually used" point: it only fires when the bot genuinely generates and emits a response (`message:response`), not for every inbound message considered.

## Behavior
- Successful (non-empty) response -> the configured persona's `usageCount` is incremented once.
- Empty LLM response (`message:skipped`) -> no increment.
- No persona configured, or the placeholder `'default'` ID that doesn't resolve to a stored persona -> no-op (`incrementUsageCount` returns false harmlessly).
- Any failure in usage tracking is caught and logged via `debug`; it never aborts the pipeline or blocks the response.

## Verification
- `npx tsc --noEmit` (backend): clean.
- Affected Jest suites pass: new `tests/unit/pipeline/inferencePersonaUsage.test.ts` (5 tests) plus all existing `tests/unit/pipeline`, `tests/integration/pipeline` (26 total) and `tests/unit/server/personasRoutes.test.ts` (3) — green.
- ESLint could not run in this environment due to a pre-existing ajv/@eslint/eslintrc dependency conflict that crashes on unrelated files in the base repo as well; the change introduces no new lint patterns (follows existing import/style conventions in the file).
- Frontend untouched (backend-only change).

Note: tests added; no debug/scratch files included.