### PR TITLE
feat(auth): persist user store durably across restarts

### DIFF
--- a/src/auth/AuthManager.ts
+++ b/src/auth/AuthManager.ts
@@ -4,6 +4,7 @@ import Debug from 'debug';
 import jwt from 'jsonwebtoken';
 import { AuthenticationError, ValidationError } from '@src/types/errorClasses';
 import { SecureConfigManager } from '@config/SecureConfigManager';
+import { UserRepository } from './UserRepository';
 import type {
   AuthToken,
   JWTPayload,
@@ -22,6 +23,9 @@ export class AuthManager {
   private emailMap = new Map<string, string>();
   private generatedPassword: string | null = null;
   private refreshTokens = new Set<string>();
+  // Durable backing store for the user maps. Null in the test environment,
+  // where persistence is intentionally skipped (mirrors the bcrypt skips).
+  private userRepo: UserRepository | null = null;
   private readonly jwtSecret: string;
   private readonly jwtRefreshSecret: string;
   private readonly bcryptRounds = 12;
@@ -95,6 +99,19 @@ export class AuthManager {
         envJwtRefreshSecret || secureJwtRefreshSecret || this.generateSecureSecret('jwt_refresh');
     }
 
+    // Open the durable user store and hydrate the in-memory maps from it so
+    // registered users, password changes, and lastLogin survive restarts.
+    // Skipped under test (kept fully in-memory, as elsewhere in this class).
+    if (process.env.NODE_ENV !== 'test') {
+      try {
+        this.userRepo = new UserRepository();
+        this.loadUsersFromStore();
+      } catch (err) {
+        debug('WARN:', 'Failed to initialize durable user store; using in-memory only:', err);
+        this.userRepo = null;
+      }
+    }
+
     // Create default admin user synchronously
     this.initializeDefaultAdminSync();
 
@@ -106,6 +123,47 @@ export class AuthManager {
       AuthManager.instance = new AuthManager();
     }
     return AuthManager.instance;
+  }
+
+  /**
+   * Hydrate the in-memory maps from the durable store. No-op when the store
+   * is unavailable (test env or initialization failure).
+   */
+  private loadUsersFromStore(): void {
+    if (!this.userRepo) return;
+    const persisted = this.userRepo.getAll();
+    for (const user of persisted) {
+      this.users.set(user.id, user);
+      this.usernameMap.set(user.username, user.id);
+      this.emailMap.set(user.email, user.id);
+    }
+    debug('Loaded %d user(s) from durable store', persisted.length);
+  }
+
+  /**
+   * Write a single user through to the durable store. Persistence failures are
+   * logged but never surfaced to callers — auth must keep working even if the
+   * store is momentarily unavailable.
+   */
+  private persistUser(user: User): void {
+    if (!this.userRepo) return;
+    try {
+      this.userRepo.upsert(user);
+    } catch (err) {
+      debug('WARN:', 'Failed to persist user %s:', user.id, err);
+    }
+  }
+
+  /**
+   * Remove a user from the durable store. Failures are logged, not thrown.
+   */
+  private removeUserFromStore(userId: string): void {
+    if (!this.userRepo) return;
+    try {
+      this.userRepo.delete(userId);
+    } catch (err) {
+      debug('WARN:', 'Failed to delete user %s from store:', userId, err);
+    }
   }
 
   /**
@@ -156,6 +214,13 @@ export class AuthManager {
       return;
     }
 
+    // If a default admin was already loaded from the durable store, keep it as
+    // is (preserves any changed password / lastLogin across restarts).
+    if (this.usernameMap.has('admin')) {
+      debug('Default admin user loaded from durable store');
+      return;
+    }
+
     let password = process.env.ADMIN_PASSWORD;
 
     if (!password) {
@@ -186,6 +251,7 @@ export class AuthManager {
     this.users.set('admin', defaultAdmin);
     this.usernameMap.set(defaultAdmin.username, defaultAdmin.id);
     this.emailMap.set(defaultAdmin.email, defaultAdmin.id);
+    this.persistUser(defaultAdmin);
     debug('Default admin user created');
   }
 
@@ -261,6 +327,7 @@ export class AuthManager {
     this.users.set(user.id, user);
     this.usernameMap.set(user.username, user.id);
     this.emailMap.set(user.email, user.id);
+    this.persistUser(user);
     debug(`User registered: ${user.username}`);
 
     // Destructure to omit passwordHash — setting it to undefined leaves the
@@ -289,6 +356,7 @@ export class AuthManager {
     // Update last login
     user.lastLogin = new Date().toISOString();
     this.users.set(user.id, user);
+    this.persistUser(user);
 
     // Generate tokens
     const accessToken = this.generateAccessToken(user);
@@ -321,6 +389,7 @@ export class AuthManager {
     if (user.role !== 'admin') throw new AuthenticationError('User is not an admin', 'NOT_ADMIN');
     user.lastLogin = new Date().toISOString();
     this.users.set(user.id, user);
+    this.persistUser(user);
     const accessToken = this.generateAccessToken(user);
     const refreshToken = this.generateRefreshToken(user);
     this.refreshTokens.add(refreshToken);
@@ -496,6 +565,7 @@ export class AuthManager {
 
     const updatedUser = { ...user, ...updates };
     this.users.set(userId, updatedUser);
+    this.persistUser(updatedUser);
 
     const { passwordHash: _ph, ...safeUser } = updatedUser;
     return safeUser;
@@ -510,6 +580,7 @@ export class AuthManager {
       this.usernameMap.delete(user.username);
       this.emailMap.delete(user.email);
     }
+    this.removeUserFromStore(userId);
     return this.users.delete(userId);
   }
 
@@ -524,6 +595,7 @@ export class AuthManager {
 
     user.passwordHash = await this.hashPassword(newPassword);
     this.users.set(userId, user);
+    this.persistUser(user);
 
     return true;
   }

--- a/src/auth/UserRepository.ts
+++ b/src/auth/UserRepository.ts
@@ -1,0 +1,177 @@
+import path from 'path';
+import fs from 'fs';
+import Database, { type Database as BetterSqliteDatabase } from 'better-sqlite3';
+import Debug from 'debug';
+import databaseConfig from '@config/databaseConfig';
+import type { User, UserRole } from './types';
+
+const debug = Debug('app:UserRepository');
+
+/**
+ * Shape of a row in the `auth_users` table. SQLite stores booleans as 0/1
+ * and has no native NULL coercion for our domain types, so we keep the raw
+ * column types here and convert in {@link UserRepository.rowToUser}.
+ */
+interface UserRow {
+  id: string;
+  username: string;
+  email: string;
+  role: string;
+  is_active: number;
+  created_at: string;
+  last_login: string | null;
+  password_hash: string | null;
+  tenant_id: string | null;
+}
+
+/**
+ * Synchronous, durable persistence for the AuthManager user store.
+ *
+ * AuthManager mutates its user maps synchronously (register/login/update/
+ * delete/changePassword), so this repository deliberately uses better-sqlite3's
+ * synchronous API rather than the async IDatabase wrapper. This keeps the
+ * auth code paths unchanged while making registered users, password changes,
+ * and lastLogin survive restarts (previously they lived only in in-memory Maps).
+ */
+export class UserRepository {
+  private db: BetterSqliteDatabase;
+
+  /**
+   * @param databasePath Path to the SQLite file, or ':memory:' for tests.
+   *                     Defaults to the configured DATABASE_PATH.
+   * @param injectedDb  An already-constructed better-sqlite3 Database. Used by
+   *                    tests to supply a real in-memory DB (the production path
+   *                    opens the file itself). When provided, `databasePath`
+   *                    is ignored.
+   */
+  constructor(databasePath?: string, injectedDb?: BetterSqliteDatabase) {
+    if (injectedDb) {
+      this.db = injectedDb;
+    } else {
+      const resolved = databasePath ?? UserRepository.defaultDatabasePath();
+
+      if (resolved !== ':memory:') {
+        const dir = path.dirname(resolved);
+        if (!fs.existsSync(dir)) {
+          fs.mkdirSync(dir, { recursive: true });
+        }
+      }
+
+      let DBConstructor: typeof Database = Database;
+      if (typeof DBConstructor !== 'function') {
+        const maybeDefault = (Database as unknown as { default?: typeof Database }).default;
+        if (typeof maybeDefault === 'function') {
+          DBConstructor = maybeDefault;
+        }
+      }
+
+      this.db = new DBConstructor(resolved);
+      debug('UserRepository initialized at %s', resolved);
+    }
+
+    try {
+      this.db.pragma('journal_mode = WAL');
+      this.db.pragma('foreign_keys = ON');
+      this.db.pragma('busy_timeout = 5000');
+    } catch (err) {
+      debug('Failed to apply PRAGMAs (continuing):', err);
+    }
+
+    this.createTable();
+  }
+
+  private static defaultDatabasePath(): string {
+    const configured = databaseConfig.get('DATABASE_PATH');
+    return path.isAbsolute(configured) ? configured : path.join(process.cwd(), configured);
+  }
+
+  private createTable(): void {
+    this.db
+      .prepare(
+        `
+        CREATE TABLE IF NOT EXISTS auth_users (
+          id TEXT PRIMARY KEY,
+          username TEXT NOT NULL UNIQUE,
+          email TEXT NOT NULL UNIQUE,
+          role TEXT NOT NULL,
+          is_active INTEGER NOT NULL DEFAULT 1,
+          created_at TEXT NOT NULL,
+          last_login TEXT,
+          password_hash TEXT,
+          tenant_id TEXT
+        )
+      `
+      )
+      .run();
+  }
+
+  private rowToUser(row: UserRow): User {
+    return {
+      id: row.id,
+      username: row.username,
+      email: row.email,
+      role: row.role as UserRole,
+      isActive: row.is_active === 1,
+      createdAt: row.created_at,
+      lastLogin: row.last_login,
+      passwordHash: row.password_hash ?? undefined,
+      tenantId: row.tenant_id ?? undefined,
+    };
+  }
+
+  /** Load every persisted user (including password hashes). */
+  public getAll(): User[] {
+    const rows = this.db.prepare('SELECT * FROM auth_users').all() as UserRow[];
+    return rows.map((row) => this.rowToUser(row));
+  }
+
+  /** Insert a new user or replace the existing row with the same id. */
+  public upsert(user: User): void {
+    this.db
+      .prepare(
+        `
+        INSERT INTO auth_users (
+          id, username, email, role, is_active, created_at, last_login, password_hash, tenant_id
+        ) VALUES (
+          @id, @username, @email, @role, @is_active, @created_at, @last_login, @password_hash, @tenant_id
+        )
+        ON CONFLICT(id) DO UPDATE SET
+          username = excluded.username,
+          email = excluded.email,
+          role = excluded.role,
+          is_active = excluded.is_active,
+          created_at = excluded.created_at,
+          last_login = excluded.last_login,
+          password_hash = excluded.password_hash,
+          tenant_id = excluded.tenant_id
+      `
+      )
+      .run({
+        id: user.id,
+        username: user.username,
+        email: user.email,
+        role: user.role,
+        is_active: user.isActive ? 1 : 0,
+        created_at: user.createdAt,
+        last_login: user.lastLogin ?? null,
+        password_hash: user.passwordHash ?? null,
+        tenant_id: user.tenantId ?? null,
+      });
+  }
+
+  /** Delete a user by id. Returns true if a row was removed. */
+  public delete(userId: string): boolean {
+    const info = this.db.prepare('DELETE FROM auth_users WHERE id = ?').run(userId);
+    return info.changes > 0;
+  }
+
+  /** Whether any user already exists in the store. */
+  public count(): number {
+    const row = this.db.prepare('SELECT COUNT(*) AS n FROM auth_users').get() as { n: number };
+    return row.n;
+  }
+
+  public close(): void {
+    this.db.close();
+  }
+}

--- a/tests/auth/UserRepository.test.ts
+++ b/tests/auth/UserRepository.test.ts
@@ -1,0 +1,112 @@
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+import { UserRepository } from '../../src/auth/UserRepository';
+import type { User } from '../../src/auth/types';
+
+// The global jest config maps `better-sqlite3` to a hand-written mock that only
+// understands a fixed set of table names. These persistence tests need real SQL
+// (named params, ON CONFLICT, COUNT, the auth_users table), so we load the
+// actual better-sqlite3 implementation and inject a real DB instance.
+// moduleNameMapper rewrites bare specifiers (even via requireActual), so we
+// resolve the package's real entry point and require it by absolute path.
+const realBetterSqlitePath = require.resolve('better-sqlite3/lib/index.js');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const RealDatabase = jest.requireActual(realBetterSqlitePath) as unknown as new (
+  filename: string
+) => import('better-sqlite3').Database;
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: overrides.id ?? `id-${Math.random().toString(36).slice(2)}`,
+    username: overrides.username ?? 'alice',
+    email: overrides.email ?? 'alice@example.com',
+    role: overrides.role ?? 'user',
+    isActive: overrides.isActive ?? true,
+    createdAt: overrides.createdAt ?? new Date('2024-01-01T00:00:00.000Z').toISOString(),
+    lastLogin: overrides.lastLogin ?? null,
+    passwordHash: overrides.passwordHash ?? 'hashed-secret',
+    ...overrides,
+  };
+}
+
+describe('UserRepository', () => {
+  it('round-trips a user through upsert/getAll', () => {
+    const repo = new UserRepository(undefined, new RealDatabase(':memory:'));
+    const user = makeUser();
+
+    repo.upsert(user);
+    const all = repo.getAll();
+
+    expect(all).toHaveLength(1);
+    expect(all[0]).toEqual(user);
+    repo.close();
+  });
+
+  it('preserves password hash, lastLogin, isActive and role on update', () => {
+    const repo = new UserRepository(undefined, new RealDatabase(':memory:'));
+    const user = makeUser({ id: 'u1' });
+    repo.upsert(user);
+
+    const updated: User = {
+      ...user,
+      passwordHash: 'new-hash',
+      lastLogin: new Date('2024-02-02T10:00:00.000Z').toISOString(),
+      isActive: false,
+      role: 'admin',
+    };
+    repo.upsert(updated);
+
+    const rows = repo.getAll();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].passwordHash).toBe('new-hash');
+    expect(rows[0].lastLogin).toBe(updated.lastLogin);
+    expect(rows[0].isActive).toBe(false);
+    expect(rows[0].role).toBe('admin');
+    repo.close();
+  });
+
+  it('deletes a user and reports whether a row was removed', () => {
+    const repo = new UserRepository(undefined, new RealDatabase(':memory:'));
+    const user = makeUser({ id: 'u2' });
+    repo.upsert(user);
+
+    expect(repo.count()).toBe(1);
+    expect(repo.delete('u2')).toBe(true);
+    expect(repo.count()).toBe(0);
+    expect(repo.delete('does-not-exist')).toBe(false);
+    repo.close();
+  });
+
+  it('persists users durably across separate repository instances (survives restart)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'user-repo-test-'));
+    const dbPath = path.join(dir, 'users.db');
+
+    try {
+      // First "process": register a user and change a password.
+      const first = new UserRepository(undefined, new RealDatabase(dbPath));
+      first.upsert(makeUser({ id: 'persist-1', username: 'bob', email: 'bob@example.com' }));
+      first.upsert(
+        makeUser({
+          id: 'persist-1',
+          username: 'bob',
+          email: 'bob@example.com',
+          passwordHash: 'changed-after-restart',
+          lastLogin: new Date('2024-03-03T12:00:00.000Z').toISOString(),
+        })
+      );
+      first.close();
+
+      // Second "process": a brand-new repository over the same file must see it.
+      const second = new UserRepository(undefined, new RealDatabase(dbPath));
+      const loaded = second.getAll();
+      expect(loaded).toHaveLength(1);
+      expect(loaded[0].username).toBe('bob');
+      expect(loaded[0].passwordHash).toBe('changed-after-restart');
+      expect(loaded[0].lastLogin).toBe('2024-03-03T12:00:00.000Z');
+      second.close();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## What
Adds durable persistence for the AuthManager user store. Introduces `src/auth/UserRepository.ts` (a synchronous better-sqlite3 `auth_users` table at `DATABASE_PATH`) and wires `AuthManager` to hydrate from it on startup and write through on every user mutation.

## Why
`AuthManager` stored users only in in-memory Maps (`AuthManager.ts:20`). On restart, registered users, password changes, and `lastLogin` timestamps were lost — only the default admin was recreated. This makes the user store survive restarts.

## Behavior
- Startup loads persisted users into the in-memory maps, then bootstraps the default admin **only if absent** (an existing persisted admin — including a rotated password — is preserved instead of overwritten).
- Write-through on `register`, `login` (lastLogin), `trustedLogin` (lastLogin), `updateUser`, `deleteUser`, and `changePassword`.
- Passwords remain bcrypt-hashed exactly as before; no auth logic weakened.
- Persistence is skipped under `NODE_ENV=test` (mirrors the existing bcrypt test short-circuits). Store failures are logged via debug and never break auth — the in-memory maps remain the request-time source of truth.

## Verification
- `tsc --noEmit`: clean.
- New `tests/auth/UserRepository.test.ts` (4 tests) — CRUD, field preservation, delete semantics, and cross-instance durability (survives a simulated restart). Passes; existing auth suites still pass.
- Manual smoke (dev mode, real DB path): default admin bootstraps; a registered user with a rotated password survives a simulated AuthManager restart.
- ESLint could not be run: the shared node_modules has a pre-existing ajv/eslintrc incompatibility that crashes ESLint on untouched files too (e.g. `src/auth/SessionStore.ts`) — environmental, unrelated to this change.