### PR TITLE
feat(config): real YAML parse/serialize for import-export round-trip

### DIFF
--- a/src/server/services/configImportExport/formatConverters.ts
+++ b/src/server/services/configImportExport/formatConverters.ts
@@ -21,39 +21,110 @@ export function detectFormat(filePath: string): 'json' | 'yaml' | 'csv' {
 }
 
 /**
- * Convert data to YAML (simplified implementation)
+ * Serialize a scalar value (string, number, boolean, null, Date) to its YAML
+ * representation. Strings are quoted whenever they could otherwise be
+ * misinterpreted as another type (number, boolean, null), contain characters
+ * that need escaping, or start/end with whitespace.
  */
+function serializeScalar(value: unknown): string {
+  if (value === null || value === undefined) {
+    return 'null';
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? String(value) : `"${String(value)}"`;
+  }
+  if (value instanceof Date) {
+    // Dates round-trip as ISO-8601 strings.
+    return JSON.stringify(value.toISOString());
+  }
 
-export function convertToYAML(data: any): string {
-  // This is a simplified YAML converter
-  // In production, use a proper YAML library like js-yaml
+  const str = String(value);
 
-  const convert = (obj: any, indent = 0): string => {
+  // Empty strings and strings that would be ambiguous must be quoted.
+  const needsQuoting =
+    str.length === 0 ||
+    /^[\s]|[\s]$/.test(str) || // leading/trailing whitespace
+    /[:#\-?,[\]{}&*!|>'"%@`\n\t]/.test(str) || // YAML indicator / special chars
+    /^(?:true|false|null|~|yes|no|on|off)$/i.test(str) || // reserved words
+    /^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/.test(str); // numeric-looking
+
+  if (needsQuoting) {
+    // Use JSON string quoting which produces valid double-quoted YAML scalars
+    // (YAML's double-quoted flow scalar shares JSON's escape semantics).
+    return JSON.stringify(str);
+  }
+  return str;
+}
+
+/**
+ * Convert data to YAML.
+ *
+ * Supports nested maps, arrays (including arrays of maps and nested arrays),
+ * and the scalar types produced by configuration exports (string, number,
+ * boolean, null, Date). Output is designed to round-trip through {@link parseYAML}.
+ */
+export function convertToYAML(data: unknown): string {
+  const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+    typeof v === 'object' && v !== null && !Array.isArray(v) && !(v instanceof Date);
+
+  const convert = (obj: unknown, indent: number): string => {
     const spaces = ' '.repeat(indent);
-    let result = '';
 
-    if (typeof obj === 'object' && obj !== null) {
-      if (Array.isArray(obj)) {
-        for (const item of obj) {
-          result += spaces + '- ' + convert(item, indent + 2).trim() + '\n';
-        }
-      } else {
-        for (const [key, value] of Object.entries(obj)) {
-          if (typeof value === 'object' && value !== null) {
-            result += spaces + key + ':\n' + convert(value, indent + 2);
-          } else {
-            result += spaces + key + ': ' + value + '\n';
-          }
+    if (Array.isArray(obj)) {
+      if (obj.length === 0) {
+        return spaces + '[]\n';
+      }
+      let result = '';
+      for (const item of obj) {
+        if (isPlainObject(item) && Object.keys(item).length > 0) {
+          // Render the first key inline with the dash, the rest indented.
+          const rendered = convert(item, indent + 2);
+          result += spaces + '- ' + rendered.slice(indent + 2);
+        } else if (Array.isArray(item) && item.length > 0) {
+          const rendered = convert(item, indent + 2);
+          result += spaces + '- ' + rendered.slice(indent + 2);
+        } else {
+          result += spaces + '- ' + serializeScalar(item) + '\n';
         }
       }
-    } else {
-      return String(obj);
+      return result;
     }
 
-    return result;
+    if (isPlainObject(obj)) {
+      const entries = Object.entries(obj);
+      if (entries.length === 0) {
+        return spaces + '{}\n';
+      }
+      let result = '';
+      for (const [key, value] of entries) {
+        const safeKey = serializeScalar(key);
+        if (Array.isArray(value)) {
+          if (value.length === 0) {
+            result += spaces + safeKey + ': []\n';
+          } else {
+            result += spaces + safeKey + ':\n' + convert(value, indent + 2);
+          }
+        } else if (isPlainObject(value)) {
+          if (Object.keys(value).length === 0) {
+            result += spaces + safeKey + ': {}\n';
+          } else {
+            result += spaces + safeKey + ':\n' + convert(value, indent + 2);
+          }
+        } else {
+          result += spaces + safeKey + ': ' + serializeScalar(value) + '\n';
+        }
+      }
+      return result;
+    }
+
+    // Top-level scalar.
+    return spaces + serializeScalar(obj) + '\n';
   };
 
-  return convert(data);
+  return convert(data, 0);
 }
 
 /**
@@ -95,14 +166,222 @@ export function convertToCSV(data: any): string {
 }
 
 /**
- // eslint-disable-next-line @typescript-eslint/no-explicit-any
- * Parse YAML (simplified implementation)
+ * Parse a single YAML scalar token into its JS value.
  */
+function parseScalar(token: string): unknown {
+  const raw = token.trim();
+  if (raw.length === 0) {
+    return '';
+  }
+  // Double-quoted strings use JSON escape semantics.
+  if (raw.startsWith('"')) {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      // Fall through to returning the raw value if it is not valid JSON.
+    }
+  }
+  // Single-quoted strings: YAML escapes '' to a literal single quote.
+  if (raw.startsWith("'") && raw.endsWith("'") && raw.length >= 2) {
+    return raw.slice(1, -1).replace(/''/g, "'");
+  }
+  if (raw === 'null' || raw === '~') {
+    return null;
+  }
+  if (raw === 'true') {
+    return true;
+  }
+  if (raw === 'false') {
+    return false;
+  }
+  if (raw === '[]') {
+    return [];
+  }
+  if (raw === '{}') {
+    return {};
+  }
+  if (/^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/.test(raw)) {
+    const num = Number(raw);
+    if (Number.isFinite(num)) {
+      return num;
+    }
+  }
+  return raw;
+}
 
-export function parseYAML(_yamlString: string): any {
-  // This is a simplified YAML parser
-  // In production, use a proper YAML library like js-yaml
-  throw new Error('YAML parsing not implemented in this version');
+interface YamlLine {
+  indent: number;
+  content: string;
+}
+
+/**
+ * Split a `key: value` mapping entry, respecting quoted keys/values so that a
+ * colon inside a quoted string is not treated as the separator.
+ */
+function splitKeyValue(content: string): { key: string; value: string } | null {
+  let inDouble = false;
+  let inSingle = false;
+  for (let i = 0; i < content.length; i++) {
+    const ch = content[i];
+    if (ch === '"' && !inSingle) {
+      // Account for escaped quotes inside double-quoted strings.
+      if (!(inDouble && content[i - 1] === '\\')) {
+        inDouble = !inDouble;
+      }
+    } else if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+    } else if (ch === ':' && !inDouble && !inSingle) {
+      const next = content[i + 1];
+      if (next === undefined || next === ' ') {
+        return {
+          key: content.slice(0, i).trim(),
+          value: content.slice(i + 1).trim(),
+        };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Recursively parse a block of lines at a given minimum indentation into the
+ * corresponding JS value (mapping, sequence, or scalar).
+ */
+function parseBlock(lines: YamlLine[], start: number, end: number): unknown {
+  // Skip leading blank region; the first significant line defines the type.
+  let i = start;
+  while (i < end && lines[i].content.length === 0) {
+    i++;
+  }
+  if (i >= end) {
+    return null;
+  }
+
+  const baseIndent = lines[i].indent;
+  const isSequence = lines[i].content.startsWith('- ') || lines[i].content === '-';
+
+  if (isSequence) {
+    const arr: unknown[] = [];
+    let j = i;
+    while (j < end) {
+      const line = lines[j];
+      if (line.content.length === 0) {
+        j++;
+        continue;
+      }
+      if (line.indent < baseIndent) {
+        break;
+      }
+      if (line.indent === baseIndent && (line.content.startsWith('- ') || line.content === '-')) {
+        const after = line.content === '-' ? '' : line.content.slice(2);
+        // Gather child lines belonging to this item (the inline part plus any
+        // deeper-indented following lines).
+        const childLines: YamlLine[] = [];
+        if (after.length > 0) {
+          // The inline content sits two columns past the dash.
+          childLines.push({ indent: baseIndent + 2, content: after });
+        }
+        let k = j + 1;
+        while (k < end) {
+          if (lines[k].content.length === 0) {
+            childLines.push(lines[k]);
+            k++;
+            continue;
+          }
+          if (lines[k].indent <= baseIndent) {
+            break;
+          }
+          childLines.push(lines[k]);
+          k++;
+        }
+        arr.push(parseBlock(childLines, 0, childLines.length));
+        j = k;
+      } else {
+        break;
+      }
+    }
+    return arr;
+  }
+
+  // Otherwise this is a mapping (or a lone scalar).
+  const kv = splitKeyValue(lines[i].content);
+  if (kv === null) {
+    // A bare scalar block.
+    return parseScalar(lines[i].content);
+  }
+
+  const obj: Record<string, unknown> = {};
+  let j = i;
+  while (j < end) {
+    const line = lines[j];
+    if (line.content.length === 0) {
+      j++;
+      continue;
+    }
+    if (line.indent < baseIndent) {
+      break;
+    }
+    if (line.indent > baseIndent) {
+      // Should have been consumed as a child of the previous key.
+      j++;
+      continue;
+    }
+    const entry = splitKeyValue(line.content);
+    if (entry === null) {
+      break;
+    }
+    const key = parseScalar(entry.key) as string | number;
+    if (entry.value.length > 0) {
+      obj[String(key)] = parseScalar(entry.value);
+      j++;
+    } else {
+      // Nested block: collect deeper-indented lines as the value.
+      const childLines: YamlLine[] = [];
+      let k = j + 1;
+      while (k < end) {
+        if (lines[k].content.length === 0) {
+          childLines.push(lines[k]);
+          k++;
+          continue;
+        }
+        if (lines[k].indent <= baseIndent) {
+          break;
+        }
+        childLines.push(lines[k]);
+        k++;
+      }
+      obj[String(key)] = childLines.length > 0 ? parseBlock(childLines, 0, childLines.length) : null;
+      j = k;
+    }
+  }
+  return obj;
+}
+
+/**
+ * Parse YAML produced by {@link convertToYAML} (and compatible block-style YAML)
+ * back into a JS value. Supports nested mappings, block sequences, and the
+ * scalar types used by configuration import/export.
+ */
+export function parseYAML(yamlString: string): any {
+  const lines: YamlLine[] = yamlString
+    .split(/\r?\n/)
+    .map((line) => {
+      // Strip a trailing comment that is outside of any quotes. We only support
+      // comments that begin the line or follow whitespace, which is sufficient
+      // for round-tripping our own output (which emits no comments).
+      const stripped = line.replace(/\t/g, '  ');
+      const indent = stripped.length - stripped.trimStart().length;
+      const content = stripped.trim();
+      return { indent, content };
+    })
+    // Drop full-line comments and blank-only document markers.
+    .filter((line) => line.content !== '---' && !line.content.startsWith('#'));
+
+  if (lines.every((line) => line.content.length === 0)) {
+    return null;
+  }
+
+  return parseBlock(lines, 0, lines.length);
 }
 
 /**

--- a/tests/unit/server/services/configImportExport/formatConverters.test.ts
+++ b/tests/unit/server/services/configImportExport/formatConverters.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for YAML/CSV format conversion in the configuration import/export pipeline.
+ *
+ * Regression: parseYAML previously threw 'YAML parsing not implemented' and
+ * convertToYAML was a lossy hand-rolled serializer, so YAML exports could not be
+ * re-imported. These tests assert that convertToYAML + parseYAML round-trip the
+ * config export shapes (nested maps, arrays of objects, mixed scalar types).
+ */
+import {
+  convertToYAML,
+  parseYAML,
+  detectFormat,
+  convertToCSV,
+  parseCSV,
+} from '../../../../../src/server/services/configImportExport/formatConverters';
+
+describe('detectFormat', () => {
+  it('detects formats from file extension', () => {
+    expect(detectFormat('config.json')).toBe('json');
+    expect(detectFormat('config.yaml')).toBe('yaml');
+    expect(detectFormat('config.yml')).toBe('yaml');
+    expect(detectFormat('config.csv')).toBe('csv');
+    expect(detectFormat('config.unknown')).toBe('json');
+  });
+});
+
+describe('convertToYAML / parseYAML round-trip', () => {
+  const roundTrip = (value: unknown): unknown => parseYAML(convertToYAML(value));
+
+  it('round-trips a flat mapping of scalars', () => {
+    const data = { name: 'bot-1', enabled: true, count: 3, disabled: false, note: null };
+    expect(roundTrip(data)).toEqual(data);
+  });
+
+  it('round-trips nested mappings', () => {
+    const data = {
+      metadata: { id: 'exp-1', configCount: 2, encrypted: false },
+      settings: { llm: { provider: 'openai', temperature: 0.7 } },
+    };
+    expect(roundTrip(data)).toEqual(data);
+  });
+
+  it('round-trips arrays of objects (configurations export shape)', () => {
+    const data = {
+      metadata: { name: 'export', configCount: 2 },
+      configurations: [
+        { id: 1, name: 'Alpha', enabled: true },
+        { id: 2, name: 'Beta', enabled: false },
+      ],
+    };
+    expect(roundTrip(data)).toEqual(data);
+  });
+
+  it('round-trips arrays of scalars and empty collections', () => {
+    const data = {
+      tags: ['a', 'b', 'c'],
+      empties: [],
+      emptyObj: {},
+    };
+    expect(roundTrip(data)).toEqual(data);
+  });
+
+  it('round-trips nested arrays inside array items', () => {
+    const data = {
+      groups: [
+        { name: 'g1', members: ['x', 'y'] },
+        { name: 'g2', members: [] },
+      ],
+    };
+    expect(roundTrip(data)).toEqual(data);
+  });
+
+  it('quotes and recovers strings that look like other types', () => {
+    const data = {
+      stringTrue: 'true',
+      stringNull: 'null',
+      stringNumber: '42',
+      withColon: 'key: value',
+      withHash: 'a # b',
+      empty: '',
+      leadingSpace: '  padded  ',
+    };
+    expect(roundTrip(data)).toEqual(data);
+  });
+
+  it('preserves special characters via quoting', () => {
+    const data = { text: 'line with "quotes", commas, and: colons' };
+    expect(roundTrip(data)).toEqual(data);
+  });
+
+  it('serializes Date values as ISO strings', () => {
+    const date = new Date('2026-06-03T12:00:00.000Z');
+    const yaml = convertToYAML({ createdAt: date });
+    const parsed = parseYAML(yaml) as { createdAt: string };
+    expect(parsed.createdAt).toBe('2026-06-03T12:00:00.000Z');
+  });
+
+  it('produces parseable output for a realistic export payload', () => {
+    const exportData = {
+      metadata: {
+        id: 'export-123',
+        name: 'my-backup',
+        configCount: 1,
+        format: 'yaml',
+        encrypted: false,
+        compressed: false,
+      },
+      configurations: [
+        {
+          id: 7,
+          name: 'Support Bot',
+          messageProvider: 'discord',
+          llmProvider: 'openai',
+          isActive: true,
+          description: 'Handles: customer support, escalations',
+        },
+      ],
+    };
+    expect(roundTrip(exportData)).toEqual(exportData);
+  });
+});
+
+describe('parseYAML edge cases', () => {
+  it('returns null for empty input', () => {
+    expect(parseYAML('')).toBeNull();
+    expect(parseYAML('\n\n')).toBeNull();
+  });
+
+  it('ignores document markers and comment lines', () => {
+    const yaml = '---\n# a comment\nname: bot\nenabled: true\n';
+    expect(parseYAML(yaml)).toEqual({ name: 'bot', enabled: true });
+  });
+
+  it('parses single-quoted strings', () => {
+    expect(parseYAML("name: 'it''s here'\n")).toEqual({ name: "it's here" });
+  });
+});
+
+describe('convertToCSV / parseCSV', () => {
+  it('round-trips configuration rows without embedded delimiters', () => {
+    const data = {
+      configurations: [
+        { id: '1', name: 'Alpha', note: 'plain' },
+        { id: '2', name: 'Beta', note: 'simple' },
+      ],
+    };
+    const csv = convertToCSV(data);
+    const parsed = parseCSV(csv);
+    expect(parsed).toEqual(data);
+  });
+
+  it('throws when converting non-configuration data', () => {
+    expect(() => convertToCSV({ foo: 'bar' })).toThrow(/non-configuration/);
+  });
+});


### PR DESCRIPTION
## What
Implements real YAML serialization and parsing in `src/server/services/configImportExport/formatConverters.ts` so configuration exports in YAML format can be re-imported.

- `convertToYAML` was a lossy hand-rolled serializer (no quoting/escaping; comment said 'In production, use a proper YAML library').
- `parseYAML` threw `Error('YAML parsing not implemented in this version')`, so every `.yaml`/`.yml` import path (`ConfigurationImportExportService`, `ConfigImporter`) failed outright.

## Why
YAML was an advertised export format but could not round-trip: exports were lossy and imports were impossible. This closes the gap with no new runtime dependency. (PR #2819 attempted this earlier but had a dependency conflict and was not merged; this implementation is dependency-free.)

## Behavior
- `convertToYAML` emits block-style YAML for nested maps, arrays of maps, nested arrays, and empty collections (`[]`/`{}`). Scalars (string/number/boolean/null/Date) are serialized with quoting/escaping so strings that look like other types (`'true'`, `'42'`, `'null'`), contain YAML indicators (`:`, `#`, `,`, quotes), or have leading/trailing whitespace are preserved. Dates serialize as ISO-8601 strings.
- `parseYAML` is an indentation-based block parser that reverses the above and tolerates document markers (`---`) and comment lines. Returns `null` for empty input.
- Result: `parseYAML(convertToYAML(x))` deep-equals `x` for config export shapes.
- No public signatures changed; all existing callers (export/import/backup-restore) keep working and YAML import now succeeds.

## Verification
- `npx tsc --noEmit` (backend): clean.
- New unit tests `tests/unit/server/services/configImportExport/formatConverters.test.ts`: 15 passing (round-trip of flat/nested maps, arrays of objects, nested arrays, empty collections, ambiguous strings, special chars, Date; parser edge cases).
- Affected suite `tests/unit/server/routes/admin/backup.test.ts`: passing (19 tests total across both suites).
- No frontend files touched.

Note: repo ESLint is currently non-functional in this environment (ajv module-load crash in `@eslint/eslintrc`, unrelated to this change); changes were checked manually against the active rules (no unused imports; `no-explicit-any` is disabled in config).