### PR TITLE
feat(audit): durable DB persistence for audit events

### DIFF
--- a/src/database/DatabaseManager.ts
+++ b/src/database/DatabaseManager.ts
@@ -11,6 +11,12 @@ import { ActivityRepository, type ActivityLog } from './repositories/ActivityRep
 import { AIFeedbackRepository } from './repositories/AIFeedbackRepository';
 import { AnomalyRepository } from './repositories/AnomalyRepository';
 import { ApprovalRepository } from './repositories/ApprovalRepository';
+import {
+  AuditEventRepository,
+  type AuditEventQuery,
+  type AuditEventRecord,
+  type AuditEventStats,
+} from './repositories/AuditEventRepository';
 import { BotConfigRepository } from './repositories/BotConfigRepository';
 import { DecisionRepository } from './repositories/DecisionRepository';
 import { InferenceRepository } from './repositories/InferenceRepository';
@@ -64,6 +70,12 @@ export type {
   IDatabase,
 } from './types';
 
+export type {
+  AuditEventRecord,
+  AuditEventQuery,
+  AuditEventStats,
+} from './repositories/AuditEventRepository';
+
 export type { Database } from './sqliteWrapper';
 
 const debug = Debug('app:DatabaseManager');
@@ -82,6 +94,7 @@ export class DatabaseManager {
   private botConfigRepo!: BotConfigRepository;
   private anomalyRepo!: AnomalyRepository;
   private approvalRepo!: ApprovalRepository;
+  private auditEventRepo!: AuditEventRepository;
   private aiFeedbackRepo!: AIFeedbackRepository;
   private decisionRepo!: DecisionRepository;
   private activityRepo!: ActivityRepository;
@@ -249,6 +262,7 @@ export class DatabaseManager {
     this.botConfigRepo = new BotConfigRepository(getDb, ensure);
     this.anomalyRepo = new AnomalyRepository(getDb, isConn);
     this.approvalRepo = new ApprovalRepository(getDb, ensure);
+    this.auditEventRepo = new AuditEventRepository(getDb, isConn);
     this.aiFeedbackRepo = new AIFeedbackRepository(getDb, ensure);
     this.decisionRepo = new DecisionRepository(getDb, isConn);
     this.activityRepo = new ActivityRepository(getDb, isConn);
@@ -466,6 +480,26 @@ export class DatabaseManager {
 
   async deleteApprovalRequest(id: number): Promise<boolean> {
     return this.approvalRepo.deleteApprovalRequest(id);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Audit event operations -- delegated to AuditEventRepository
+  // ---------------------------------------------------------------------------
+
+  async insertAuditEvent(event: AuditEventRecord): Promise<boolean> {
+    return this.auditEventRepo.insert(event);
+  }
+
+  async queryAuditEvents(filters?: AuditEventQuery): Promise<AuditEventRecord[]> {
+    return this.auditEventRepo.query(filters);
+  }
+
+  async getRecentAuditEvents(limit = 100): Promise<AuditEventRecord[]> {
+    return this.auditEventRepo.getRecent(limit);
+  }
+
+  async getAuditEventStats(startTime?: string, endTime?: string): Promise<AuditEventStats> {
+    return this.auditEventRepo.getStats(startTime, endTime);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/database/repositories/AuditEventRepository.ts
+++ b/src/database/repositories/AuditEventRepository.ts
@@ -1,0 +1,241 @@
+import Debug from 'debug';
+import type { IDatabase as Database } from '../types';
+
+const debug = Debug('app:AuditEventRepository');
+
+/**
+ * A persisted audit event. Mirrors the in-memory `AuditLogEntry` shape used by
+ * the audit logging middleware so callers can durably store and replay the
+ * request/security audit trail across restarts.
+ */
+export interface AuditEventRecord {
+  timestamp: string;
+  action: string;
+  resource: string;
+  resourceId?: string;
+  userId?: string;
+  ip: string;
+  userAgent: string;
+  before?: unknown;
+  after?: unknown;
+  status: 'success' | 'failure';
+  errorMessage?: string;
+}
+
+/**
+ * Filters for querying persisted audit events. Mirrors the in-memory query API
+ * exposed by `AuditLoggerService` so the SQL-backed path is a drop-in source.
+ */
+export interface AuditEventQuery {
+  startTime?: string;
+  endTime?: string;
+  actions?: string[];
+  resources?: string[];
+  status?: 'success' | 'failure';
+  search?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface AuditEventStats {
+  total: number;
+  byAction: Record<string, number>;
+  byResource: Record<string, number>;
+  byStatus: { success: number; failure: number };
+  failureRate: number;
+}
+
+/**
+ * Repository for durable persistence of audit events.
+ *
+ * All methods are best-effort: when the database is unavailable they degrade
+ * gracefully (no throw) so the audit path never breaks the request pipeline.
+ */
+export class AuditEventRepository {
+  constructor(
+    private getDb: () => Database | null,
+    private isConnected: () => boolean
+  ) {}
+
+  /** Persist a single audit event. Returns false when the write was skipped. */
+  async insert(event: AuditEventRecord): Promise<boolean> {
+    const db = this.getDb();
+    if (!db || !this.isConnected()) {
+      return false;
+    }
+
+    try {
+      await db.run(
+        `INSERT INTO audit_events
+           (timestamp, action, resource, resource_id, user_id, ip, user_agent, before_value, after_value, status, error_message)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          event.timestamp,
+          event.action,
+          event.resource,
+          event.resourceId ?? null,
+          event.userId ?? null,
+          event.ip ?? null,
+          event.userAgent ?? null,
+          event.before !== undefined ? JSON.stringify(event.before) : null,
+          event.after !== undefined ? JSON.stringify(event.after) : null,
+          event.status,
+          event.errorMessage ?? null,
+        ]
+      );
+      return true;
+    } catch (error) {
+      debug('Error inserting audit event:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Query persisted audit events with the same filter/pagination semantics as
+   * the in-memory logger. Results are returned newest-first.
+   */
+  async query(filters: AuditEventQuery = {}): Promise<AuditEventRecord[]> {
+    const db = this.getDb();
+    if (!db || !this.isConnected()) {
+      return [];
+    }
+
+    const { where, params } = this.buildWhere(filters);
+    const limit = filters.limit && filters.limit > 0 ? filters.limit : 100;
+    const offset = filters.offset && filters.offset > 0 ? filters.offset : 0;
+
+    try {
+      const rows = await db.all(
+        `SELECT * FROM audit_events ${where} ORDER BY id DESC LIMIT ? OFFSET ?`,
+        [...params, limit, offset]
+      );
+      return rows.map((row: Record<string, unknown>) => this.rowToRecord(row));
+    } catch (error) {
+      debug('Error querying audit events:', error);
+      return [];
+    }
+  }
+
+  /** Retrieve the most recent N audit events (newest-first). */
+  async getRecent(limit = 100): Promise<AuditEventRecord[]> {
+    return this.query({ limit });
+  }
+
+  /**
+   * Aggregate statistics over a time window. Mirrors the in-memory getStats.
+   */
+  async getStats(startTime?: string, endTime?: string): Promise<AuditEventStats> {
+    const empty: AuditEventStats = {
+      total: 0,
+      byAction: {},
+      byResource: {},
+      byStatus: { success: 0, failure: 0 },
+      failureRate: 0,
+    };
+
+    const db = this.getDb();
+    if (!db || !this.isConnected()) {
+      return empty;
+    }
+
+    const { where, params } = this.buildWhere({ startTime, endTime });
+
+    try {
+      const rows = await db.all(
+        `SELECT action, resource, status, COUNT(*) AS count
+           FROM audit_events ${where}
+          GROUP BY action, resource, status`,
+        params
+      );
+
+      const byAction: Record<string, number> = {};
+      const byResource: Record<string, number> = {};
+      let successCount = 0;
+      let failureCount = 0;
+
+      for (const row of rows as Record<string, unknown>[]) {
+        const count = Number(row.count) || 0;
+        const action = row.action as string;
+        const resource = row.resource as string;
+        byAction[action] = (byAction[action] || 0) + count;
+        byResource[resource] = (byResource[resource] || 0) + count;
+        if (row.status === 'success') successCount += count;
+        else failureCount += count;
+      }
+
+      const total = successCount + failureCount;
+      return {
+        total,
+        byAction,
+        byResource,
+        byStatus: { success: successCount, failure: failureCount },
+        failureRate: total > 0 ? (failureCount / total) * 100 : 0,
+      };
+    } catch (error) {
+      debug('Error computing audit stats:', error);
+      return empty;
+    }
+  }
+
+  private buildWhere(filters: AuditEventQuery): { where: string; params: unknown[] } {
+    const clauses: string[] = [];
+    const params: unknown[] = [];
+
+    if (filters.startTime) {
+      clauses.push('timestamp >= ?');
+      params.push(filters.startTime);
+    }
+    if (filters.endTime) {
+      clauses.push('timestamp <= ?');
+      params.push(filters.endTime);
+    }
+    if (filters.actions && filters.actions.length > 0) {
+      clauses.push(`action IN (${filters.actions.map(() => '?').join(', ')})`);
+      params.push(...filters.actions);
+    }
+    if (filters.resources && filters.resources.length > 0) {
+      clauses.push(`resource IN (${filters.resources.map(() => '?').join(', ')})`);
+      params.push(...filters.resources);
+    }
+    if (filters.status) {
+      clauses.push('status = ?');
+      params.push(filters.status);
+    }
+    if (filters.search) {
+      const term = `%${filters.search.toLowerCase()}%`;
+      clauses.push(
+        '(LOWER(action) LIKE ? OR LOWER(resource) LIKE ? OR LOWER(COALESCE(resource_id, \'\')) LIKE ? OR LOWER(COALESCE(user_id, \'\')) LIKE ? OR LOWER(COALESCE(error_message, \'\')) LIKE ?)'
+      );
+      params.push(term, term, term, term, term);
+    }
+
+    const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';
+    return { where, params };
+  }
+
+  private rowToRecord(row: Record<string, unknown>): AuditEventRecord {
+    return {
+      timestamp: row.timestamp as string,
+      action: row.action as string,
+      resource: row.resource as string,
+      resourceId: (row.resource_id as string) ?? undefined,
+      userId: (row.user_id as string) ?? undefined,
+      ip: (row.ip as string) ?? '',
+      userAgent: (row.user_agent as string) ?? '',
+      before: this.parseJson(row.before_value),
+      after: this.parseJson(row.after_value),
+      status: row.status as 'success' | 'failure',
+      errorMessage: (row.error_message as string) ?? undefined,
+    };
+  }
+
+  private parseJson(value: unknown): unknown {
+    if (value === null || value === undefined) return undefined;
+    if (typeof value !== 'string') return value;
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value;
+    }
+  }
+}

--- a/src/database/schemas/LoggingSchemas.ts
+++ b/src/database/schemas/LoggingSchemas.ts
@@ -4,6 +4,9 @@ import type { ISchemaModule } from './ISchemaModule';
 
 export class LoggingSchemas implements ISchemaModule {
   async createTables(db: Database): Promise<void> {
+    const isPostgres = (db as any).constructor.name === 'PostgresWrapper' || !!(db as any).pool;
+    const pkAuto = isPostgres ? 'SERIAL PRIMARY KEY' : 'INTEGER PRIMARY KEY AUTOINCREMENT';
+
     // Activity logs table
     await this.createTable(
       db,
@@ -49,6 +52,27 @@ export class LoggingSchemas implements ISchemaModule {
         new_values TEXT,
         timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
         FOREIGN KEY (bot_id) REFERENCES bots (id) ON DELETE CASCADE
+      )
+    `
+    );
+
+    // Audit events table (durable persistence for the request/security audit trail)
+    await this.createTable(
+      db,
+      `
+      CREATE TABLE IF NOT EXISTS audit_events (
+        id ${pkAuto},
+        timestamp TEXT NOT NULL,
+        action TEXT NOT NULL,
+        resource TEXT NOT NULL,
+        resource_id TEXT,
+        user_id TEXT,
+        ip TEXT,
+        user_agent TEXT,
+        before_value TEXT,
+        after_value TEXT,
+        status TEXT NOT NULL,
+        error_message TEXT
       )
     `
     );
@@ -220,6 +244,13 @@ export class LoggingSchemas implements ISchemaModule {
       'CREATE INDEX IF NOT EXISTS idx_bot_audit_logs_bot_id ON bot_audit_logs(bot_id)',
       'CREATE INDEX IF NOT EXISTS idx_bot_audit_logs_user_id ON bot_audit_logs(user_id)',
       'CREATE INDEX IF NOT EXISTS idx_bot_audit_logs_timestamp ON bot_audit_logs(timestamp)',
+
+      // Audit events indexes
+      'CREATE INDEX IF NOT EXISTS idx_audit_events_timestamp ON audit_events(timestamp)',
+      'CREATE INDEX IF NOT EXISTS idx_audit_events_action ON audit_events(action)',
+      'CREATE INDEX IF NOT EXISTS idx_audit_events_resource ON audit_events(resource)',
+      'CREATE INDEX IF NOT EXISTS idx_audit_events_user_id ON audit_events(user_id)',
+      'CREATE INDEX IF NOT EXISTS idx_audit_events_status ON audit_events(status)',
 
       // Bot error logs indexes
       'CREATE INDEX IF NOT EXISTS idx_bot_error_logs_bot_id ON bot_error_logs(bot_id)',

--- a/src/server/middleware/auditLogger.ts
+++ b/src/server/middleware/auditLogger.ts
@@ -54,9 +54,81 @@ export interface AuditLogStats {
   failureRate: number;
 }
 
+/**
+ * Durable backing store for audit events. Abstracts the persistence layer so
+ * the logger can be unit-tested without a live database, while production wires
+ * it to the SQLite/Postgres-backed AuditEventRepository via DatabaseManager.
+ */
+export interface AuditEventStore {
+  insert(entry: AuditLogEntry): Promise<boolean>;
+  query(filters: AuditLogQuery): Promise<AuditLogEntry[]>;
+  getStats(startTime?: string, endTime?: string): Promise<AuditLogStats>;
+  getRecent(limit: number): Promise<AuditLogEntry[]>;
+}
+
+/**
+ * Default store that lazily resolves the DatabaseManager singleton. The require
+ * is deferred to call-time to avoid an import cycle at module load and to keep
+ * the audit path resilient when the database is not configured.
+ */
+const defaultAuditEventStore: AuditEventStore = {
+  async insert(entry: AuditLogEntry): Promise<boolean> {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+      const { DatabaseManager } = require('@src/database/DatabaseManager');
+      return await DatabaseManager.getInstance().insertAuditEvent(entry);
+    } catch {
+      return false;
+    }
+  },
+  async query(filters: AuditLogQuery): Promise<AuditLogEntry[]> {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+      const { DatabaseManager } = require('@src/database/DatabaseManager');
+      return await DatabaseManager.getInstance().queryAuditEvents(filters);
+    } catch {
+      return [];
+    }
+  },
+  async getStats(startTime?: string, endTime?: string): Promise<AuditLogStats> {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+      const { DatabaseManager } = require('@src/database/DatabaseManager');
+      return await DatabaseManager.getInstance().getAuditEventStats(startTime, endTime);
+    } catch {
+      return { total: 0, byAction: {}, byResource: {}, byStatus: { success: 0, failure: 0 }, failureRate: 0 };
+    }
+  },
+  async getRecent(limit: number): Promise<AuditLogEntry[]> {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+      const { DatabaseManager } = require('@src/database/DatabaseManager');
+      return await DatabaseManager.getInstance().getRecentAuditEvents(limit);
+    } catch {
+      return [];
+    }
+  },
+};
+
 class AuditLoggerService {
   private logs: AuditLogEntry[] = [];
   private readonly maxLogs: number = 1000;
+  private store: AuditEventStore;
+  private hydrated = false;
+
+  constructor(store: AuditEventStore = defaultAuditEventStore) {
+    this.store = store;
+  }
+
+  /**
+   * Swap the durable backing store (primarily for tests). Resets the hydration
+   * flag so the in-memory cache is reloaded from the new store on next access.
+   */
+  setStore(store: AuditEventStore): void {
+    this.store = store;
+    this.hydrated = false;
+    this.logs = [];
+  }
 
   log(entry: Omit<AuditLogEntry, 'timestamp'>): void {
     const fullEntry: AuditLogEntry = {
@@ -71,8 +143,55 @@ class AuditLoggerService {
       this.logs = this.logs.slice(-this.maxLogs);
     }
 
+    // Durable persistence (fire-and-forget; never blocks the request path).
+    void this.store.insert(fullEntry).catch((error) => {
+      Logger.debug(`Audit event persistence failed: ${String(error)}`);
+    });
+
     // Also log to structured logger
     Logger.info('AUDIT', fullEntry);
+  }
+
+  /**
+   * Hydrate the in-memory cache from the durable store. Runs at most once and
+   * only merges events that are not already cached, so volatile recent entries
+   * (logged this process) survive alongside the persisted history after a
+   * restart. Errors are swallowed so reads never fail.
+   */
+  async hydrate(): Promise<void> {
+    if (this.hydrated) return;
+    this.hydrated = true;
+    try {
+      const persisted = await this.store.getRecent(this.maxLogs);
+      if (persisted.length > 0) {
+        const seen = new Set(this.logs.map((l) => `${l.timestamp}|${l.action}|${l.resource}`));
+        // Persisted are newest-first; restore chronological (oldest-first) order.
+        const restored = [...persisted]
+          .reverse()
+          .filter((l) => !seen.has(`${l.timestamp}|${l.action}|${l.resource}`));
+        this.logs = [...restored, ...this.logs].slice(-this.maxLogs);
+      }
+    } catch {
+      // Best-effort hydration; in-memory cache remains the source of truth.
+    }
+  }
+
+  /**
+   * Durable query backed by the persistence layer. Use this for reads that must
+   * survive a restart; falls back to the in-memory cache when the store yields
+   * nothing (e.g. database not configured).
+   */
+  async queryPersisted(filters: AuditLogQuery): Promise<AuditLogEntry[]> {
+    const persisted = await this.store.query(filters);
+    if (persisted.length > 0) return persisted;
+    return this.query(filters);
+  }
+
+  /** Durable stats backed by the persistence layer, falling back to in-memory. */
+  async getStatsPersisted(startTime?: string, endTime?: string): Promise<AuditLogStats> {
+    const stats = await this.store.getStats(startTime, endTime);
+    if (stats.total > 0) return stats;
+    return this.getStats(startTime, endTime);
   }
 
   getLogs(limit = 100): AuditLogEntry[] {

--- a/tests/unit/repositories/AuditEventRepository.test.ts
+++ b/tests/unit/repositories/AuditEventRepository.test.ts
@@ -1,0 +1,271 @@
+import {
+  AuditEventRepository,
+  type AuditEventRecord,
+} from '../../../src/database/repositories/AuditEventRepository';
+import type { IDatabase } from '../../../src/database/types';
+
+/**
+ * Lightweight in-memory fake of the SQLite-flavoured IDatabase that interprets
+ * the specific SQL shapes AuditEventRepository issues. This exercises real
+ * filter / pagination / stats behaviour without a live database.
+ */
+interface StoredRow {
+  id: number;
+  timestamp: string;
+  action: string;
+  resource: string;
+  resource_id: string | null;
+  user_id: string | null;
+  ip: string | null;
+  user_agent: string | null;
+  before_value: string | null;
+  after_value: string | null;
+  status: string;
+  error_message: string | null;
+}
+
+function makeFakeDb(): { db: IDatabase; rows: StoredRow[] } {
+  const rows: StoredRow[] = [];
+  let nextId = 1;
+
+  // Re-implements the WHERE semantics the repository builds, consuming params
+  // positionally in the same order buildWhere pushes them.
+  function applyWhere(sql: string, params: any[]): { matched: StoredRow[]; rest: any[] } {
+    let i = 0;
+    let matched = [...rows];
+    if (sql.includes('timestamp >= ?')) {
+      const v = params[i++];
+      matched = matched.filter((r) => r.timestamp >= v);
+    }
+    if (sql.includes('timestamp <= ?')) {
+      const v = params[i++];
+      matched = matched.filter((r) => r.timestamp <= v);
+    }
+    const actionIn = sql.match(/action IN \(([^)]*)\)/);
+    if (actionIn) {
+      const n = actionIn[1].split(',').length;
+      const vals = params.slice(i, i + n);
+      i += n;
+      matched = matched.filter((r) => vals.includes(r.action));
+    }
+    const resourceIn = sql.match(/resource IN \(([^)]*)\)/);
+    if (resourceIn) {
+      const n = resourceIn[1].split(',').length;
+      const vals = params.slice(i, i + n);
+      i += n;
+      matched = matched.filter((r) => vals.includes(r.resource));
+    }
+    if (sql.includes('status = ?')) {
+      const v = params[i++];
+      matched = matched.filter((r) => r.status === v);
+    }
+    if (sql.includes('LOWER(action) LIKE ?')) {
+      const term = String(params[i]).replace(/%/g, '').toLowerCase();
+      i += 5; // search uses 5 bound params
+      matched = matched.filter(
+        (r) =>
+          r.action.toLowerCase().includes(term) ||
+          r.resource.toLowerCase().includes(term) ||
+          (r.resource_id ?? '').toLowerCase().includes(term) ||
+          (r.user_id ?? '').toLowerCase().includes(term) ||
+          (r.error_message ?? '').toLowerCase().includes(term)
+      );
+    }
+    return { matched, rest: params.slice(i) };
+  }
+
+  const db = {
+    async run(sql: string, params: any[] = []) {
+      if (sql.includes('INSERT INTO audit_events')) {
+        const [
+          timestamp,
+          action,
+          resource,
+          resource_id,
+          user_id,
+          ip,
+          user_agent,
+          before_value,
+          after_value,
+          status,
+          error_message,
+        ] = params;
+        rows.push({
+          id: nextId++,
+          timestamp,
+          action,
+          resource,
+          resource_id,
+          user_id,
+          ip,
+          user_agent,
+          before_value,
+          after_value,
+          status,
+          error_message,
+        });
+        return { lastID: nextId - 1, changes: 1 };
+      }
+      throw new Error(`Unexpected SQL in run(): ${sql}`);
+    },
+    async all(sql: string, params: any[] = []) {
+      if (sql.includes('GROUP BY action, resource, status')) {
+        const { matched } = applyWhere(sql, params);
+        const groups = new Map<string, { action: string; resource: string; status: string; count: number }>();
+        for (const r of matched) {
+          const key = `${r.action}|${r.resource}|${r.status}`;
+          const g = groups.get(key) || { action: r.action, resource: r.resource, status: r.status, count: 0 };
+          g.count++;
+          groups.set(key, g);
+        }
+        return [...groups.values()];
+      }
+      if (sql.includes('SELECT * FROM audit_events')) {
+        const { matched, rest } = applyWhere(sql, params);
+        const [limit, offset] = rest;
+        const ordered = [...matched].sort((a, b) => b.id - a.id);
+        return ordered.slice(offset, offset + limit);
+      }
+      throw new Error(`Unexpected SQL in all(): ${sql}`);
+    },
+    async get() {
+      return undefined;
+    },
+    async exec() {},
+    async transaction(cb: any) {
+      return cb(db);
+    },
+    async close() {},
+  } as unknown as IDatabase;
+
+  return { db, rows };
+}
+
+function makeRepo(connected = true) {
+  const { db, rows } = makeFakeDb();
+  const repo = new AuditEventRepository(
+    () => db,
+    () => connected
+  );
+  return { repo, rows };
+}
+
+const base: Omit<AuditEventRecord, 'timestamp'> = {
+  action: 'CREATE',
+  resource: 'bot',
+  ip: '127.0.0.1',
+  userAgent: 'jest',
+  status: 'success',
+};
+
+function event(overrides: Partial<AuditEventRecord> & { timestamp: string }): AuditEventRecord {
+  return { ...base, ...overrides };
+}
+
+describe('AuditEventRepository', () => {
+  it('persists an event and reads it back', async () => {
+    const { repo, rows } = makeRepo();
+    const ok = await repo.insert(event({ timestamp: '2024-01-01T00:00:00.000Z' }));
+    expect(ok).toBe(true);
+    expect(rows).toHaveLength(1);
+
+    const all = await repo.query();
+    expect(all).toHaveLength(1);
+    expect(all[0]).toMatchObject({ action: 'CREATE', resource: 'bot', status: 'success' });
+  });
+
+  it('round-trips structured before/after values as JSON', async () => {
+    const { repo } = makeRepo();
+    await repo.insert(
+      event({
+        timestamp: '2024-01-01T00:00:00.000Z',
+        action: 'UPDATE',
+        before: { name: 'old' },
+        after: { name: 'new' },
+      })
+    );
+    const [row] = await repo.query();
+    expect(row.before).toEqual({ name: 'old' });
+    expect(row.after).toEqual({ name: 'new' });
+  });
+
+  it('returns false when not connected and does not write', async () => {
+    const { repo, rows } = makeRepo(false);
+    const ok = await repo.insert(event({ timestamp: '2024-01-01T00:00:00.000Z' }));
+    expect(ok).toBe(false);
+    expect(rows).toHaveLength(0);
+  });
+
+  it('orders results newest-first and paginates', async () => {
+    const { repo } = makeRepo();
+    for (let i = 1; i <= 5; i++) {
+      await repo.insert(
+        event({ timestamp: `2024-01-0${i}T00:00:00.000Z`, resourceId: String(i) })
+      );
+    }
+    const firstPage = await repo.query({ limit: 2 });
+    expect(firstPage.map((e) => e.resourceId)).toEqual(['5', '4']);
+
+    const secondPage = await repo.query({ limit: 2, offset: 2 });
+    expect(secondPage.map((e) => e.resourceId)).toEqual(['3', '2']);
+  });
+
+  it('filters by time window, action, resource and status', async () => {
+    const { repo } = makeRepo();
+    await repo.insert(event({ timestamp: '2024-01-01T00:00:00.000Z', action: 'CREATE', resource: 'bot' }));
+    await repo.insert(event({ timestamp: '2024-02-01T00:00:00.000Z', action: 'DELETE', resource: 'user', status: 'failure' }));
+    await repo.insert(event({ timestamp: '2024-03-01T00:00:00.000Z', action: 'UPDATE', resource: 'bot' }));
+
+    const byTime = await repo.query({ startTime: '2024-01-15T00:00:00.000Z', endTime: '2024-02-15T00:00:00.000Z' });
+    expect(byTime.map((e) => e.action)).toEqual(['DELETE']);
+
+    const byAction = await repo.query({ actions: ['CREATE', 'UPDATE'] });
+    expect(byAction.map((e) => e.action).sort()).toEqual(['CREATE', 'UPDATE']);
+
+    const byResource = await repo.query({ resources: ['user'] });
+    expect(byResource).toHaveLength(1);
+
+    const byStatus = await repo.query({ status: 'failure' });
+    expect(byStatus.map((e) => e.action)).toEqual(['DELETE']);
+  });
+
+  it('supports free-text search across fields', async () => {
+    const { repo } = makeRepo();
+    await repo.insert(event({ timestamp: '2024-01-01T00:00:00.000Z', userId: 'alice' }));
+    await repo.insert(event({ timestamp: '2024-01-02T00:00:00.000Z', userId: 'bob', errorMessage: 'permission denied', status: 'failure' }));
+
+    const byUser = await repo.query({ search: 'ALICE' });
+    expect(byUser).toHaveLength(1);
+    expect(byUser[0].userId).toBe('alice');
+
+    const byError = await repo.query({ search: 'denied' });
+    expect(byError).toHaveLength(1);
+    expect(byError[0].userId).toBe('bob');
+  });
+
+  it('computes aggregate stats over a window', async () => {
+    const { repo } = makeRepo();
+    await repo.insert(event({ timestamp: '2024-01-01T00:00:00.000Z', action: 'CREATE', resource: 'bot' }));
+    await repo.insert(event({ timestamp: '2024-01-02T00:00:00.000Z', action: 'CREATE', resource: 'bot' }));
+    await repo.insert(event({ timestamp: '2024-01-03T00:00:00.000Z', action: 'DELETE', resource: 'user', status: 'failure' }));
+
+    const stats = await repo.getStats();
+    expect(stats.total).toBe(3);
+    expect(stats.byAction).toEqual({ CREATE: 2, DELETE: 1 });
+    expect(stats.byResource).toEqual({ bot: 2, user: 1 });
+    expect(stats.byStatus).toEqual({ success: 2, failure: 1 });
+    expect(stats.failureRate).toBeCloseTo((1 / 3) * 100);
+  });
+
+  it('returns empty stats when not connected', async () => {
+    const { repo } = makeRepo(false);
+    const stats = await repo.getStats();
+    expect(stats).toEqual({
+      total: 0,
+      byAction: {},
+      byResource: {},
+      byStatus: { success: 0, failure: 0 },
+      failureRate: 0,
+    });
+  });
+});

--- a/tests/unit/server/middleware/auditLoggerPersistence.test.ts
+++ b/tests/unit/server/middleware/auditLoggerPersistence.test.ts
@@ -1,0 +1,155 @@
+import {
+  auditLogger,
+  type AuditEventStore,
+  type AuditLogEntry,
+  type AuditLogQuery,
+  type AuditLogStats,
+} from '../../../../src/server/middleware/auditLogger';
+
+/** In-memory fake of the durable AuditEventStore for deterministic tests. */
+function makeFakeStore() {
+  const inserted: AuditLogEntry[] = [];
+  let seed: AuditLogEntry[] = [];
+
+  const store: AuditEventStore = {
+    async insert(entry: AuditLogEntry): Promise<boolean> {
+      inserted.push(entry);
+      return true;
+    },
+    async query(filters: AuditLogQuery): Promise<AuditLogEntry[]> {
+      let results = [...seed];
+      if (filters.actions && filters.actions.length > 0) {
+        results = results.filter((e) => filters.actions!.includes(e.action));
+      }
+      if (filters.status) {
+        results = results.filter((e) => e.status === filters.status);
+      }
+      return results;
+    },
+    async getStats(): Promise<AuditLogStats> {
+      const total = seed.length;
+      const failure = seed.filter((e) => e.status === 'failure').length;
+      return {
+        total,
+        byAction: {},
+        byResource: {},
+        byStatus: { success: total - failure, failure },
+        failureRate: total > 0 ? (failure / total) * 100 : 0,
+      };
+    },
+    async getRecent(limit: number): Promise<AuditLogEntry[]> {
+      // newest-first, as the real repository returns
+      return [...seed].reverse().slice(0, limit);
+    },
+  };
+
+  return {
+    store,
+    inserted,
+    setSeed: (events: AuditLogEntry[]) => {
+      seed = events;
+    },
+  };
+}
+
+function entry(overrides: Partial<AuditLogEntry> = {}): Omit<AuditLogEntry, 'timestamp'> {
+  return {
+    action: 'CREATE',
+    resource: 'bot',
+    ip: '127.0.0.1',
+    userAgent: 'jest',
+    status: 'success',
+    ...overrides,
+  };
+}
+
+describe('AuditLoggerService durable persistence', () => {
+  afterEach(() => {
+    // Reset to a clean fake store so tests are isolated.
+    auditLogger.setStore(makeFakeStore().store);
+  });
+
+  it('persists each logged event to the durable store', async () => {
+    const fake = makeFakeStore();
+    auditLogger.setStore(fake.store);
+
+    auditLogger.log(entry({ action: 'CREATE' }));
+    auditLogger.log(entry({ action: 'DELETE', status: 'failure' }));
+
+    // insert is fire-and-forget; flush the microtask queue.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fake.inserted).toHaveLength(2);
+    expect(fake.inserted[0].action).toBe('CREATE');
+    expect(fake.inserted[1].action).toBe('DELETE');
+    // timestamp is stamped by the logger, not the caller.
+    expect(fake.inserted[0].timestamp).toEqual(expect.any(String));
+  });
+
+  it('keeps the synchronous in-memory query working alongside persistence', async () => {
+    const fake = makeFakeStore();
+    auditLogger.setStore(fake.store);
+
+    auditLogger.log(entry({ action: 'UPDATE', resource: 'user' }));
+    const recent = auditLogger.query({ actions: ['UPDATE'] });
+    expect(recent).toHaveLength(1);
+    expect(recent[0].resource).toBe('user');
+  });
+
+  it('hydrates the in-memory cache from the durable store after a restart', async () => {
+    const fake = makeFakeStore();
+    fake.setSeed([
+      {
+        timestamp: '2024-01-01T00:00:00.000Z',
+        action: 'CREATE',
+        resource: 'bot',
+        ip: '10.0.0.1',
+        userAgent: 'prior-process',
+        status: 'success',
+      },
+    ]);
+    auditLogger.setStore(fake.store);
+
+    // Simulate a fresh process: in-memory cache empty, then hydrate from DB.
+    expect(auditLogger.getLogs()).toHaveLength(0);
+    await auditLogger.hydrate();
+
+    const logs = auditLogger.getLogs();
+    expect(logs).toHaveLength(1);
+    expect(logs[0].userAgent).toBe('prior-process');
+  });
+
+  it('queryPersisted reads from the durable store', async () => {
+    const fake = makeFakeStore();
+    fake.setSeed([
+      {
+        timestamp: '2024-02-01T00:00:00.000Z',
+        action: 'DELETE',
+        resource: 'user',
+        ip: '10.0.0.2',
+        userAgent: 'db',
+        status: 'failure',
+      },
+    ]);
+    auditLogger.setStore(fake.store);
+
+    const results = await auditLogger.queryPersisted({ status: 'failure' });
+    expect(results).toHaveLength(1);
+    expect(results[0].action).toBe('DELETE');
+  });
+
+  it('getStatsPersisted aggregates from the durable store', async () => {
+    const fake = makeFakeStore();
+    fake.setSeed([
+      { timestamp: '2024-03-01T00:00:00.000Z', action: 'CREATE', resource: 'bot', ip: '', userAgent: '', status: 'success' },
+      { timestamp: '2024-03-02T00:00:00.000Z', action: 'DELETE', resource: 'bot', ip: '', userAgent: '', status: 'failure' },
+    ]);
+    auditLogger.setStore(fake.store);
+
+    const stats = await auditLogger.getStatsPersisted();
+    expect(stats.total).toBe(2);
+    expect(stats.byStatus).toEqual({ success: 1, failure: 1 });
+    expect(stats.failureRate).toBeCloseTo(50);
+  });
+});


### PR DESCRIPTION
## What
Adds durable database persistence for the request/security audit trail produced by `src/server/middleware/auditLogger.ts`, while keeping the existing query/stats/filter API intact.

- New `audit_events` table + indexes in `LoggingSchemas` (Postgres `SERIAL` / SQLite `AUTOINCREMENT` aware, matching the existing `ActivitySchemas` pattern).
- New `AuditEventRepository` (`src/database/repositories/AuditEventRepository.ts`) with `insert` / `query` / `getStats` / `getRecent`, mirroring the in-memory filter and pagination semantics (time window, action/resource IN, status, free-text search, newest-first, limit/offset).
- Wired through `DatabaseManager` (repo init + delegate methods + type re-exports), following the established repository delegation pattern.
- `AuditLoggerService` now:
  - persists every logged event to the store (fire-and-forget; never blocks the request path),
  - can `hydrate()` its in-memory cache from the store after a restart,
  - exposes `queryPersisted` / `getStatsPersisted` for durable reads,
  - accepts an injectable `AuditEventStore` (defaults to a lazy `DatabaseManager`-backed store) for testability.

## Why
The audit logger stored events only in a volatile in-memory array capped at 1000 entries. The entire audit trail was lost on every process restart, and old entries were silently dropped past the cap with no durable record — unsuitable for a security audit log.

## Behavior
- Existing synchronous API (`log`, `getLogs*`, `query`, `getStats`) is unchanged and still backed by the in-memory cache for fast, non-blocking reads.
- Each `log()` call additionally writes to `audit_events`. Persistence is best-effort: if the DB is unconfigured/unavailable, the write is skipped silently and the request path is unaffected.
- `queryPersisted` / `getStatsPersisted` read from the DB and fall back to the in-memory cache when the store yields nothing (e.g. DB not configured).
- After a restart, `hydrate()` reloads recent persisted events into the in-memory cache so the existing sync API survives restarts.
- The `audit_events` table is created automatically on connect via the schema registry (no manual migration step).

## Verification
- Backend `npx tsc --noEmit`: clean.
- Frontend `cd src/client && npx tsc --noEmit`: clean (no frontend files changed).
- New unit tests pass:
  - `tests/unit/repositories/AuditEventRepository.test.ts` (insert, JSON round-trip of before/after, disconnected no-op, newest-first pagination, time/action/resource/status filters, free-text search, aggregate stats).
  - `tests/unit/server/middleware/auditLoggerPersistence.test.ts` (insert wiring, sync API coexistence, restart hydration, durable query/stats).
- Existing `tests/unit/server/routes/auditRoutes.test.ts` and `tests/database/DatabaseManager.test.ts` still pass.

Note: repo-wide `eslint` is currently broken in the shared install (ajv `missingRefs` error reproduces on unchanged files and even on `eslint --version`), so it could not be run; the new code mirrors the lint-conforming style of neighboring repositories.