### PR TITLE
feat(models): live model-list query with static fallback (OpenAI/OpenWebUI)

### DIFF
--- a/src/server/routes/admin/monitoring.ts
+++ b/src/server/routes/admin/monitoring.ts
@@ -16,6 +16,7 @@ import {
   getModelsForProvider,
   getSupportedProviders,
 } from '../../data/llmModels';
+import { getLiveModelsForProvider, supportsLiveModels } from '../../services/LiveModelService';
 import { PipelineDebuggerService } from '../../services/PipelineDebuggerService';
 
 const debug = Debug('open-hivemind:admin:monitoring');
@@ -392,10 +393,11 @@ router.get('/system-info', async (req: Request, res: Response) => {
  *       200:
  *         description: List of available models with metadata
  */
-router.get('/llm-providers/:type/models', (req: Request, res: Response) => {
+router.get('/llm-providers/:type/models', async (req: Request, res: Response) => {
   try {
     const { type } = req.params;
     const { modelType } = req.query;
+    const live = req.query.live === 'true' || req.query.live === '1';
 
     // Validate provider type
     const supportedProviders = getSupportedProviders();
@@ -403,6 +405,22 @@ router.get('/llm-providers/:type/models', (req: Request, res: Response) => {
       return res.status(HTTP_STATUS.BAD_REQUEST).json({
         error: `Unsupported provider type '${type}'. Supported providers: ${supportedProviders.join(', ')}`,
         code: 'INVALID_PROVIDER_TYPE',
+      });
+    }
+
+    // Live query (opt-in via ?live=true) for providers that expose a model list
+    // endpoint (e.g. OpenAI, OpenWebUI). Falls back to the static list on
+    // failure or for unsupported providers. The type filter is only applied to
+    // the static list, since live ids do not carry reliable chat/embedding tags.
+    if (live && !modelType && supportsLiveModels(type)) {
+      const { models, source } = await getLiveModelsForProvider(type);
+      return res.json({
+        success: true,
+        provider: type,
+        modelType: 'all',
+        source,
+        count: models.length,
+        models,
       });
     }
 
@@ -420,6 +438,7 @@ router.get('/llm-providers/:type/models', (req: Request, res: Response) => {
       success: true,
       provider: type,
       modelType: (modelType as string) || 'all',
+      source: 'static',
       count: models.length,
       models,
     });

--- a/src/server/routes/admin/systemInfo.ts
+++ b/src/server/routes/admin/systemInfo.ts
@@ -11,6 +11,7 @@ import {
   getModelsForProvider,
   getSupportedProviders,
 } from '../../data/llmModels';
+import { getLiveModelsForProvider, supportsLiveModels } from '../../services/LiveModelService';
 import { PanicModeService } from '../../services/PanicModeService';
 
 const router = Router();
@@ -179,10 +180,11 @@ router.get('/system-info', async (req: Request, res: Response) => {
  *       200:
  *         description: List of available models with metadata
  */
-router.get('/llm-providers/:type/models', (req: Request, res: Response) => {
+router.get('/llm-providers/:type/models', async (req: Request, res: Response) => {
   try {
     const { type } = req.params;
     const { modelType } = req.query;
+    const live = req.query.live === 'true' || req.query.live === '1';
 
     // Validate provider type
     const supportedProviders = getSupportedProviders();
@@ -190,6 +192,22 @@ router.get('/llm-providers/:type/models', (req: Request, res: Response) => {
       return res.status(HTTP_STATUS.BAD_REQUEST).json({
         error: `Unsupported provider type '${type}'. Supported providers: ${supportedProviders.join(', ')}`,
         code: 'INVALID_PROVIDER_TYPE',
+      });
+    }
+
+    // Live query (opt-in via ?live=true) for providers that expose a model list
+    // endpoint (e.g. OpenAI, OpenWebUI). Falls back to the static list on
+    // failure or for unsupported providers. The type filter is only applied to
+    // the static list, since live ids do not carry reliable chat/embedding tags.
+    if (live && !modelType && supportsLiveModels(type)) {
+      const { models, source } = await getLiveModelsForProvider(type);
+      return res.json({
+        success: true,
+        provider: type,
+        modelType: 'all',
+        source,
+        count: models.length,
+        models,
       });
     }
 
@@ -207,6 +225,7 @@ router.get('/llm-providers/:type/models', (req: Request, res: Response) => {
       success: true,
       provider: type,
       modelType: (modelType as string) || 'all',
+      source: 'static',
       count: models.length,
       models,
     });

--- a/src/server/services/LiveModelService.ts
+++ b/src/server/services/LiveModelService.ts
@@ -1,0 +1,132 @@
+import Debug from 'debug';
+import OpenAI from 'openai';
+import openaiConfig from '../../config/openaiConfig';
+import openWebUIConfig from '../../config/openWebUIConfig';
+import { getModelsForProvider, type ModelMetadata } from '../data/llmModels';
+
+const debug = Debug('app:webui:live-model-service');
+
+/**
+ * Result of a live model lookup, including whether the data came from a live
+ * provider query or the static curated fallback.
+ */
+export interface LiveModelResult {
+  models: ModelMetadata[];
+  /** 'live' when fetched from the provider, 'static' when served from the curated list. */
+  source: 'live' | 'static';
+}
+
+/**
+ * Providers for which we can query a live model list. OpenAI and OpenWebUI both
+ * expose an OpenAI-compatible `GET /models` endpoint, so a single OpenAI SDK
+ * client (pointed at the appropriate base URL) covers both.
+ */
+const LIVE_PROVIDERS = new Set(['openai', 'openwebui']);
+
+/**
+ * Whether a provider supports a live model-list query.
+ */
+export function supportsLiveModels(providerId: string): boolean {
+  return LIVE_PROVIDERS.has(providerId.toLowerCase());
+}
+
+interface LiveClientSettings {
+  apiKey: string;
+  baseURL: string;
+}
+
+/**
+ * Resolve the OpenAI-compatible client settings (API key + base URL) for a
+ * provider, or null when the provider has no live endpoint / is unconfigured.
+ */
+function resolveClientSettings(providerId: string): LiveClientSettings | null {
+  const normalized = providerId.toLowerCase();
+
+  if (normalized === 'openai') {
+    const apiKey = openaiConfig.get('OPENAI_API_KEY');
+    if (!apiKey) {
+      debug('OpenAI API key not configured; cannot query live models');
+      return null;
+    }
+    return { apiKey, baseURL: openaiConfig.get('OPENAI_BASE_URL') };
+  }
+
+  if (normalized === 'openwebui') {
+    // OpenWebUI exposes an OpenAI-compatible API. The configured URL points at
+    // `/api/`; the OpenAI-compatible model list lives under `/api/v1`.
+    const rawUrl = openWebUIConfig.get('OPEN_WEBUI_API_URL') as string;
+    const baseURL = `${rawUrl.replace(/\/+$/, '')}/v1`;
+    // OpenWebUI authenticates with a bearer token (its password/JWT). When absent
+    // we still attempt the call; the SDK requires a non-empty key placeholder.
+    const apiKey = (openWebUIConfig.get('OPEN_WEBUI_PASSWORD') as string) || 'sk-openwebui';
+    return { apiKey, baseURL };
+  }
+
+  return null;
+}
+
+/**
+ * Map a raw provider model id to our ModelMetadata shape, enriching with static
+ * metadata when we already know the model, otherwise returning a minimal record.
+ */
+function toModelMetadata(providerId: string, modelId: string): ModelMetadata {
+  const known = getModelsForProvider(providerId).find((m) => m.id === modelId);
+  if (known) {
+    return known;
+  }
+  return {
+    id: modelId,
+    name: modelId,
+    description: 'Live model reported by provider',
+    type: 'chat',
+  };
+}
+
+/**
+ * Fetch the live model list for a provider, falling back to the curated static
+ * list when the provider has no live endpoint, is unconfigured, or the request
+ * fails for any reason. Never throws.
+ */
+export async function getLiveModelsForProvider(
+  providerId: string,
+  options: { timeoutMs?: number } = {}
+): Promise<LiveModelResult> {
+  const normalized = providerId.toLowerCase();
+  const staticModels = getModelsForProvider(normalized);
+
+  if (!supportsLiveModels(normalized)) {
+    return { models: staticModels, source: 'static' };
+  }
+
+  const settings = resolveClientSettings(normalized);
+  if (!settings) {
+    return { models: staticModels, source: 'static' };
+  }
+
+  try {
+    const client = new OpenAI({
+      apiKey: settings.apiKey,
+      baseURL: settings.baseURL,
+      timeout: options.timeoutMs ?? 10000,
+      maxRetries: 0,
+    });
+
+    const list = await client.models.list();
+    const ids = list.data.map((m) => m.id).filter((id): id is string => Boolean(id));
+
+    if (ids.length === 0) {
+      debug('Live model list for %s was empty; falling back to static', normalized);
+      return { models: staticModels, source: 'static' };
+    }
+
+    const models = ids.map((id) => toModelMetadata(normalized, id));
+    return { models, source: 'live' };
+  } catch (error) {
+    debug(
+      'Live model query for %s failed (%s); falling back to static',
+      normalized,
+      error instanceof Error ? error.message : String(error)
+    );
+    return { models: staticModels, source: 'static' };
+  }
+}

--- a/tests/unit/server/services/LiveModelService.test.ts
+++ b/tests/unit/server/services/LiveModelService.test.ts
@@ -1,0 +1,100 @@
+import { getModelsForProvider } from '../../../../src/server/data/llmModels';
+import {
+  getLiveModelsForProvider,
+  supportsLiveModels,
+} from '../../../../src/server/services/LiveModelService';
+
+/**
+ * Tests for LiveModelService, which queries a provider's live model-list
+ * endpoint (OpenAI-compatible `GET /models`) and falls back to the curated
+ * static list on failure / for unsupported providers.
+ *
+ * The OpenAI SDK and the provider config modules are mocked so no network
+ * calls are made and the live branch is deterministically exercised.
+ */
+
+const mockModelsList = jest.fn();
+
+jest.mock('openai', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    models: { list: mockModelsList },
+  })),
+}));
+
+// Provide a non-empty OpenAI API key so the live branch is attempted regardless
+// of the real environment / config files.
+jest.mock('../../../../src/config/openaiConfig', () => {
+  const get = (key: string): string => {
+    if (key === 'OPENAI_API_KEY') return 'sk-test-key';
+    return 'https://api.openai.com/v1';
+  };
+  return { __esModule: true, default: { get } };
+});
+
+describe('LiveModelService', () => {
+  beforeEach(() => {
+    mockModelsList.mockReset();
+  });
+
+  describe('supportsLiveModels', () => {
+    it('reports live support for openai and openwebui', () => {
+      expect(supportsLiveModels('openai')).toBe(true);
+      expect(supportsLiveModels('OpenAI')).toBe(true);
+      expect(supportsLiveModels('openwebui')).toBe(true);
+    });
+
+    it('reports no live support for providers without a model-list endpoint', () => {
+      expect(supportsLiveModels('anthropic')).toBe(false);
+      expect(supportsLiveModels('google')).toBe(false);
+    });
+  });
+
+  describe('getLiveModelsForProvider', () => {
+    it('returns live models from the provider when the query succeeds', async () => {
+      mockModelsList.mockResolvedValue({
+        data: [{ id: 'gpt-4o' }, { id: 'some-new-future-model' }],
+      });
+
+      const result = await getLiveModelsForProvider('openai');
+
+      expect(result.source).toBe('live');
+      const ids = result.models.map((m) => m.id);
+      expect(ids).toContain('gpt-4o');
+      expect(ids).toContain('some-new-future-model');
+
+      // Known models are enriched from the static metadata.
+      const known = result.models.find((m) => m.id === 'gpt-4o');
+      expect(known?.name).toBe('GPT-4o');
+      // Unknown models get a minimal metadata record.
+      const unknown = result.models.find((m) => m.id === 'some-new-future-model');
+      expect(unknown?.type).toBe('chat');
+    });
+
+    it('falls back to the static list when the live query throws', async () => {
+      mockModelsList.mockRejectedValue(new Error('network down'));
+
+      const result = await getLiveModelsForProvider('openai');
+
+      expect(result.source).toBe('static');
+      expect(result.models).toEqual(getModelsForProvider('openai'));
+    });
+
+    it('falls back to the static list when the live query returns no models', async () => {
+      mockModelsList.mockResolvedValue({ data: [] });
+
+      const result = await getLiveModelsForProvider('openai');
+
+      expect(result.source).toBe('static');
+      expect(result.models).toEqual(getModelsForProvider('openai'));
+    });
+
+    it('returns the static list without a live query for unsupported providers', async () => {
+      const result = await getLiveModelsForProvider('anthropic');
+
+      expect(result.source).toBe('static');
+      expect(mockModelsList).not.toHaveBeenCalled();
+      expect(result.models).toEqual(getModelsForProvider('anthropic'));
+    });
+  });
+});


### PR DESCRIPTION
## What
Completes the partially-implemented **live model listing** feature. Previously `GET /api/admin/llm-providers/:type/models` (served from both `systemInfo.ts` and `monitoring.ts`) returned **only** the curated static list in `src/server/data/llmModels.ts`, so the UI model picker was hardcoded.

This adds a live model-list query for providers that support it, with a safe fallback to the static list.

## Why
The static list goes stale (new models ship constantly) and cannot reflect models actually available on a self-hosted / custom endpoint. Operators want to see the models their configured provider really exposes.

## Behavior
- New `src/server/services/LiveModelService.ts`:
  - `supportsLiveModels(provider)` -> true for `openai` and `openwebui` (both expose an OpenAI-compatible `GET /models`).
  - `getLiveModelsForProvider(provider)` uses the official `openai` SDK (pointed at the provider's configured base URL + key) to list models. Known ids are enriched from the static metadata; unknown ids get a minimal record. **Never throws** — falls back to the static list on any error, empty result, missing key, or unsupported provider.
- Both `/llm-providers/:type/models` endpoints now accept opt-in **`?live=true`** (only on the unfiltered/all path; `modelType=chat|embedding` filtering stays static since live ids lack reliable type tags). Responses include a `source: 'live' | 'static'` field. Default behavior (no `live` param) is unchanged.

## Scope
Intentionally scoped to **2 providers** (OpenAI + OpenWebUI) since both share the OpenAI-compatible `/models` contract and a single SDK client covers them. Other providers (anthropic, google, perplexity) continue to serve the static list. Opt-in via query param means no change to existing callers.

## Verification
- Backend `npx tsc --noEmit`: clean
- ESLint on all changed src + test files: 0 errors
- New unit test `tests/unit/server/services/LiveModelService.test.ts`: 6/6 passing (live success, error fallback, empty fallback, unsupported-provider static, support flags)
- Existing `monitoringAnomalies.test.ts` (same router file): 3/3 still passing

Does NOT touch startup, the default pipeline, auth, or the live DB path.