### PR TITLE
fix(flowise): report completion support accurately and make path explicit

### DIFF
--- a/packages/llm-flowise/src/flowiseProvider.test.ts
+++ b/packages/llm-flowise/src/flowiseProvider.test.ts
@@ -50,6 +50,30 @@ describe('FlowiseProvider', () => {
     expect(result).toMatch(/error communicating/);
   });
 
+  it('reports completion support accurately', () => {
+    expect(provider.supportsCompletion()).toBe(true);
+    expect(provider.supportsChatCompletion()).toBe(true);
+  });
+
+  it('generateCompletion uses the SDK prediction endpoint when useRest is false', async () => {
+    const result = await provider.generateCompletion('write a haiku');
+    expect(getFlowiseSdkResponse).toHaveBeenCalledWith('write a haiku', 'flow-123');
+    expect(result).toBe('sdk response');
+  });
+
+  it('generateCompletion uses a dedicated stateless channel in REST mode', async () => {
+    provider = new FlowiseProvider({ useRest: true });
+    const result = await provider.generateCompletion('write a haiku');
+    expect(getFlowiseResponse).toHaveBeenCalledWith('flowise-completion', 'write a haiku');
+    expect(result).toBe('rest response');
+  });
+
+  it('generateCompletion returns error string when the client throws', async () => {
+    (getFlowiseSdkResponse as jest.Mock).mockRejectedValueOnce(new Error('timeout'));
+    const result = await provider.generateCompletion('write a haiku');
+    expect(result).toMatch(/error communicating/);
+  });
+
   it('validateCredentials returns true for REST mode', async () => {
     provider = new FlowiseProvider({ useRest: true });
     expect(await provider.validateCredentials()).toBe(true);

--- a/packages/llm-flowise/src/flowiseProvider.ts
+++ b/packages/llm-flowise/src/flowiseProvider.ts
@@ -16,11 +16,40 @@ export class FlowiseProvider implements ILlmProvider {
   }
 
   supportsCompletion(): boolean {
-    return false;
+    // Flowise exposes a single `/prediction/{chatflowId}` endpoint that accepts a
+    // `question` and returns text. This serves single-turn completions as well as
+    // chat, so non-chat completion is supported.
+    return true;
   }
 
   supportsChatCompletion(): boolean {
     return true;
+  }
+
+  /**
+   * Sends a single question to Flowise's prediction endpoint and returns the
+   * text. Shared by both chat and completion paths. The `channelId` keys the
+   * stateful chat session (REST mode) so independent conversations stay
+   * isolated; completion uses a dedicated stateless channel id.
+   */
+  private async predict(channelId: string, question: string): Promise<string> {
+    flowiseDebug(`Sending request to Flowise for channel ${channelId}`);
+
+    const useRest =
+      this.config.useRest !== undefined
+        ? this.config.useRest
+        : flowiseConfig.get('FLOWISE_USE_REST');
+
+    if (useRest) {
+      return getFlowiseResponse(channelId, question);
+    }
+
+    const chatflowId =
+      this.config.chatflowId || flowiseConfig.get('FLOWISE_CONVERSATION_CHATFLOW_ID');
+    if (!chatflowId) {
+      throw new Error('FLOWISE_CONVERSATION_CHATFLOW_ID is not set.');
+    }
+    return getFlowiseSdkResponse(question, chatflowId);
   }
 
   async generateChatCompletion(
@@ -35,34 +64,26 @@ export class FlowiseProvider implements ILlmProvider {
     }
 
     try {
-      flowiseDebug(`Sending request to Flowise for channel ${channelId}`);
-      let response: string;
-
-      const useRest =
-        this.config.useRest !== undefined
-          ? this.config.useRest
-          : flowiseConfig.get('FLOWISE_USE_REST');
-
-      if (useRest) {
-        response = await getFlowiseResponse(channelId, userMessage);
-      } else {
-        const chatflowId =
-          this.config.chatflowId || flowiseConfig.get('FLOWISE_CONVERSATION_CHATFLOW_ID');
-        if (!chatflowId) {
-          throw new Error('FLOWISE_CONVERSATION_CHATFLOW_ID is not set.');
-        }
-        response = await getFlowiseSdkResponse(userMessage, chatflowId);
-      }
-      return response;
+      return await this.predict(channelId, userMessage);
     } catch (error) {
       flowiseDebug('Error getting response from Flowise:', error);
       return 'There was an error communicating with the AI service.';
     }
   }
 
+  /**
+   * Single-turn, stateless text completion. Flowise has no separate completion
+   * endpoint, so this hits the same `/prediction/{chatflowId}` endpoint with a
+   * dedicated channel id that is kept isolated from interactive chat sessions.
+   */
   async generateCompletion(prompt: string): Promise<string> {
-    flowiseDebug('generateCompletion is not supported, redirecting to generateChatCompletion.');
-    return this.generateChatCompletion(prompt, [], { channelId: 'default-completion' });
+    flowiseDebug('generateCompletion: using stateless Flowise prediction.');
+    try {
+      return await this.predict('flowise-completion', prompt);
+    } catch (error) {
+      flowiseDebug('Error getting completion from Flowise:', error);
+      return 'There was an error communicating with the AI service.';
+    }
   }
 
   async validateCredentials(): Promise<boolean> {


### PR DESCRIPTION
## What
Aligns the Flowise provider's reported capabilities with its actual behavior and makes the completion path explicit.

- `supportsCompletion()` now returns `true` (was `false`).
- `generateCompletion()` calls Flowise's prediction endpoint directly via a new shared `predict()` helper, using a dedicated stateless `flowise-completion` channel id instead of silently masquerading as chat with a magic `default-completion` channelId.

## Why
Flowise exposes a single `/prediction/{chatflowId}` endpoint that accepts a `question` and returns text — this serves single-turn completion just as well as chat. Previously `supportsCompletion()` returned `false` while `generateCompletion()` quietly redirected through `generateChatCompletion()`, so the capability was misreported. Consumers like `StartupGreetingService` and `ai-assist.ts` branch on `supportsCompletion()`, and sibling providers (openwebui, openswarm) already report `true` for the equivalent endpoint. This makes Flowise consistent and accurate.

## Behavior
- Completion now hits the real prediction endpoint (REST: `getFlowiseResponse('flowise-completion', prompt)`; SDK: `getFlowiseSdkResponse(prompt, chatflowId)`).
- The dedicated channel id keeps stateless completions isolated from interactive REST chat sessions.
- Chat completion behavior is unchanged (refactored to share the `predict()` helper).
- Errors are caught and return the existing user-facing error string.

## Verification
- `tsc --noEmit`: clean
- eslint on changed files: 0 errors
- `jest packages/llm-flowise/src/flowiseProvider.test.ts`: 10/10 pass (4 new: completion-support reporting, REST path, SDK path, error path)