### PR TITLE
fix(mattermost): surface typing-indicator failures via debug logging

### DIFF
--- a/packages/message-mattermost/src/MattermostService.ts
+++ b/packages/message-mattermost/src/MattermostService.ts
@@ -671,7 +671,11 @@ export class MattermostService extends EventEmitter implements IMessengerService
         return;
       }
       await client.sendTyping(channelId, threadId);
-    } catch {}
+    } catch (error: unknown) {
+      // Typing indicators are best-effort; surface the failure via debug
+      // logging rather than swallowing it silently so issues are diagnosable.
+      debug('sendTyping failed: %s', error instanceof Error ? error.message : String(error));
+    }
   }
 
   public async setModelActivity(modelId: string, senderKey?: string): Promise<void> {

--- a/packages/message-mattermost/src/mattermostTyping.test.ts
+++ b/packages/message-mattermost/src/mattermostTyping.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Regression test for audit (mattermost-typing):
+ * MattermostClient.sendTyping() must POST the Mattermost typing endpoint
+ * `/users/{user_id}/typing` with a `{ channel_id, parent_id }` payload, and
+ * must surface failures via debug logging rather than throwing or silently
+ * swallowing them. MattermostService.sendTyping() must likewise not throw.
+ */
+
+jest.mock('@src/config/BotConfigurationManager', () => ({
+  __esModule: true,
+  default: {
+    getInstance: jest.fn().mockReturnValue({ getAllBots: jest.fn().mockReturnValue([]) }),
+  },
+}));
+
+import MattermostClient from './mattermostClient';
+
+describe('MattermostClient.sendTyping', () => {
+  const build = () => {
+    const client = new MattermostClient({ serverUrl: 'https://mm.example.com', token: 'tok' });
+    (client as unknown as { connected: boolean }).connected = true;
+    jest.spyOn(client, 'getCurrentUserId').mockReturnValue('botUser');
+    const post = jest.fn().mockResolvedValue(undefined);
+    (client as unknown as { api: { post: typeof post } }).api = { post } as never;
+    return { client, post };
+  };
+
+  it('POSTs the correct typing endpoint and payload', async () => {
+    const { client, post } = build();
+
+    await client.sendTyping('chan1', 'root42');
+
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledWith('/users/botUser/typing', {
+      channel_id: 'chan1',
+      parent_id: 'root42',
+    });
+  });
+
+  it('defaults parent_id to empty string when no thread id is supplied', async () => {
+    const { client, post } = build();
+
+    await client.sendTyping('chan1');
+
+    expect(post).toHaveBeenCalledWith('/users/botUser/typing', {
+      channel_id: 'chan1',
+      parent_id: '',
+    });
+  });
+
+  it('does not POST when the client is not connected', async () => {
+    const { client, post } = build();
+    (client as unknown as { connected: boolean }).connected = false;
+
+    await client.sendTyping('chan1');
+
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('swallows POST failures (best-effort) instead of throwing', async () => {
+    const { client, post } = build();
+    post.mockRejectedValue(new Error('boom'));
+
+    await expect(client.sendTyping('chan1')).resolves.toBeUndefined();
+  });
+});
+
+describe('MattermostService.sendTyping', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('delegates to the resolved client and surfaces failures without throwing', async () => {
+    const { MattermostService } = await import('./MattermostService');
+    const service = MattermostService.getInstance();
+
+    const failing = {
+      sendTyping: jest.fn().mockRejectedValue(new Error('network down')),
+    };
+    (service as unknown as { clients: Map<string, unknown> }).clients.set('bot1', failing);
+
+    // Must not throw even though the underlying client rejects.
+    await expect(service.sendTyping('chan1', 'bot1', 'thread1')).resolves.toBeUndefined();
+    expect(failing.sendTyping).toHaveBeenCalledWith('chan1', 'thread1');
+
+    await service.shutdown();
+  });
+});


### PR DESCRIPTION
## What
`MattermostService.sendTyping()` previously wrapped its body in `try { ... } catch {}`, silently discarding every error (client lookup failures, network errors bubbling up, etc.). This replaces the empty catch with a `debug()` log so best-effort typing failures remain diagnosable.

The underlying `MattermostClient.sendTyping()` was already correct — it POSTs the documented Mattermost endpoint `POST /api/v4/users/{user_id}/typing` with a `{ channel_id, parent_id }` payload and logs failures via `logger.debug`. This PR brings the service wrapper in line with that pattern and adds the missing test coverage.

## Why
Silent `catch {}` blocks hide real failures (auth/permission/server-support issues) with no trace, making the typing feature undebuggable in production.

## Behavior
- Typing indicators stay best-effort: no error ever propagates to callers.
- Failures are now logged via the `app:MattermostService:verbose` debug namespace instead of vanishing.
- No change to the wire request — endpoint and payload are unchanged (now covered by tests).

## Verification
- `npx tsc --noEmit` — clean.
- New suite `packages/message-mattermost/src/mattermostTyping.test.ts` (5 tests) passes: asserts correct endpoint/payload, `parent_id` defaulting, no-POST-when-disconnected, and best-effort no-throw on failure at both client and service layers.
- Existing `mattermost.test.ts` + `mattermostReceive.test.ts` still pass (6 tests).
- ESLint could not run in this worktree due to a pre-existing ajv/pnpm module-load crash that reproduces on unchanged files (not related to this change).