### PR TITLE
fix(slack): register RTM message handler for primary bot

### DIFF
--- a/packages/message-slack/src/SlackBotManager.rtm.test.ts
+++ b/packages/message-slack/src/SlackBotManager.rtm.test.ts
@@ -1,0 +1,116 @@
+import { EventEmitter } from 'events';
+
+// --- Mock the Slack SDK clients so no network calls happen ---
+
+// RTM client: records the 'message' handler and lets the test emit events.
+const rtmInstances: MockRTMClient[] = [];
+class MockRTMClient extends EventEmitter {
+  public started = false;
+  constructor(public token: string) {
+    super();
+    rtmInstances.push(this);
+  }
+  async start() {
+    this.started = true;
+    return {};
+  }
+  async disconnect() {
+    this.started = false;
+  }
+}
+
+class MockSocketModeClient extends EventEmitter {
+  async start() {
+    return {};
+  }
+  async disconnect() {
+    return undefined;
+  }
+}
+
+const authTestMock = jest.fn().mockResolvedValue({ user_id: 'UPRIMARY', user: 'primarybot' });
+class MockWebClient {
+  public auth = { test: authTestMock };
+  public conversations = { history: jest.fn().mockResolvedValue({ messages: [] }) };
+  constructor(public token: string) {}
+}
+
+jest.mock('@slack/rtm-api', () => ({
+  RTMClient: jest.fn().mockImplementation((token: string) => new MockRTMClient(token)),
+}));
+jest.mock('@slack/socket-mode', () => ({
+  SocketModeClient: jest.fn().mockImplementation(() => new MockSocketModeClient()),
+}));
+jest.mock('@slack/web-api', () => ({
+  WebClient: jest.fn().mockImplementation((token: string) => new MockWebClient(token)),
+}));
+
+import { SlackBotManager } from './SlackBotManager';
+
+describe('SlackBotManager RTM receive (primary bot)', () => {
+  beforeEach(() => {
+    rtmInstances.length = 0;
+    authTestMock.mockClear();
+  });
+
+  it('registers an RTM message handler for the primary bot and forwards incoming messages', async () => {
+    const manager = new SlackBotManager([{ token: 'xoxb-primary' }], 'rtm');
+
+    const handler = jest.fn().mockResolvedValue('ok');
+    manager.setMessageHandler(handler);
+
+    await manager.initialize();
+
+    // The RTM client for the primary bot must have been constructed and started.
+    expect(rtmInstances.length).toBe(1);
+    const rtm = rtmInstances[0];
+    expect(rtm.started).toBe(true);
+
+    // Simulate an inbound channel message from another user.
+    rtm.emit('message', {
+      type: 'message',
+      text: 'hello from rtm',
+      user: 'USOMEONE',
+      channel: 'C123',
+      ts: '1700000000.000100',
+    });
+
+    // Allow the async handler in the listener to run.
+    await new Promise((r) => setImmediate(r));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const [msgArg, , botConfig] = handler.mock.calls[0];
+    expect(msgArg.getText()).toBe('hello from rtm');
+    expect(botConfig.token).toBe('xoxb-primary');
+  });
+
+  it('ignores self-authored and empty RTM messages', async () => {
+    const manager = new SlackBotManager([{ token: 'xoxb-primary' }], 'rtm');
+    const handler = jest.fn().mockResolvedValue('ok');
+    manager.setMessageHandler(handler);
+    await manager.initialize();
+
+    const rtm = rtmInstances[0];
+
+    // Self message (user === bot user id resolved from auth.test => UPRIMARY)
+    rtm.emit('message', {
+      type: 'message',
+      text: 'echo',
+      user: 'UPRIMARY',
+      channel: 'C123',
+      ts: '1700000000.000200',
+    });
+    // Empty text
+    rtm.emit('message', {
+      type: 'message',
+      text: '',
+      user: 'USOMEONE',
+      channel: 'C123',
+      ts: '1700000000.000300',
+    });
+
+    await new Promise((r) => setImmediate(r));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/packages/message-slack/src/SlackBotManager.ts
+++ b/packages/message-slack/src/SlackBotManager.ts
@@ -196,6 +196,58 @@ export class SlackBotManager {
             reject(networkError);
           }
         }
+      } else if (this.mode === 'rtm' && primaryBot.rtmClient) {
+        primaryBot.rtmClient.on('message', async (event: any) => {
+          debug(`RTM message event received: ${JSON.stringify(event)}`);
+          // RTM emits the raw event with a `ts` field (socket mode uses `event_ts`).
+          const eventId = event.ts;
+          if (this.processedEvents.has(eventId)) {
+            debug(`Duplicate message event skipped: event_id=${eventId}`);
+            return;
+          }
+
+          if (!event.text || event.subtype === 'bot_message' || allBotUserIds.includes(event.user)) {
+            debug('Message event filtered out: no text, bot message, or self-message');
+            return;
+          }
+
+          const channel = event.channel || 'unknown';
+          const lastTs = this.lastEventTsByChannel.get(channel);
+          if (lastTs === event.ts) {
+            debug(`Duplicate message TS detected in channel ${channel}: ${event.ts}`);
+            return;
+          }
+          this.lastEventTsByChannel.set(channel, event.ts);
+          this.processedEvents.add(eventId);
+
+          debug(`Primary bot received channel message: ${event.text}`);
+          if (this.messageHandler) {
+            const slackMessage = new SlackMessage(event.text, event.channel, event as any);
+            const history = this.includeHistory
+              ? await this.fetchMessagesForBot(primaryBot, event.channel, 10)
+              : [];
+            await this.messageHandler(slackMessage, history, primaryBot.config);
+          } else {
+            debug('No message handler set for message event');
+          }
+        });
+
+        try {
+          debug('Starting primary RTM client');
+          await primaryBot.rtmClient.start();
+          debug('Primary RTM client started for channels');
+          resolve();
+        } catch (error: unknown) {
+          const hivemindError = ErrorUtils.toHivemindError(error) as any;
+          const errorInfo = ErrorUtils.classifyError(hivemindError);
+          debug('Failed to start primary RTM client:', {
+            error: hivemindError.message,
+            errorCode: hivemindError.code,
+            errorType: errorInfo.type,
+            severity: errorInfo.severity,
+          });
+          reject(hivemindError);
+        }
       }
 
       for (const botInfo of this.slackBots) {
@@ -287,6 +339,40 @@ export class SlackBotManager {
             }
           }
         } else if (this.mode === 'rtm' && botInfo.rtmClient) {
+          botInfo.rtmClient.on('message', async (event: any) => {
+            debug(`RTM message event received: ${JSON.stringify(event)}`);
+            const eventId = event.ts;
+            if (this.processedEvents.has(eventId)) {
+              debug(`Duplicate message event skipped: event_id=${eventId}`);
+              return;
+            }
+
+            if (
+              event.channel_type !== 'im' ||
+              !event.text ||
+              event.subtype === 'bot_message' ||
+              event.user === botInfo.botUserId
+            ) {
+              debug('Message event filtered out');
+              return;
+            }
+
+            const channel = event.channel || 'unknown';
+            const lastTs = this.lastEventTsByChannel.get(channel);
+            if (lastTs === event.ts) {
+              debug(`Duplicate message TS detected in channel ${channel}: ${event.ts}`);
+              return;
+            }
+            this.lastEventTsByChannel.set(channel, event.ts);
+            this.processedEvents.add(eventId);
+
+            debug(`${botInfo.botUserName} received: ${event.text}`);
+            if (this.messageHandler) {
+              const slackMessage = new SlackMessage(event.text, event.channel, event as any);
+              await this.messageHandler(slackMessage, [], botInfo.config);
+            }
+          });
+
           try {
             debug(`Starting RTM client for ${botInfo.botUserName}`);
             await botInfo.rtmClient.start();


### PR DESCRIPTION
## What
Register the RTM `'message'` event handler (and `start()`) for the **primary** Slack bot when `mode === 'rtm'`, plus a handler for non-primary RTM bots. Adds a unit test.

## Why
`SlackBotManager` constructs an `RTMClient` when `mode==='rtm'`, but `startListening()` only wired `'message'` handlers for the socket-mode path. The primary-bot block had a `if (this.mode === 'socket' ...)` branch with **no** `rtm` counterpart, and the non-primary loop started RTM clients without ever registering a `'message'` handler. Result: RTM-mode bots connected but **never received messages**.

## Behavior
- Primary bot RTM client now registers a `'message'` handler and is started, mirroring the socket-mode primary path (dedup via `processedEvents`, self/empty/bot-message filtering, per-channel TS dedup, optional history, forwarding to `messageHandler` with the bot config).
- Non-primary RTM bots get a DM-scoped `'message'` handler mirroring the socket-mode non-primary path.
- RTM emits the **raw** event object directly (with a `ts` field), unlike socket mode which wraps it as `{ event }` using `event_ts`; the handlers account for this.

## Verification
- `npx tsc --noEmit` (backend): clean (exit 0).
- `jest packages/message-slack`: 3 suites, 15 tests pass — including the new `SlackBotManager.rtm.test.ts` (forwards an inbound RTM message; ignores self-authored/empty messages).
- Backend-only change; frontend untouched.
- Note: repo-wide `eslint` currently crashes on load (ajv/eslintrc env conflict) for *any* file including unchanged ones — pre-existing, unrelated to this change.
