### PR TITLE
fix(webhook): wire inbound webhook ingress to handleIncomingWebhook

### DIFF
--- a/src/webhook/routes/webhookRoutes.ts
+++ b/src/webhook/routes/webhookRoutes.ts
@@ -21,6 +21,24 @@ interface WebhookBody {
   [key: string]: unknown;
 }
 
+/**
+ * Messenger services that accept inbound webhook payloads (e.g. the
+ * `@hivemind/message-webhook` adapter) expose `handleIncomingWebhook`. The base
+ * IMessengerService interface does not declare it, so we narrow structurally.
+ */
+interface IInboundWebhookReceiver {
+  handleIncomingWebhook(payload: unknown, channelId?: string): Promise<string>;
+}
+
+function supportsIncomingWebhook(
+  service: IMessengerService | null | undefined
+): service is IMessengerService & IInboundWebhookReceiver {
+  return (
+    !!service &&
+    typeof (service as Partial<IInboundWebhookReceiver>).handleIncomingWebhook === 'function'
+  );
+}
+
 function validateWebhookBody(body: WebhookBody): { valid: boolean; errors: string[] } {
   const errors: string[] = [];
 
@@ -131,8 +149,55 @@ export function configureWebhookRoutes(
     }
   );
 
+  // Inbound webhook ingress: deliver the payload to the messenger service's
+  // registered message handler (via handleIncomingWebhook) when the service
+  // supports it. This is what makes externally-pushed messages reach the
+  // pipeline rather than being silently dropped.
+  app.post(
+    '/webhook/receive',
+    verifyWebhookToken,
+    verifyIpWhitelist,
+    async (req: Request, res: Response) => {
+      debug('Received inbound webhook payload:', { bodyKeys: Object.keys(req.body || {}) });
+
+      if (!supportsIncomingWebhook(messageService)) {
+        debug('Messenger service does not support inbound webhooks');
+        return res.status(501).json({
+          error: 'Inbound webhooks are not supported by the configured messenger service',
+        });
+      }
+
+      try {
+        const reply = await messageService.handleIncomingWebhook(req.body, targetChannel);
+        return res.status(200).json({ success: true, reply });
+      } catch (error) {
+        debug(
+          'Failed to process inbound webhook:',
+          error instanceof Error ? error.message : String(error)
+        );
+        return res.status(500).json({ error: 'Failed to process inbound webhook' });
+      }
+    }
+  );
+
   app.post('/webhook/slack', verifySlackSignature, async (req: Request, res: Response) => {
     debug('Received Slack webhook:', req.body);
+
+    // Slack-formatted payloads are also handled by handleIncomingWebhook
+    // (it understands attachments/username). Forward when supported.
+    if (supportsIncomingWebhook(messageService)) {
+      try {
+        const reply = await messageService.handleIncomingWebhook(req.body, targetChannel);
+        return res.status(200).json({ success: true, reply });
+      } catch (error) {
+        debug(
+          'Failed to process Slack webhook:',
+          error instanceof Error ? error.message : String(error)
+        );
+        return res.status(500).json({ error: 'Failed to process Slack webhook' });
+      }
+    }
+
     return res.status(200).json({ success: true });
   });
 }

--- a/tests/unit/webhook/webhookRoutes.inbound.test.ts
+++ b/tests/unit/webhook/webhookRoutes.inbound.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests that inbound webhook ingress is wired to the messenger service's
+ * handleIncomingWebhook method.
+ *
+ * Regression guard: previously WebhookService.handleIncomingWebhook (in
+ * @hivemind/message-webhook) built an IMessage and invoked the registered
+ * handler, but nothing in src/webhook/routes called it, so the inbound
+ * webhook path was dead. configureWebhookRoutes now mounts POST
+ * /webhook/receive (and forwards /webhook/slack) to that method.
+ *
+ * Security middleware is mocked to pass-through here; token/IP enforcement
+ * is covered by webhookSecurity's own behavior. This suite focuses on the
+ * wiring between the route and the messenger service.
+ */
+
+// Pass-through the security middleware so we exercise the routing logic.
+jest.mock('@webhook/security/webhookSecurity', () => ({
+  verifyWebhookToken: (_req: unknown, _res: unknown, next: () => void) => next(),
+  verifyIpWhitelist: (_req: unknown, _res: unknown, next: () => void) => next(),
+  verifySlackSignature: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+import express from 'express';
+import request from 'supertest';
+import type { IMessengerService } from '@message/interfaces/IMessengerService';
+import { configureWebhookRoutes } from '@webhook/routes/webhookRoutes';
+import { WebhookService } from '@hivemind/message-webhook';
+
+function buildApp(messageService: IMessengerService, targetChannel?: string) {
+  const app = express();
+  app.use(express.json());
+  configureWebhookRoutes(app, messageService, targetChannel);
+  return app;
+}
+
+describe('inbound webhook route wiring', () => {
+  it('POST /webhook/receive delivers the payload to the registered handler', async () => {
+    const service = new WebhookService();
+    const handler = jest.fn().mockResolvedValue('handled-reply');
+    service.setMessageHandler(handler);
+
+    const app = buildApp(service);
+
+    const res = await request(app)
+      .post('/webhook/receive')
+      .send({ text: 'hello from outside', username: 'Alice', channel: 'C123' })
+      .expect(200);
+
+    expect(res.body).toEqual({ success: true, reply: 'handled-reply' });
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    const [message] = handler.mock.calls[0];
+    expect(message.getText()).toBe('hello from outside');
+    expect(message.getAuthorName()).toBe('Alice');
+    expect(message.getChannelId()).toBe('C123');
+  });
+
+  it('POST /webhook/receive prefers the configured target channel', async () => {
+    const service = new WebhookService();
+    const handler = jest.fn().mockResolvedValue('ok');
+    service.setMessageHandler(handler);
+
+    const app = buildApp(service, 'target-channel');
+
+    await request(app).post('/webhook/receive').send({ text: 'hi' }).expect(200);
+
+    const [message] = handler.mock.calls[0];
+    expect(message.getChannelId()).toBe('target-channel');
+  });
+
+  it('POST /webhook/slack forwards Slack-formatted payloads to the handler', async () => {
+    const service = new WebhookService();
+    const handler = jest.fn().mockResolvedValue('slack-ok');
+    service.setMessageHandler(handler);
+
+    const app = buildApp(service);
+
+    const res = await request(app)
+      .post('/webhook/slack')
+      .send({ text: 'base', attachments: [{ text: 'extra detail' }] })
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(handler).toHaveBeenCalledTimes(1);
+    const [message] = handler.mock.calls[0];
+    expect(message.getText()).toContain('base');
+    expect(message.getText()).toContain('extra detail');
+  });
+
+  it('returns 501 when the messenger service does not support inbound webhooks', async () => {
+    const bareService = {
+      getDefaultChannel: () => 'default',
+      setMessageHandler: () => undefined,
+    } as unknown as IMessengerService;
+
+    const app = buildApp(bareService);
+
+    await request(app).post('/webhook/receive').send({ text: 'hi' }).expect(501);
+  });
+
+  it('returns 500 when handleIncomingWebhook rejects', async () => {
+    const failingService = {
+      getDefaultChannel: () => 'default',
+      setMessageHandler: () => undefined,
+      handleIncomingWebhook: jest.fn().mockRejectedValue(new Error('boom')),
+    } as unknown as IMessengerService;
+
+    const app = buildApp(failingService);
+
+    await request(app).post('/webhook/receive').send({ text: 'hi' }).expect(500);
+  });
+});


### PR DESCRIPTION
@
## What
Wire the inbound webhook receive path into the webhook ingress routes. Adds `POST /webhook/receive` and forwards `POST /webhook/slack` payloads to `messageService.handleIncomingWebhook(...)`.

## Why
`@hivemind/message-webhook` `WebhookService.handleIncomingWebhook` (packages/message-webhook/src/WebhookService.ts:68) builds an `IMessage` from a generic/Slack payload and invokes the registered message handler — but a grep showed nothing in `src/webhook/routes` ever called it. The inbound webhook path was dead: externally pushed messages never reached the handler/pipeline. The existing `/webhook` route only handles outbound prediction-result notifications, and `/webhook/slack` previously just returned 200 without doing anything.

## Behavior
- `POST /webhook/receive` — token + IP guarded (reuses `verifyWebhookToken` / `verifyIpWhitelist`). Delivers the JSON body to `handleIncomingWebhook`, passing the configured `targetChannel`. Returns `{ success: true, reply }`.
- `POST /webhook/slack` — when the messenger service supports inbound webhooks, forwards the Slack-formatted payload (attachments/username supported by `handleIncomingWebhook`) to the same path; otherwise keeps the prior 200 behavior.
- Services that do not expose `handleIncomingWebhook` get `501`; a rejection from the handler yields `500`.
- The base `IMessengerService` does not declare `handleIncomingWebhook`, so the route narrows structurally via a `supportsIncomingWebhook` type guard. No interface change, no startup/pipeline/auth/DB changes.

## Verification
- `npx tsc --noEmit` clean.
- New suite `tests/unit/webhook/webhookRoutes.inbound.test.ts` (5 tests) passes: delivery to handler, target-channel preference, Slack attachment merge, 501 for unsupported services, 500 on handler rejection.
- Existing `tests/unit/webhook` + `packages/message-webhook` suites still green.
- Note: repo-wide `eslint` currently fails to start due to a pre-existing ajv/eslintrc environment conflict in node_modules (unrelated to this change); changed code follows the existing patterns in the same file.
@