### PR TITLE
fix(webhook): CIDR + proxy-aware IP whitelist validation

### DIFF
--- a/src/webhook/security/webhookSecurity.ts
+++ b/src/webhook/security/webhookSecurity.ts
@@ -3,6 +3,7 @@ import net from 'net';
 import type { NextFunction, Request, Response } from 'express';
 import webhookConfig from '@config/webhookConfig';
 import Logger from '@common/logger';
+import { getClientKey, isIPInCIDR } from '@src/middleware/rateLimiterCore';
 
 export const verifyWebhookToken = (req: Request, res: Response, next: NextFunction): void => {
   // Handle case-insensitive header names; Express normally lowercases, but unit tests pass raw objects
@@ -105,7 +106,12 @@ export const verifyIpWhitelist = (req: Request, res: Response, next: NextFunctio
     return;
   }
 
-  let requestIp: string = req.ip ?? '';
+  // Resolve the real client IP in a proxy-aware way (honours TRUSTED_PROXIES and
+  // X-Forwarded-For / X-Real-IP only when the direct connection is a trusted proxy).
+  let requestIp: string = getClientKey(req);
+  if (requestIp === 'unknown') {
+    requestIp = req.ip ?? '';
+  }
   const ipv4Match = requestIp.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
   if (ipv4Match) {
     requestIp = ipv4Match[1];
@@ -123,7 +129,12 @@ export const verifyIpWhitelist = (req: Request, res: Response, next: NextFunctio
     return;
   }
 
-  if (!whitelistedIps.includes(requestIp)) {
+  // An entry may be a single IP (exact match) or a CIDR range (e.g. 10.0.0.0/8).
+  const isWhitelisted = whitelistedIps.some((entry) =>
+    entry.includes('/') ? isIPInCIDR(requestIp, entry) : entry === requestIp
+  );
+
+  if (!isWhitelisted) {
     res.status(403).send('Forbidden: Unauthorized IP address');
     return;
   }

--- a/tests/unit/webhook/webhookSecurity.ipWhitelist.test.ts
+++ b/tests/unit/webhook/webhookSecurity.ipWhitelist.test.ts
@@ -1,0 +1,99 @@
+import type { NextFunction, Request, Response } from 'express';
+import { verifyIpWhitelist } from '@webhook/security/webhookSecurity';
+import webhookConfig from '@config/webhookConfig';
+
+/**
+ * Tests for proxy-aware client IP resolution + CIDR whitelist matching in
+ * verifyIpWhitelist.
+ */
+describe('verifyIpWhitelist - CIDR + proxy-aware', () => {
+  const originalWhitelist = webhookConfig.get('WEBHOOK_IP_WHITELIST');
+  const originalTrustedProxies = process.env.TRUSTED_PROXIES;
+
+  afterEach(() => {
+    webhookConfig.set('WEBHOOK_IP_WHITELIST', originalWhitelist);
+    if (originalTrustedProxies === undefined) {
+      delete process.env.TRUSTED_PROXIES;
+    } else {
+      process.env.TRUSTED_PROXIES = originalTrustedProxies;
+    }
+    jest.clearAllMocks();
+  });
+
+  const buildRes = () => {
+    const res: Partial<Response> = {};
+    res.status = jest.fn().mockReturnValue(res as Response);
+    res.send = jest.fn().mockReturnValue(res as Response);
+    return res as Response;
+  };
+
+  const run = (req: Partial<Request>) => {
+    const res = buildRes();
+    const next = jest.fn() as unknown as NextFunction;
+    verifyIpWhitelist(req as Request, res, next);
+    return { res, next };
+  };
+
+  it('allows an exact single-IP match (backward compatible)', () => {
+    webhookConfig.set('WEBHOOK_IP_WHITELIST', '203.0.113.5');
+    const { res, next } = run({ ip: '203.0.113.5', socket: { remoteAddress: '203.0.113.5' } as any });
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('allows an IP inside a CIDR range', () => {
+    webhookConfig.set('WEBHOOK_IP_WHITELIST', '203.0.113.0/24');
+    const { res, next } = run({ ip: '203.0.113.42', socket: { remoteAddress: '203.0.113.42' } as any });
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('rejects an IP outside a CIDR range', () => {
+    webhookConfig.set('WEBHOOK_IP_WHITELIST', '203.0.113.0/24');
+    const { res, next } = run({ ip: '198.51.100.1', socket: { remoteAddress: '198.51.100.1' } as any });
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.send).toHaveBeenCalledWith('Forbidden: Unauthorized IP address');
+  });
+
+  it('supports a mixed list of exact IPs and CIDR ranges', () => {
+    webhookConfig.set('WEBHOOK_IP_WHITELIST', '10.0.0.0/8, 203.0.113.5');
+    const cidrHit = run({ ip: '10.4.5.6', socket: { remoteAddress: '10.4.5.6' } as any });
+    expect(cidrHit.next).toHaveBeenCalledTimes(1);
+
+    const exactHit = run({ ip: '203.0.113.5', socket: { remoteAddress: '203.0.113.5' } as any });
+    expect(exactHit.next).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses X-Forwarded-For client IP when the direct connection is a trusted proxy', () => {
+    // 127.0.0.1 is a default trusted proxy; the real client is in the XFF header.
+    webhookConfig.set('WEBHOOK_IP_WHITELIST', '203.0.113.0/24');
+    const { res, next } = run({
+      ip: '127.0.0.1',
+      socket: { remoteAddress: '127.0.0.1' } as any,
+      headers: { 'x-forwarded-for': '203.0.113.77' },
+    });
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('does NOT trust X-Forwarded-For when the direct connection is not a trusted proxy', () => {
+    // Untrusted direct connection: the spoofed XFF header must be ignored.
+    webhookConfig.set('WEBHOOK_IP_WHITELIST', '203.0.113.0/24');
+    const { res, next } = run({
+      ip: '198.51.100.9',
+      socket: { remoteAddress: '198.51.100.9' } as any,
+      headers: { 'x-forwarded-for': '203.0.113.77' },
+    });
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('blocks when the whitelist is empty', () => {
+    webhookConfig.set('WEBHOOK_IP_WHITELIST', '');
+    const { res, next } = run({ ip: '203.0.113.5', socket: { remoteAddress: '203.0.113.5' } as any });
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.send).toHaveBeenCalledWith('Forbidden: IP whitelist is empty');
+  });
+});


### PR DESCRIPTION
## What
`verifyIpWhitelist` (`src/webhook/security/webhookSecurity.ts`) now:
- Resolves the real client IP in a **proxy-aware** way via the existing `getClientKey` helper (`src/middleware/rateLimiterCore.ts`), instead of trusting `req.ip` directly.
- Supports **CIDR range** entries in `WEBHOOK_IP_WHITELIST` (e.g. `10.0.0.0/8`) via the existing `isIPInCIDR` helper, in addition to exact single-IP matches.

## Why
Previously the whitelist only did an exact string match (`whitelistedIps.includes(requestIp)`), so CIDR ranges silently never matched. It also read `req.ip` without honouring trusted proxies, so behind a reverse proxy the whitelist compared against the proxy address rather than the real client, and a client could not be reliably identified. Reusing the existing rate-limiter helpers keeps the proxy/spoofing logic consistent across the codebase.

## Behavior
- Exact single-IP whitelist entries still match exactly (backward compatible).
- CIDR entries match any IP within the range; IPs outside are rejected with 403 `Forbidden: Unauthorized IP address`.
- X-Forwarded-For is only trusted when the direct connection is a trusted proxy (`TRUSTED_PROXIES`, defaulting to loopback/private ranges); a spoofed XFF from an untrusted connection is ignored.
- Empty whitelist still blocks all requests; malformed IPs still return 403.

## Verification
- `npx tsc --noEmit` clean (backend).
- New suite `tests/unit/webhook/webhookSecurity.ipWhitelist.test.ts`: **7/7 passing** (exact match, CIDR in/out of range, mixed list, trusted-proxy XFF, spoofed XFF rejected, empty whitelist).
- No frontend files changed.
- Note: local `eslint` is broken by a pre-existing ajv dependency mismatch in the shared node_modules (fails before reading any file); CI's clean install is unaffected.