### PR TITLE
fix(pipeline): use consistent botName key for swarm claim de-duplication

### DIFF
--- a/src/pipeline/DecisionStage.ts
+++ b/src/pipeline/DecisionStage.ts
@@ -109,7 +109,6 @@ export class DecisionStage {
       }
 
       const messageId = ctx.message.getMessageId();
-      const botId = (ctx.botConfig.BOT_ID as string) || (ctx.botConfig.botId as string) || '';
 
       // Record the inbound interaction for idle-response tracking. Mirrors the
       // legacy `replyDecision.ts` recording so idle response works in pipeline
@@ -127,8 +126,13 @@ export class DecisionStage {
       const botName = ctx.botName;
 
       // --- Swarm claim check: skip if another bot already claimed ---
+      // Compare against `botName`, the SAME identity key used when this stage
+      // claims the message below via `swarm.claimMessage(messageId, botName)`
+      // (SwarmCoordinator stores that value as the claim's `botId`). Using the
+      // config `BOT_ID` here instead would mismatch when `BOT_NAME !== BOT_ID`,
+      // causing a bot to fail to recognize its own claim and mis-deduplicate.
       const existingClaim = swarm.getClaim(messageId);
-      const alreadyClaimed = existingClaim !== undefined && existingClaim.botId !== botId;
+      const alreadyClaimed = existingClaim !== undefined && existingClaim.botId !== botName;
       if (alreadyClaimed) {
         const reason = existingClaim
           ? `Message already claimed by bot ${existingClaim.botId} in swarm`
@@ -172,7 +176,7 @@ export class DecisionStage {
       if (decision.shouldReply) {
         // Claim the message for this bot
         swarm.claimMessage(messageId, botName);
-        debug('[DecisionStage] Message %s: claimed by %s', messageId, botId);
+        debug('[DecisionStage] Message %s: claimed by %s', messageId, botName);
 
         // Broadcast decision to WebSocket for Live Orchestration Log
         this.bus.emit('pipeline:decision', {

--- a/tests/unit/pipeline/decisionStageSwarmClaim.test.ts
+++ b/tests/unit/pipeline/decisionStageSwarmClaim.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Regression tests for swarm-claim identity consistency in DecisionStage.
+ *
+ * Bug: DecisionStage claimed a message via
+ *   `swarm.claimMessage(messageId, botName)`
+ * (SwarmCoordinator stores `botName` as the claim's `botId`), but the
+ * "already claimed?" check compared `existingClaim.botId` against the config
+ * `BOT_ID` instead of `botName`. When a bot's `BOT_NAME` differed from its
+ * `BOT_ID`, the bot failed to recognize its OWN claim and treated the message
+ * as claimed by another bot — causing mis-deduplication in multi-bot swarms.
+ *
+ * These tests assert the read-side comparison now uses the same identity key
+ * (`botName`) as the write-side claim.
+ */
+
+import { MessageBus } from '@src/events/MessageBus';
+import type { ActivityRecorder } from '@src/pipeline/ActivityRecorder';
+import { DecisionStage, type DecisionStrategy } from '@src/pipeline/DecisionStage';
+import { SwarmCoordinator } from '@src/services/SwarmCoordinator';
+import { IMessage } from '@message/interfaces/IMessage';
+
+// ---------------------------------------------------------------------------
+// Stub message
+// ---------------------------------------------------------------------------
+
+class StubMessage extends IMessage {
+  constructor(private id = 'msg-1') {
+    super({}, 'user');
+    this.content = 'hello';
+    this.channelId = 'ch-swarm';
+    this.platform = 'discord';
+  }
+  getMessageId(): string {
+    return this.id;
+  }
+  getText(): string {
+    return this.content;
+  }
+  getTimestamp(): Date {
+    return new Date();
+  }
+  setText(t: string): void {
+    this.content = t;
+  }
+  getChannelId(): string {
+    return this.channelId;
+  }
+  getAuthorId(): string {
+    return 'user-1';
+  }
+  getChannelTopic(): string | null {
+    return null;
+  }
+  getUserMentions(): string[] {
+    return [];
+  }
+  getChannelUsers(): string[] {
+    return [];
+  }
+  mentionsUsers(): boolean {
+    return false;
+  }
+  isFromBot(): boolean {
+    return false;
+  }
+  getAuthorName(): string {
+    return 'Tester';
+  }
+}
+
+/**
+ * Build a MessageContext whose `BOT_NAME` (used for swarm claims) differs from
+ * its `BOT_ID` — the exact configuration that triggered the original bug.
+ */
+function makeContext(message: IMessage) {
+  return {
+    message,
+    history: [],
+    botConfig: { BOT_NAME: 'AliceBot', BOT_ID: 'discord-user-id-999' },
+    botName: 'AliceBot',
+    platform: 'discord',
+    channelId: message.getChannelId(),
+    metadata: {} as Record<string, any>,
+  };
+}
+
+function noopRecorder(): ActivityRecorder {
+  return {
+    recordInteraction: jest.fn(),
+    recordBotResponse: jest.fn(),
+  };
+}
+
+describe('DecisionStage swarm-claim identity consistency', () => {
+  let bus: MessageBus;
+
+  beforeEach(() => {
+    MessageBus.getInstance().reset();
+    bus = MessageBus.getInstance();
+    SwarmCoordinator.resetInstance();
+  });
+
+  afterEach(() => {
+    bus.reset();
+    SwarmCoordinator.resetInstance();
+  });
+
+  it('stores the swarm claim keyed by botName (not config BOT_ID)', async () => {
+    const strategy: DecisionStrategy = {
+      shouldReply: jest.fn().mockResolvedValue({ shouldReply: true, reason: 'yes' }),
+    };
+    const stage = new DecisionStage(bus, strategy, noopRecorder());
+
+    await stage.process(makeContext(new StubMessage('m-claim')));
+
+    const claim = SwarmCoordinator.getInstance().getClaim('m-claim');
+    expect(claim).toBeDefined();
+    // The claim must be keyed by botName, since that is what the read-side
+    // de-dup check compares against.
+    expect(claim?.botId).toBe('AliceBot');
+  });
+
+  it('recognizes its OWN claim on re-processing and does NOT skip (BOT_NAME != BOT_ID)', async () => {
+    const strategy: DecisionStrategy = {
+      shouldReply: jest.fn().mockResolvedValue({ shouldReply: true, reason: 'yes' }),
+    };
+    const stage = new DecisionStage(bus, strategy, noopRecorder());
+
+    const skipped: string[] = [];
+    bus.on('message:skipped', (ctx: any) => skipped.push(ctx.reason));
+
+    // First pass claims the message for AliceBot.
+    const first = await stage.process(makeContext(new StubMessage('m-self')));
+    expect(first.shouldReply).toBe(true);
+
+    // Second pass (same bot, same message) must recognize its own claim and
+    // run the strategy again — NOT be skipped as "claimed by another bot".
+    const second = await stage.process(makeContext(new StubMessage('m-self')));
+
+    expect(second.shouldReply).toBe(true);
+    expect(skipped).toHaveLength(0);
+    // Strategy ran on both passes (would be short-circuited if mis-deduplicated).
+    expect((strategy.shouldReply as jest.Mock)).toHaveBeenCalledTimes(2);
+  });
+
+  it('still skips when a DIFFERENT bot already claimed the message', async () => {
+    const strategy: DecisionStrategy = {
+      shouldReply: jest.fn().mockResolvedValue({ shouldReply: true, reason: 'yes' }),
+    };
+
+    // A different bot (BobBot) claims the message first.
+    SwarmCoordinator.getInstance().claimMessage('m-other', 'BobBot');
+
+    const stage = new DecisionStage(bus, strategy, noopRecorder());
+
+    const skipped: string[] = [];
+    bus.on('message:skipped', (ctx: any) => skipped.push(ctx.reason));
+
+    const result = await stage.process(makeContext(new StubMessage('m-other')));
+
+    expect(result.shouldReply).toBe(false);
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0]).toContain('BobBot');
+    // The strategy should never run — the message was de-duplicated.
+    expect(strategy.shouldReply).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What
Fix an identity-key mismatch in `DecisionStage`'s swarm-claim de-duplication so a bot reliably recognizes its own claim.

## Why
`DecisionStage` claims a message via `swarm.claimMessage(messageId, botName)` (`SwarmCoordinator.claimMessage` stores `botName` as the claim's `botId`, src/services/SwarmCoordinator.ts:196). But the already-claimed check compared `existingClaim.botId` against the **config `BOT_ID`** (`ctx.botConfig.BOT_ID`), not `botName`.

`botName` resolves from `BOT_NAME || name` (ReceiveStage.ts:81) while the old `botId` resolved from `BOT_ID || botId`. When `BOT_NAME !== BOT_ID`, a bot's own stored claim (`botId === botName`) never matched the check (`botId === BOT_ID`), so the bot treated its own claim as belonging to another bot — causing mis-deduplication in multi-bot swarms.

## Behavior
- Read-side comparison now uses `botName`, the same key the write-side claim uses.
- A bot recognizes its own prior claim and does not wrongly skip its message.
- A claim by a genuinely different bot still correctly de-duplicates (skip).
- The stale debug log that referenced the removed `botId` now logs `botName`.

## Verification
- Backend `npx tsc --noEmit`: clean.
- New test `tests/unit/pipeline/decisionStageSwarmClaim.test.ts` (3 cases): claim keyed by botName; own-claim recognized on re-process (BOT_NAME != BOT_ID); different bot still skips. Verified it FAILS when the fix is reverted and PASSES with it.
- Existing `tests/unit/pipeline/pipelineActivityTracking.test.ts` still passes (8/8 total across both suites).
- Frontend untouched (no client changes).

Note: repo-level eslint is currently broken in this environment (ajv `defaultMeta` TypeError before linting any file) — unrelated to this change, which adds no new lint surface.