### PR TITLE
feat(memory-postgres): OpenWebUI embeddings + configurable embedding provider

### DIFF
--- a/packages/llm-openwebui/src/openWebUIConfig.ts
+++ b/packages/llm-openwebui/src/openWebUIConfig.ts
@@ -52,6 +52,12 @@ const openWebUIConfig = convict({
     default: 'llama3.2',
     env: 'OPEN_WEBUI_MODEL',
   },
+  embeddingModel: {
+    doc: 'The model to use for generating embeddings (used by vector memory providers)',
+    format: String,
+    default: 'nomic-embed-text',
+    env: 'OPEN_WEBUI_EMBEDDING_MODEL',
+  },
 });
 
 /**

--- a/packages/llm-openwebui/src/openWebUIProvider.test.ts
+++ b/packages/llm-openwebui/src/openWebUIProvider.test.ts
@@ -13,6 +13,7 @@ jest.mock('convict', () => {
     get: jest.fn((key: string) => {
       if (key === 'apiUrl') return 'https://openwebui.example.com';
       if (key === 'model') return 'test-model';
+      if (key === 'embeddingModel') return 'test-embed-model';
       return '';
     }),
     set: jest.fn(),
@@ -84,6 +85,26 @@ describe('openWebUIProvider', () => {
     mockFetch({ error: 'fail' }, 500);
     await expect(openWebUIProvider.generateCompletion('prompt')).rejects.toThrow(
       'Non-chat completion failed'
+    );
+  });
+
+  it('generateEmbedding returns the embedding vector', async () => {
+    const vector = [0.1, 0.2, 0.3];
+    mockFetch({ data: [{ embedding: vector }] });
+    expect(await openWebUIProvider.generateEmbedding!('embed me')).toEqual(vector);
+  });
+
+  it('generateEmbedding throws when the response has no embedding', async () => {
+    mockFetch({ data: [{}] });
+    await expect(openWebUIProvider.generateEmbedding!('embed me')).rejects.toThrow(
+      'Embedding generation failed'
+    );
+  });
+
+  it('generateEmbedding throws on HTTP error', async () => {
+    mockFetch({ error: 'fail' }, 500);
+    await expect(openWebUIProvider.generateEmbedding!('embed me')).rejects.toThrow(
+      'Embedding generation failed'
     );
   });
 });

--- a/packages/llm-openwebui/src/openWebUIProvider.ts
+++ b/packages/llm-openwebui/src/openWebUIProvider.ts
@@ -84,6 +84,34 @@ export const openWebUIProvider: ILlmProvider = {
       throw new Error(`Non-chat completion failed: ${getErrorMessage(error)}`);
     }
   },
+
+  /**
+   * Generates an embedding vector for the given text using the OpenAI-compatible
+   * `/embeddings` endpoint exposed by OpenWebUI / Ollama. The embedding model is
+   * configurable via `OPEN_WEBUI_EMBEDDING_MODEL` so this provider can back
+   * vector memory stores (e.g. PostgresMemoryProvider) without OpenAI.
+   */
+  async generateEmbedding(text: string): Promise<number[]> {
+    debug('Generating embedding with OpenWebUI:', { text });
+
+    const client = await createOpenWebUIClient();
+    const embeddingModel = openWebUIConfig.get('embeddingModel');
+
+    try {
+      const data = await client.post<{ data: Array<{ embedding: number[] }> }>('/embeddings', {
+        model: embeddingModel,
+        input: text,
+      });
+      const embedding = data.data?.[0]?.embedding;
+      if (!Array.isArray(embedding)) {
+        throw new Error('OpenWebUI embedding response did not include an embedding vector');
+      }
+      return embedding;
+    } catch (error) {
+      debug('Error generating embedding:', formatError(error));
+      throw new Error(`Embedding generation failed: ${getErrorMessage(error)}`);
+    }
+  },
 };
 
 /**

--- a/packages/memory-postgres/README.md
+++ b/packages/memory-postgres/README.md
@@ -15,7 +15,7 @@ The package is PluginLoader-compatible (it exposes both `create` and `manifest`)
 
 ## Environment variables
 
-None read directly. Database connectivity is provided by the host app; the embedding profile is selected by the `embeddingProfile` config field, which must match the `name` of an LLM provider that exposes `generateEmbedding()`.
+None read directly. Database connectivity is provided by the host app; the embedding profile is selected by the `embeddingProfile` config field, which must match the `name` of an LLM provider that exposes `generateEmbedding()`. Both the OpenAI (`openai`) and OpenWebUI/Ollama (`openwebui`) providers implement `generateEmbedding()`; the OpenWebUI embedding model is configurable via `OPEN_WEBUI_EMBEDDING_MODEL` (default `nomic-embed-text`). If `embeddingProfile` names a provider that does not support embeddings, construction throws a clear error instead of silently falling back.
 
 ## Usage
 

--- a/packages/memory-postgres/src/PostgresMemoryProvider.test.ts
+++ b/packages/memory-postgres/src/PostgresMemoryProvider.test.ts
@@ -96,4 +96,83 @@ describe('PostgresMemoryProvider (Mocked)', () => {
     expect(mockDbManager.getMemories).not.toHaveBeenCalled();
     expect(result).toBeNull();
   });
+
+  it('should select a non-OpenAI provider that implements generateEmbedding', async () => {
+    const openWebUiLike = {
+      name: 'openwebui',
+      generateEmbedding: jest.fn().mockResolvedValue(new Array(768).fill(0.2)),
+    };
+    const chatOnly = { name: 'flowise' }; // no generateEmbedding
+
+    const localDeps: IServiceDependencies = {
+      ...deps,
+      getLlmProviders: () => [chatOnly, openWebUiLike] as any,
+    };
+    const localProvider = new PostgresMemoryProvider({}, localDeps);
+
+    await localProvider.addMemory('hello');
+
+    expect(openWebUiLike.generateEmbedding).toHaveBeenCalledWith('hello');
+  });
+
+  it('should use the configured embedding profile when it supports embeddings', async () => {
+    const openai = {
+      name: 'openai',
+      generateEmbedding: jest.fn().mockResolvedValue(new Array(1536).fill(0.3)),
+    };
+    const openwebui = {
+      name: 'openwebui',
+      generateEmbedding: jest.fn().mockResolvedValue(new Array(768).fill(0.4)),
+    };
+
+    const localDeps: IServiceDependencies = {
+      ...deps,
+      getLlmProviders: () => [openai, openwebui] as any,
+    };
+    const localProvider = new PostgresMemoryProvider(
+      { embeddingProfile: 'openwebui' },
+      localDeps
+    );
+
+    await localProvider.addMemory('hi');
+
+    expect(openwebui.generateEmbedding).toHaveBeenCalledWith('hi');
+    expect(openai.generateEmbedding).not.toHaveBeenCalled();
+  });
+
+  it('should throw a clear error when the configured profile cannot embed', () => {
+    const chatOnly = { name: 'flowise' }; // no generateEmbedding
+    const localDeps: IServiceDependencies = {
+      ...deps,
+      getLlmProviders: () => [chatOnly] as any,
+    };
+
+    expect(
+      () => new PostgresMemoryProvider({ embeddingProfile: 'flowise' }, localDeps)
+    ).toThrow(/does not support embeddings/);
+  });
+
+  it('should throw a clear error when the configured profile is missing', () => {
+    const localDeps: IServiceDependencies = {
+      ...deps,
+      getLlmProviders: () => [mockEmbeddingProvider],
+    };
+
+    expect(
+      () => new PostgresMemoryProvider({ embeddingProfile: 'nonexistent' }, localDeps)
+    ).toThrow(/was not found/);
+  });
+
+  it('should throw a clear error when no embedding-capable provider is available', async () => {
+    const chatOnly = { name: 'flowise' };
+    const localDeps: IServiceDependencies = {
+      ...deps,
+      getLlmProviders: () => [chatOnly] as any,
+    };
+    const localProvider = new PostgresMemoryProvider({}, localDeps);
+
+    await expect(localProvider.addMemory('hello')).rejects.toThrow(
+      /No embedding-capable LLM provider available/
+    );
+  });
 });

--- a/packages/memory-postgres/src/PostgresMemoryProvider.ts
+++ b/packages/memory-postgres/src/PostgresMemoryProvider.ts
@@ -31,15 +31,34 @@ export class PostgresMemoryProvider implements IMemoryProvider {
 
     // Resolve embedding provider
     if (dependencies?.getLlmProviders) {
-      const providers = dependencies.getLlmProviders();
-      // Use configured profile or fallback to first one that can embed
-      if (this.config.embeddingProfile) {
-        this.embeddingProvider = providers.find((p) => p.name === this.config.embeddingProfile);
-      }
-      if (!this.embeddingProvider) {
-        this.embeddingProvider = providers.find((p) => typeof p.generateEmbedding === 'function');
-      }
+      this.embeddingProvider = this.resolveEmbeddingProvider(dependencies.getLlmProviders());
     }
+  }
+
+  /**
+   * Resolves an embedding-capable LLM provider.
+   *
+   * When `embeddingProfile` is configured, the named provider must exist AND
+   * implement `generateEmbedding` — otherwise a clear error is thrown rather
+   * than silently falling back to a different provider. When no profile is
+   * configured, the first provider that supports embeddings is used.
+   */
+  private resolveEmbeddingProvider(providers: any[]): any {
+    if (this.config.embeddingProfile) {
+      const named = providers.find((p) => p.name === this.config.embeddingProfile);
+      if (!named) {
+        throw new Error(
+          `PostgresMemoryProvider: Configured embedding profile "${this.config.embeddingProfile}" was not found among LLM providers`
+        );
+      }
+      if (typeof named.generateEmbedding !== 'function') {
+        throw new Error(
+          `PostgresMemoryProvider: Configured embedding profile "${this.config.embeddingProfile}" does not support embeddings (no generateEmbedding). Use a provider such as OpenAI or OpenWebUI/Ollama.`
+        );
+      }
+      return named;
+    }
+    return providers.find((p) => typeof p.generateEmbedding === 'function');
   }
 
   private ensureInitialized() {
@@ -52,11 +71,12 @@ export class PostgresMemoryProvider implements IMemoryProvider {
       throw new Error('PostgresMemoryProvider: DatabaseManager not available');
     }
     if (!this.embeddingProvider && this.dependencies?.getLlmProviders) {
-      const providers = this.dependencies.getLlmProviders();
-      this.embeddingProvider = providers.find((p) => typeof p.generateEmbedding === 'function');
+      this.embeddingProvider = this.resolveEmbeddingProvider(this.dependencies.getLlmProviders());
     }
     if (!this.embeddingProvider) {
-      throw new Error('PostgresMemoryProvider: Embedding provider not available');
+      throw new Error(
+        'PostgresMemoryProvider: No embedding-capable LLM provider available. Configure a provider that implements generateEmbedding (e.g. OpenAI or OpenWebUI/Ollama).'
+      );
     }
   }
 

--- a/src/llm/interfaces/ILlmProvider.ts
+++ b/src/llm/interfaces/ILlmProvider.ts
@@ -192,4 +192,16 @@ export interface ILlmProvider {
    * ```
    */
   generateCompletion: (prompt: string) => Promise<string>;
+
+  /**
+   * Generates an embedding vector for the given text.
+   *
+   * Optional. Providers that support embeddings (e.g. OpenAI, OpenWebUI/Ollama)
+   * implement this so they can back vector memory stores such as
+   * PostgresMemoryProvider. Providers without embedding support omit it.
+   *
+   * @param {string} text - The text to embed
+   * @returns {Promise<number[]>} A promise that resolves to the embedding vector
+   */
+  generateEmbedding?: (text: string) => Promise<number[]>;
 }


### PR DESCRIPTION
## What
Adds a second embedding-capable LLM provider for Postgres vector memory and makes the embedding provider selection robust.

- **OpenWebUI/Ollama embeddings**: implements `generateEmbedding()` on the OpenWebUI provider via the OpenAI-compatible `/embeddings` endpoint. The embedding model is configurable through `OPEN_WEBUI_EMBEDDING_MODEL` (default `nomic-embed-text`).
- **Interface**: declares optional `generateEmbedding?(text)` on `ILlmProvider` (`src/llm/interfaces/ILlmProvider.ts`), matching the shared-types interface.
- **Clear errors**: `PostgresMemoryProvider` now throws a descriptive error when the configured `embeddingProfile` is missing or does not implement `generateEmbedding`, instead of silently falling back to a different provider. The 'no embedding-capable provider' message now names viable options.

## Why
`PostgresMemoryProvider` resolves an LLM provider with `generateEmbedding`, but only OpenAI implemented it (hardcoded `text-embedding-3-small`). That meant Postgres-native vector memory only worked with OpenAI. Now a self-hosted OpenWebUI/Ollama instance can back it, and misconfiguration surfaces a clear error.

## Behavior
- No change to the default startup/pipeline/auth/live-DB paths.
- OpenAI embedding path is unchanged.
- New env var `OPEN_WEBUI_EMBEDDING_MODEL` (optional, defaults to `nomic-embed-text`).
- When `embeddingProfile` names a chat-only provider, construction throws `PostgresMemoryProvider: Configured embedding profile "X" does not support embeddings ...`.

## Verification
- Backend `tsc --noEmit`: clean.
- Jest: `packages/llm-openwebui/src/openWebUIProvider.test.ts` and `packages/memory-postgres/src/PostgresMemoryProvider.test.ts` — 20 passed (added tests for OpenWebUI embedding success/missing-vector/HTTP-error, and Postgres profile resolution + clear-error cases).
- eslint could not run in this environment (pre-existing ajv crash unrelated to these changes; it fails identically on unchanged files); code follows the existing surrounding style.