### PR TITLE
feat(slack): native Assistant typing indicator with placeholder fallback

### DIFF
--- a/packages/message-slack/src/SlackService.ts
+++ b/packages/message-slack/src/SlackService.ts
@@ -711,13 +711,24 @@ export class SlackService extends EventEmitter implements IMessengerService {
         return;
       }
 
-      // Default to fake typing when RTM isn't available (Socket Mode/Web API).
+      const messageIO = this.messageIO as any;
+
+      // Prefer Slack's native Assistant typing indicator when available
+      // (real status, no placeholder message). Requires an assistant thread.
+      if (typeof messageIO?.sendNativeTypingStatus === 'function') {
+        const nativeSent = await messageIO.sendNativeTypingStatus(channelId, threadId, botName);
+        if (nativeSent) {
+          return;
+        }
+      }
+
+      // Default to fake typing when RTM/native indicator isn't available
+      // (Socket Mode/Web API without an assistant thread).
       if (process.env.SLACK_FAKE_TYPING === 'false') {
         debug(`sendTyping skipped (fake typing disabled). bot=${botName} channel=${channelId}`);
         return;
       }
 
-      const messageIO = this.messageIO as any;
       if (typeof messageIO?.sendTypingPlaceholder === 'function') {
         await messageIO.sendTypingPlaceholder(channelId, botName, threadId);
       }

--- a/packages/message-slack/src/modules/ISlackMessageIO.test.ts
+++ b/packages/message-slack/src/modules/ISlackMessageIO.test.ts
@@ -1,0 +1,96 @@
+import { SlackMessageIO } from './ISlackMessageIO';
+
+/**
+ * Builds a SlackMessageIO wired to a single fake bot whose webClient is the
+ * supplied mock. Mirrors how SlackService constructs the IO module.
+ */
+function buildIO(botInfo: any) {
+  const botManager: any = {
+    getAllBots: () => (botInfo ? [botInfo] : []),
+  };
+  return new SlackMessageIO(
+    () => botManager,
+    () => 'TestBot',
+    new Map<string, string>()
+  );
+}
+
+describe('SlackMessageIO.sendNativeTypingStatus', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    jest.clearAllMocks();
+  });
+
+  it('calls assistant.threads.setStatus and returns true when available', async () => {
+    const setStatus = jest.fn().mockResolvedValue({ ok: true });
+    const botInfo = {
+      botUserName: 'TestBot',
+      webClient: { assistant: { threads: { setStatus } } },
+    };
+    const io = buildIO(botInfo);
+
+    const result = await io.sendNativeTypingStatus!('C123', '1700000000.0001', 'TestBot');
+
+    expect(result).toBe(true);
+    expect(setStatus).toHaveBeenCalledTimes(1);
+    expect(setStatus).toHaveBeenCalledWith({
+      channel_id: 'C123',
+      thread_ts: '1700000000.0001',
+      status: 'is typing...',
+    });
+  });
+
+  it('honors SLACK_TYPING_STATUS_TEXT override', async () => {
+    process.env.SLACK_TYPING_STATUS_TEXT = 'thinking…';
+    const setStatus = jest.fn().mockResolvedValue({ ok: true });
+    const botInfo = {
+      botUserName: 'TestBot',
+      webClient: { assistant: { threads: { setStatus } } },
+    };
+    const io = buildIO(botInfo);
+
+    await io.sendNativeTypingStatus!('C123', '1700000000.0001');
+
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'thinking…' })
+    );
+  });
+
+  it('returns false without a thread (assistant status is thread-scoped)', async () => {
+    const setStatus = jest.fn();
+    const botInfo = {
+      botUserName: 'TestBot',
+      webClient: { assistant: { threads: { setStatus } } },
+    };
+    const io = buildIO(botInfo);
+
+    const result = await io.sendNativeTypingStatus!('C123', undefined, 'TestBot');
+
+    expect(result).toBe(false);
+    expect(setStatus).not.toHaveBeenCalled();
+  });
+
+  it('returns false when the assistant API is not available on the client', async () => {
+    const botInfo = { botUserName: 'TestBot', webClient: {} };
+    const io = buildIO(botInfo);
+
+    const result = await io.sendNativeTypingStatus!('C123', '1700000000.0001', 'TestBot');
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false (no throw) when setStatus rejects, enabling fallback', async () => {
+    const setStatus = jest.fn().mockRejectedValue(new Error('missing_scope'));
+    const botInfo = {
+      botUserName: 'TestBot',
+      webClient: { assistant: { threads: { setStatus } } },
+    };
+    const io = buildIO(botInfo);
+
+    const result = await io.sendNativeTypingStatus!('C123', '1700000000.0001', 'TestBot');
+
+    expect(result).toBe(false);
+  });
+});

--- a/packages/message-slack/src/modules/ISlackMessageIO.ts
+++ b/packages/message-slack/src/modules/ISlackMessageIO.ts
@@ -25,6 +25,14 @@ export interface ISlackMessageIO {
 
   sendTypingPlaceholder?(channelId: string, botName?: string, threadId?: string): Promise<void>;
 
+  /**
+   * Attempts to set Slack's native Assistant typing/status indicator via
+   * `assistant.threads.setStatus`. Returns true when the native indicator was
+   * sent, false when it is unavailable (no thread, missing scope/API) so the
+   * caller can fall back to the placeholder message.
+   */
+  sendNativeTypingStatus?(channelId: string, threadId?: string, botName?: string): Promise<boolean>;
+
   fetchMessages(channelId: string, limit?: number, botName?: string): Promise<IMessage[]>;
 }
 
@@ -271,7 +279,7 @@ export class SlackMessageIO implements ISlackMessageIO {
 
     const options: any = {
       channel: channelId,
-      text: '_is typing..._',
+      text: process.env.SLACK_TYPING_PLACEHOLDER_TEXT || '_is typing..._',
       username: botInfo.botUserName || 'SlackBot',
       icon_emoji: ':robot_face:',
       unfurl_links: false,
@@ -294,6 +302,47 @@ export class SlackMessageIO implements ISlackMessageIO {
       }
     } catch (error) {
       debug(`Failed to send typing placeholder: ${error}`);
+    }
+  }
+
+  /**
+   * Uses Slack's native Assistant typing indicator (`assistant.threads.setStatus`).
+   * This renders a real "is typing..." status in the assistant pane without
+   * posting a placeholder message, but it only applies to assistant threads, so
+   * a `threadId` is required and the bot token must hold the `assistant:write`
+   * scope. Returns false (rather than throwing) when unavailable so the caller
+   * can fall back to the placeholder message.
+   */
+  public async sendNativeTypingStatus(
+    channelId: string,
+    threadId?: string,
+    botName?: string
+  ): Promise<boolean> {
+    if (!channelId || !threadId) {
+      return false;
+    }
+
+    const targetBot = botName || this.getDefaultBotName();
+    const botManager = this.getBotManager(targetBot);
+    const botInfo = botManager?.getAllBots()[0];
+    const setStatus = (botInfo?.webClient as any)?.assistant?.threads?.setStatus;
+    if (!botInfo || typeof setStatus !== 'function') {
+      return false;
+    }
+
+    const status = process.env.SLACK_TYPING_STATUS_TEXT || 'is typing...';
+    try {
+      await this.withQueue(targetBot, () =>
+        botInfo.webClient.assistant.threads.setStatus({
+          channel_id: channelId,
+          thread_ts: threadId,
+          status,
+        })
+      );
+      return true;
+    } catch (error) {
+      debug(`Native assistant typing status unavailable, falling back: ${error}`);
+      return false;
     }
   }
 


### PR DESCRIPTION
@
## What
`SlackService.sendTyping` now prefers Slacks native Assistant typing indicator (`assistant.threads.setStatus`) when available, and only falls back to the `_is typing..._` placeholder message when the native indicator cannot be used.

- Added `SlackMessageIO.sendNativeTypingStatus(channelId, threadId, botName)` which calls `webClient.assistant.threads.setStatus`. It returns `true` when the native status was sent and `false` (without throwing) when unavailable, so the caller can fall back.
- `sendTyping` calls it after the RTM path and before the placeholder path: RTM → native Assistant status → placeholder.
- Made both indicators configurable:
  - `SLACK_TYPING_STATUS_TEXT` (default `is typing...`) for the native status.
  - `SLACK_TYPING_PLACEHOLDER_TEXT` (default `_is typing..._`) for the placeholder message.

## Why
Previously the only non-RTM option was posting a fake placeholder message. Slacks Assistant API exposes a real native typing/status indicator over the Web API that does not pollute the channel with a placeholder. Using it when present is the smallest correct upgrade; the placeholder remains as a graceful fallback for non-assistant threads or apps lacking the `assistant:write` scope.

## Behavior
- RTM available → unchanged (real RTM typing).
- Native Assistant status available + thread present → native indicator, no placeholder posted.
- Otherwise → existing placeholder behavior (still skippable via `SLACK_FAKE_TYPING=false`).
- `sendNativeTypingStatus` is thread-scoped (Assistant threads require `thread_ts`) and never throws — a rejected/ missing-scope call returns `false` and falls through to the placeholder.

## Verification
- `npx tsc --noEmit` clean (backend).
- New unit test `packages/message-slack/src/modules/ISlackMessageIO.test.ts` (5 cases) passes; full `packages/message-slack` suite green (18 tests).
- No frontend files changed.
- ESLint could not be run due to a pre-existing environment ajv resolution crash that affects all files (including untouched `src/`), unrelated to this change.
@