### PR TITLE
feat(observability): wire opt-in trace export into pipeline bootstrap

### DIFF
--- a/src/observability/TraceExporter.ts
+++ b/src/observability/TraceExporter.ts
@@ -296,3 +296,81 @@ export function createExporters(): ITraceExporter[] {
 
   return exporters;
 }
+
+/**
+ * Build the set of exporters requested via the `TRACE_EXPORT` env var.
+ *
+ * `TRACE_EXPORT` is a comma-separated list of backends. Supported values:
+ *
+ * - `console` — {@link ConsoleExporter} (debug output)
+ * - `file`    — {@link JsonFileExporter}, path from `TRACE_LOG_FILE`
+ *               (default `logs/traces.ndjson`)
+ * - `otlp`    — {@link OtlpExporter}, endpoint from `OTEL_EXPORTER_OTLP_ENDPOINT`
+ *
+ * Returns an empty array when `TRACE_EXPORT` is unset/empty (export is **off**
+ * by default) or when no valid backend is selected. The `otlp` backend is
+ * skipped (with a debug warning) if `OTEL_EXPORTER_OTLP_ENDPOINT` is not set.
+ *
+ * @param spec Override the env value (primarily for testing).
+ */
+export function createExportersFromEnv(
+  spec: string | undefined = process.env.TRACE_EXPORT
+): ITraceExporter[] {
+  if (!spec || !spec.trim()) {
+    return [];
+  }
+
+  const backends = spec
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+
+  const exporters: ITraceExporter[] = [];
+
+  for (const backend of backends) {
+    switch (backend) {
+      case 'console':
+        exporters.push(new ConsoleExporter());
+        break;
+      case 'file':
+        exporters.push(
+          new JsonFileExporter(process.env.TRACE_LOG_FILE || 'logs/traces.ndjson')
+        );
+        break;
+      case 'otlp': {
+        const endpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+        if (endpoint) {
+          exporters.push(new OtlpExporter(endpoint));
+        } else {
+          debug('TRACE_EXPORT=otlp requested but OTEL_EXPORTER_OTLP_ENDPOINT is unset — skipping');
+        }
+        break;
+      }
+      default:
+        debug('Unknown TRACE_EXPORT backend %s — ignoring', backend);
+    }
+  }
+
+  return exporters;
+}
+
+/**
+ * Wire trace export into the given {@link PipelineTracer} based on the
+ * `TRACE_EXPORT` env var. No-op (returns `undefined`) when export is off.
+ *
+ * This is the production bootstrap entry point — call once after the tracer
+ * is registered.
+ *
+ * @returns the attached {@link TraceExportManager}, or `undefined` if disabled.
+ */
+export function attachTraceExporters(tracer: PipelineTracer): TraceExportManager | undefined {
+  const exporters = createExportersFromEnv();
+  if (exporters.length === 0) {
+    return undefined;
+  }
+
+  const manager = new TraceExportManager(exporters);
+  manager.attach(tracer);
+  debug('Trace export enabled via TRACE_EXPORT=%s', process.env.TRACE_EXPORT);
+  return manager;
+}

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -19,6 +19,8 @@ export {
   JsonFileExporter,
   OtlpExporter,
   createExporters,
+  createExportersFromEnv,
+  attachTraceExporters,
 } from './TraceExporter';
 export type { ITraceExporter } from './TraceExporter';
 

--- a/src/pipeline/createPipeline.ts
+++ b/src/pipeline/createPipeline.ts
@@ -16,7 +16,12 @@
  */
 
 import type { MessageBus } from '@src/events/MessageBus';
-import { ActivityRecorder, PipelineTracer, setActiveTracer } from '@src/observability';
+import {
+  ActivityRecorder,
+  PipelineTracer,
+  attachTraceExporters,
+  setActiveTracer,
+} from '@src/observability';
 import { ActivityLogger } from '@src/server/services/ActivityLogger';
 import { WebSocketService } from '@src/server/services/WebSocketService';
 import {
@@ -125,6 +130,10 @@ export function createPipeline(bus: MessageBus, deps: PipelineDependencies): boo
   const tracer = new PipelineTracer(bus);
   tracer.register();
   setActiveTracer(tracer);
+
+  // Opt-in trace export to external backends (console / NDJSON file / OTLP).
+  // Off by default; enabled via the TRACE_EXPORT env var. No-op when unset.
+  attachTraceExporters(tracer);
 
   // Record real message activity to the persistent ActivityLogger (JSONL) and
   // the live WebSocket feed so the dashboard ActivityPage / DashboardService

--- a/tests/unit/observability/TraceExporter.attach.test.ts
+++ b/tests/unit/observability/TraceExporter.attach.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for the trace-export bootstrap wiring:
+ *  - createExportersFromEnv() — TRACE_EXPORT env parsing (off by default)
+ *  - attachTraceExporters()   — production entry point used by createPipeline
+ *
+ * These guard the wiring that connects the (already implemented) exporters to
+ * a live PipelineTracer so that completed traces are actually exported.
+ */
+
+import {
+  ConsoleExporter,
+  JsonFileExporter,
+  OtlpExporter,
+  TraceExportManager,
+  createExportersFromEnv,
+  attachTraceExporters,
+} from '../../../src/observability/TraceExporter';
+import type { ITraceExporter } from '../../../src/observability/TraceExporter';
+import { PipelineTracer } from '../../../src/observability/PipelineTracer';
+import type { Trace } from '../../../src/observability/PipelineTracer';
+import { MessageBus } from '../../../src/events/MessageBus';
+import type { MessageContext, MessageEvents } from '../../../src/events/types';
+import type { IMessage } from '../../../src/message/interfaces/IMessage';
+
+function makeMessage(): IMessage {
+  return {
+    getText: () => 'hello',
+    getMessageId: () => 'msg-1',
+    getChannelId: () => 'chan-1',
+    getAuthorId: () => 'user-1',
+  } as unknown as IMessage;
+}
+
+function makeContext(): MessageContext {
+  return {
+    message: makeMessage(),
+    history: [],
+    botConfig: { BOT_NAME: 'TestBot' },
+    botName: 'TestBot',
+    platform: 'discord',
+    channelId: 'chan-1',
+    metadata: { receive: { receivedAt: Date.now() } },
+  } as unknown as MessageContext;
+}
+
+describe('createExportersFromEnv', () => {
+  const ORIGINAL = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL };
+  });
+
+  it('returns no exporters when TRACE_EXPORT is unset (off by default)', () => {
+    delete process.env.TRACE_EXPORT;
+    expect(createExportersFromEnv()).toEqual([]);
+  });
+
+  it('returns no exporters for an empty / whitespace value', () => {
+    expect(createExportersFromEnv('')).toEqual([]);
+    expect(createExportersFromEnv('   ')).toEqual([]);
+  });
+
+  it('selects the console backend', () => {
+    const exporters = createExportersFromEnv('console');
+    expect(exporters).toHaveLength(1);
+    expect(exporters[0]).toBeInstanceOf(ConsoleExporter);
+  });
+
+  it('selects the file backend using TRACE_LOG_FILE', () => {
+    process.env.TRACE_LOG_FILE = 'logs/custom.ndjson';
+    const exporters = createExportersFromEnv('file');
+    expect(exporters).toHaveLength(1);
+    expect(exporters[0]).toBeInstanceOf(JsonFileExporter);
+    expect((exporters[0] as JsonFileExporter).getFilePath()).toBe('logs/custom.ndjson');
+  });
+
+  it('selects the otlp backend only when the endpoint is configured', () => {
+    delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+    expect(createExportersFromEnv('otlp')).toEqual([]);
+
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://localhost:4318';
+    const exporters = createExportersFromEnv('otlp');
+    expect(exporters).toHaveLength(1);
+    expect(exporters[0]).toBeInstanceOf(OtlpExporter);
+  });
+
+  it('parses a comma-separated list and ignores unknown backends', () => {
+    const exporters = createExportersFromEnv('console, bogus , file');
+    expect(exporters).toHaveLength(2);
+    expect(exporters[0]).toBeInstanceOf(ConsoleExporter);
+    expect(exporters[1]).toBeInstanceOf(JsonFileExporter);
+  });
+});
+
+describe('attachTraceExporters', () => {
+  const ORIGINAL = { ...process.env };
+  let bus: MessageBus;
+
+  beforeEach(() => {
+    MessageBus.getInstance().reset();
+    bus = MessageBus.getInstance();
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL };
+    bus.reset();
+  });
+
+  it('returns undefined and attaches nothing when TRACE_EXPORT is off', () => {
+    delete process.env.TRACE_EXPORT;
+    const tracer = new PipelineTracer(bus);
+    expect(attachTraceExporters(tracer)).toBeUndefined();
+  });
+
+  it('attaches a manager that exports completed traces when enabled', async () => {
+    process.env.TRACE_EXPORT = 'console';
+
+    const exported: Trace[] = [];
+    const captureExporter: ITraceExporter = {
+      export: async (t) => {
+        exported.push(t);
+      },
+      shutdown: async () => {},
+    };
+
+    const tracer = new PipelineTracer(bus);
+    tracer.register();
+
+    const manager = attachTraceExporters(tracer);
+    expect(manager).toBeInstanceOf(TraceExportManager);
+    // Add a capture exporter so we can assert a real trace flows through.
+    manager!.getExporters().push(captureExporter);
+
+    // Drive a full trace through the bus: incoming -> ... -> sent.
+    const ctx = makeContext();
+    bus.emit('message:incoming', ctx);
+    bus.emit('message:validated', ctx);
+    bus.emit('message:accepted', {
+      ...ctx,
+      decision: { shouldReply: true },
+    } as unknown as MessageEvents['message:accepted']);
+    bus.emit('message:enriched', {
+      ...ctx,
+      memories: [],
+      systemPrompt: '',
+    } as MessageEvents['message:enriched']);
+    bus.emit('message:response', {
+      ...ctx,
+      responseText: 'hi',
+    } as MessageEvents['message:response']);
+    bus.emit('message:sent', {
+      ...ctx,
+      responseText: 'hi',
+      parts: ['hi'],
+    } as MessageEvents['message:sent']);
+
+    // exportTrace is fire-and-forget; let the microtask queue drain.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(exported).toHaveLength(1);
+    expect(exported[0].traceId).toBeDefined();
+  });
+});


### PR DESCRIPTION
## What
`TraceExporter.ts` fully implemented `ConsoleExporter`, `JsonFileExporter`, `OtlpExporter`, `TraceExportManager.attach()`, and a `createExporters()` factory — but **none of them were ever called in production**. Completed pipeline traces were emitted by `PipelineTracer` (via `onTraceCompleted`) but no exporter ever subscribed, so nothing was exported.

This PR wires trace export into the pipeline bootstrap, opt-in via env and **off by default**.

- Added `createExportersFromEnv(spec?)` — parses the comma-separated `TRACE_EXPORT` list (`console`, `file`, `otlp`), reusing existing exporter classes and the existing `TRACE_LOG_FILE` / `OTEL_EXPORTER_OTLP_ENDPOINT` env vars.
- Added `attachTraceExporters(tracer)` — builds a `TraceExportManager` and attaches it; no-op (returns `undefined`) when `TRACE_EXPORT` is unset.
- Called `attachTraceExporters(tracer)` in `createPipeline()` right after `tracer.register()`.
- Exported the two new helpers from the observability barrel.

## Why
The export layer was dead code in production. Operators had no way to ship pipeline traces to a file or an OTLP backend (Jaeger/Tempo) despite the implementation existing.

## Behavior
- Default (no `TRACE_EXPORT`): unchanged — no exporters attached, zero overhead.
- `TRACE_EXPORT=console`: traces logged via `debug('app:trace-export')`.
- `TRACE_EXPORT=file`: NDJSON appended to `TRACE_LOG_FILE` (default `logs/traces.ndjson`).
- `TRACE_EXPORT=otlp`: POSTed to `OTEL_EXPORTER_OTLP_ENDPOINT` (skipped with a debug warning if the endpoint is unset).
- Comma lists supported (e.g. `console,file`); unknown backends ignored.

## Verification
- `npx tsc --noEmit` clean.
- New test `tests/unit/observability/TraceExporter.attach.test.ts` (8 cases) passes — covers off-by-default, each backend, comma lists, unknown-backend filtering, and an end-to-end attach that drives a full trace through a live `MessageBus` and asserts a completed trace reaches a capture exporter.
- Existing `tests/integration/pipeline/createPipeline.fanout.test.ts` still passes (no regression to pipeline registration).
- ESLint could not run in this environment due to a pre-existing ajv/eslintrc conflict that fails identically on unchanged files; not related to this change.