### PR TITLE
fix(mcp): unify MCP template registries into a single source

### DIFF
--- a/src/config/mcp/toolRegistry.ts
+++ b/src/config/mcp/toolRegistry.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata';
 import { spawn } from 'child_process';
 import { v4 as uuidv4 } from 'uuid';
 import { ErrorUtils } from '@src/types/errors';
+import { toMCPProviderTemplates } from '@src/mcp/templates';
 import type { MCPProviderConfig, MCPProviderTemplate } from '../../types/mcp';
 
 import { injectable } from 'tsyringe';
@@ -238,93 +239,10 @@ export class ToolRegistry {
   }
 
   getTemplates(): MCPProviderTemplate[] {
-    return [
-      {
-        id: 'filesystem-mcp',
-        name: 'File System MCP',
-        type: 'desktop',
-        description: 'Local file system access for reading and writing files',
-        category: 'File System',
-        command: 'npx',
-        args: ['@modelcontextprotocol/server-filesystem'],
-        envVars: [
-          {
-            name: 'FILESYSTEM_ROOT',
-            description: 'Root directory for file system access',
-            required: true,
-            defaultValue: '/tmp/mcp-files',
-          },
-        ],
-        enabledByDefault: false,
-        documentation: 'https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem',
-      },
-      {
-        id: 'web-scraper-mcp',
-        name: 'Web Scraper MCP',
-        type: 'desktop',
-        description: 'Fetch and extract content from web pages',
-        category: 'Web',
-        command: 'npx',
-        args: ['@modelcontextprotocol/server-web-scraper'],
-        envVars: [],
-        enabledByDefault: false,
-        documentation: 'https://github.com/modelcontextprotocol/servers/tree/main/src/web-scraper',
-      },
-      {
-        id: 'github-mcp',
-        name: 'GitHub MCP',
-        type: 'cloud',
-        description: 'Access GitHub repositories, issues, and pull requests',
-        category: 'Development',
-        command: 'npx',
-        args: ['@modelcontextprotocol/server-github'],
-        envVars: [
-          {
-            name: 'GITHUB_TOKEN',
-            description: 'GitHub personal access token',
-            required: true,
-          },
-        ],
-        enabledByDefault: false,
-        documentation: 'https://github.com/modelcontextprotocol/servers/tree/main/src/github',
-      },
-      {
-        id: 'postgres-mcp',
-        name: 'PostgreSQL MCP',
-        type: 'desktop',
-        description: 'Query PostgreSQL databases safely',
-        category: 'Database',
-        command: 'npx',
-        args: ['@modelcontextprotocol/server-postgres'],
-        envVars: [
-          {
-            name: 'POSTGRES_CONNECTION_STRING',
-            description: 'PostgreSQL connection string',
-            required: true,
-          },
-        ],
-        enabledByDefault: false,
-        documentation: 'https://github.com/modelcontextprotocol/servers/tree/main/src/postgres',
-      },
-      {
-        id: 'slack-mcp',
-        name: 'Slack MCP',
-        type: 'cloud',
-        description: 'Send messages and access Slack workspace data',
-        category: 'Communication',
-        command: 'npx',
-        args: ['@modelcontextprotocol/server-slack'],
-        envVars: [
-          {
-            name: 'SLACK_TOKEN',
-            description: 'Slack bot token',
-            required: true,
-          },
-        ],
-        enabledByDefault: false,
-        documentation: 'https://github.com/modelcontextprotocol/servers/tree/main/src/slack',
-      },
-    ];
+    // Derive the API/UI templates from the single static registry in
+    // `src/mcp/templates.ts` so the previously-disconnected source is no longer
+    // dead and the two registries cannot drift apart.
+    return toMCPProviderTemplates();
   }
 
   createFromTemplate(templateId: string, overrides: Partial<MCPProviderConfig>): MCPProviderConfig {

--- a/src/mcp/templates.ts
+++ b/src/mcp/templates.ts
@@ -1,6 +1,13 @@
 /**
  * Registry of common MCP server templates for quick installation.
+ *
+ * This file is the single source of truth for the built-in MCP templates that
+ * both the WebUI gallery and the server-side API (`GET /api/mcp/providers/templates`,
+ * via `ToolRegistry.getTemplates()`) surface. The server consumes these via
+ * {@link toMCPProviderTemplates}, so the two registries never drift apart.
  */
+
+import type { MCPProviderTemplate } from '../types/mcp';
 
 export interface MCPTemplate {
   id: string;
@@ -74,3 +81,43 @@ export const MCP_TEMPLATES: MCPTemplate[] = [
     docsUrl: 'https://docs.mem0.ai',
   },
 ];
+
+/**
+ * Map a single quick-install {@link MCPTemplate} onto the richer
+ * {@link MCPProviderTemplate} shape consumed by the provider API and admin UI.
+ *
+ * The quick-install templates describe network-reachable MCP servers (they
+ * carry a `defaultUrl`), so they map to the `cloud` provider type. The default
+ * URL is preserved as the `command` and each required config field becomes an
+ * environment variable, keeping the existing single source of truth intact.
+ */
+export function toMCPProviderTemplate(template: MCPTemplate): MCPProviderTemplate {
+  return {
+    id: template.id,
+    name: template.name,
+    type: 'cloud',
+    description: template.description,
+    category: 'General',
+    command: template.defaultUrl,
+    args: [],
+    envVars: template.requiredConfigFields.map((field) => ({
+      name: field.key,
+      description: field.description ?? field.label,
+      required: true,
+      defaultValue: '',
+    })),
+    enabledByDefault: false,
+    documentation: template.docsUrl,
+  };
+}
+
+/**
+ * The built-in MCP templates expressed in the provider-template shape used by
+ * the server API. This is what unifies the previously-disconnected static
+ * registry with the server-side `getTemplates()` source.
+ */
+export function toMCPProviderTemplates(
+  templates: MCPTemplate[] = MCP_TEMPLATES,
+): MCPProviderTemplate[] {
+  return templates.map(toMCPProviderTemplate);
+}

--- a/tests/config/mcpTemplatesUnify.test.ts
+++ b/tests/config/mcpTemplatesUnify.test.ts
@@ -1,0 +1,58 @@
+import 'reflect-metadata';
+import { ToolRegistry } from '@src/config/mcp/toolRegistry';
+import { MCP_TEMPLATES, toMCPProviderTemplates } from '@src/mcp/templates';
+
+/**
+ * Regression coverage for the unification of the two previously-disconnected
+ * MCP template registries. `ToolRegistry.getTemplates()` (the source exposed by
+ * the `GET /api/mcp/providers/templates` API the UI consumes) must be derived
+ * from the static `MCP_TEMPLATES` registry in `src/mcp/templates.ts`, so the
+ * static templates are no longer dead and the two cannot drift apart.
+ */
+describe('MCP template unification', () => {
+  it('ToolRegistry.getTemplates() is derived from the static MCP_TEMPLATES registry', () => {
+    const registry = new ToolRegistry();
+    const templates = registry.getTemplates();
+
+    // Same number of templates, in the same order, as the single source.
+    expect(templates).toHaveLength(MCP_TEMPLATES.length);
+    expect(templates.map((t) => t.id)).toEqual(MCP_TEMPLATES.map((t) => t.id));
+
+    // It returns exactly the mapped provider-template shape.
+    expect(templates).toEqual(toMCPProviderTemplates());
+  });
+
+  it('maps a quick-install template onto the provider-template shape', () => {
+    const source = MCP_TEMPLATES.find((t) => t.id === 'google-search');
+    expect(source).toBeDefined();
+
+    const mapped = new ToolRegistry().getTemplates().find((t) => t.id === 'google-search');
+    expect(mapped).toMatchObject({
+      id: 'google-search',
+      name: source!.name,
+      type: 'cloud',
+      description: source!.description,
+      command: source!.defaultUrl,
+      documentation: source!.docsUrl,
+      enabledByDefault: false,
+    });
+
+    // Each required config field becomes a required env var.
+    expect(mapped!.envVars.map((v) => v.name)).toEqual(
+      source!.requiredConfigFields.map((f) => f.key),
+    );
+    expect(mapped!.envVars.every((v) => v.required)).toBe(true);
+  });
+
+  it('createFromTemplate works against a unified template id', () => {
+    const registry = new ToolRegistry();
+    const config = registry.createFromTemplate('google-search', {});
+
+    expect(config.name).toBe('Google Search');
+    expect(config.type).toBe('cloud');
+    // Env vars come from the static template's required config fields.
+    expect(Object.keys(config.env ?? {})).toEqual(
+      expect.arrayContaining(['API_KEY', 'CX']),
+    );
+  });
+});


### PR DESCRIPTION
## What
Unifies the two previously-disconnected MCP template registries. `ToolRegistry.getTemplates()` (the source exposed by `GET /api/mcp/providers/templates`, which the admin UI consumes) now derives its output from the static `MCP_TEMPLATES` registry in `src/mcp/templates.ts` instead of returning a separate, hard-coded list.

## Why
`src/mcp/templates.ts` (`MCP_TEMPLATES`) was imported only by the frontend `TemplateGallery.tsx` and was referenced by nothing server-side, while `ToolRegistry.getTemplates()` returned a completely different, divergent set. The two could silently drift apart. This makes the static file the single source of truth, so the static templates are no longer dead server-side.

## Behavior
- Added `toMCPProviderTemplate` / `toMCPProviderTemplates` in `src/mcp/templates.ts` that map the quick-install `MCPTemplate` shape onto the API's `MCPProviderTemplate` shape (cloud type; `defaultUrl` -> `command`; each required config field -> a required env var; `docsUrl` -> `documentation`).
- `ToolRegistry.getTemplates()` returns `toMCPProviderTemplates()`; `createFromTemplate()` continues to work against these unified ids.
- The API now serves the same templates the gallery shows. No change to the frontend gallery, startup, the default pipeline, auth, or the DB path.

## Verification
- Backend `npx tsc --noEmit`: clean.
- New suite `tests/config/mcpTemplatesUnify.test.ts` (3 tests) passes; existing `tests/config/mcpSpawnError.test.ts` (4 tests) still passes.
- Frontend `src/client` `npx tsc --noEmit`: clean; MCP vitest suites (`MCPServersPage`, `MCPServerManager`) pass.
- Note: repo-wide `eslint` is currently broken in this environment by an ajv/eslintrc version conflict (crashes before linting any file, including unchanged ones) — unrelated to this change.