### PR TITLE
fix(security): enforce sensitive-tool guard on admin MCP call-tool route

### DIFF
--- a/src/server/routes/mcp/servers.ts
+++ b/src/server/routes/mcp/servers.ts
@@ -13,6 +13,7 @@ import {
   connectedClients,
   connectToMCPServer,
   disconnectFromMCPServer,
+  isToolGuardedAsSensitive,
   loadMCPServers,
   saveMCPServers,
   type MCPServer,
@@ -314,6 +315,21 @@ router.post(
       const mcpClient = connectedClients.get(name);
       if (!mcpClient) {
         return res.status(HTTP_STATUS.NOT_FOUND).json({ error: 'MCP server not connected' });
+      }
+
+      // Guard parity with the LLM tool path: tools an operator flagged as
+      // sensitive (mcpGuard.sensitiveTools) require human-in-the-loop approval
+      // and must NOT be executable via the unattended admin direct-call route.
+      // Owner/custom user guards are intentionally not applied here — they need
+      // a bot/forum context this admin route does not have, and this router is
+      // already gated by authenticate + requireAdmin (see ./shared docs).
+      if (isToolGuardedAsSensitive(toolName)) {
+        debug(`Refusing direct admin call of sensitive MCP tool: ${toolName}`);
+        return res.status(HTTP_STATUS.FORBIDDEN).json({
+          error: `Tool "${toolName}" is marked sensitive and requires administrator approval; it cannot be invoked directly.`,
+          code: 'MCP_TOOL_SENSITIVE',
+          timestamp: new Date().toISOString(),
+        });
       }
 
       const result = await mcpClient.client.callTool({

--- a/src/server/routes/mcp/shared.ts
+++ b/src/server/routes/mcp/shared.ts
@@ -4,6 +4,7 @@ import Debug from 'debug';
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import type { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { ErrorUtils } from '@src/types/errors';
+import { BotConfigurationManager } from '@config/BotConfigurationManager';
 
 const debug = Debug('app:webui:mcp:shared');
 
@@ -131,6 +132,53 @@ export const connectToMCPServer = async (server: MCPServer): Promise<MCPClient> 
     throw hivemindError;
   }
 };
+
+/**
+ * Returns the set of tool names that ANY bot has flagged as "sensitive" in an
+ * *enabled* `mcpGuard.sensitiveTools` list.
+ *
+ * The per-bot `MCPGuard` (owner/custom user-allow-list) used on the LLM tool
+ * path is intentionally NOT applied to these admin routes: it gates which
+ * *chat users* in a *bot's forum* may trigger a tool and therefore requires a
+ * bot/forum/owner/user context that simply does not exist for a direct WebUI
+ * admin request (the entire `/api/mcp` router is already locked behind
+ * `authenticate + requireAdmin`). The one piece of guard intent that DOES carry
+ * over is the `sensitiveTools` HITL guardrail: tools an operator has marked as
+ * requiring administrator approval should not be executable via the unattended
+ * direct `call-tool` path either. We therefore aggregate sensitive tool names
+ * across all bot guard configs so the admin route can refuse them, while never
+ * blocking ordinary (non-sensitive) admin tool usage.
+ */
+export const getGuardedSensitiveTools = (): Set<string> => {
+  const sensitive = new Set<string>();
+  try {
+    const bots = BotConfigurationManager.getInstance().getAllBots();
+    for (const bot of bots) {
+      const guard = bot.mcpGuard;
+      if (guard && guard.enabled && Array.isArray(guard.sensitiveTools)) {
+        for (const toolName of guard.sensitiveTools) {
+          if (typeof toolName === 'string' && toolName.length > 0) {
+            sensitive.add(toolName);
+          }
+        }
+      }
+    }
+  } catch (error: unknown) {
+    // Be conservative on lookup failure: do not lock out admins. Log and treat
+    // as "no sensitive tools" so legitimate admin operations still work.
+    const hivemindError = ErrorUtils.toHivemindError(error);
+    debug('Failed to resolve guarded sensitive tools:', ErrorUtils.getMessage(hivemindError));
+  }
+  return sensitive;
+};
+
+/**
+ * Whether a given tool name is flagged sensitive by any enabled bot guard.
+ * Used by the admin direct `call-tool` route to refuse unattended execution of
+ * tools that an operator marked as requiring administrator approval (HITL).
+ */
+export const isToolGuardedAsSensitive = (toolName: string): boolean =>
+  getGuardedSensitiveTools().has(toolName);
 
 // Disconnect from MCP server
 export const disconnectFromMCPServer = async (serverName: string): Promise<void> => {

--- a/tests/unit/server/routes/mcp/callToolGuard.test.ts
+++ b/tests/unit/server/routes/mcp/callToolGuard.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Security regression test for mcp-admin-guard-enforcement.
+ *
+ * The admin `/api/mcp/servers/:name/call-tool` route executed
+ * `client.callTool()` directly with NO guard parity to the LLM tool path. Tools
+ * an operator flagged as sensitive (`mcpGuard.sensitiveTools`) require
+ * human-in-the-loop approval and must not be invokable via this unattended
+ * admin route.
+ *
+ * These tests assert:
+ *  - a NON-sensitive tool is still executed (no admin lockout — conservative);
+ *  - a tool flagged sensitive by any enabled bot guard is refused with 403;
+ *  - the guard helper aggregates sensitive tools only from enabled guards.
+ *
+ * The router (servers.ts) carries no auth middleware itself — auth lives in
+ * mcp/index.ts — so we can mount it directly and focus on the guard behavior.
+ */
+
+import express from 'express';
+import request from 'supertest';
+import { BotConfigurationManager } from '@config/BotConfigurationManager';
+import serversRouter from '@src/server/routes/mcp/servers';
+import {
+  connectedClients,
+  getGuardedSensitiveTools,
+  type MCPClient,
+} from '@src/server/routes/mcp/shared';
+
+type GetAllBots = ReturnType<typeof BotConfigurationManager.getInstance>['getAllBots'];
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/', serversRouter);
+  return app;
+}
+
+function injectFakeClient(serverName: string, callTool: jest.Mock): void {
+  const fakeClient = {
+    client: { callTool },
+  } as unknown as MCPClient;
+  connectedClients.set(serverName, fakeClient);
+}
+
+function mockBots(bots: unknown[]): jest.SpyInstance {
+  return jest
+    .spyOn(BotConfigurationManager, 'getInstance')
+    .mockReturnValue({ getAllBots: (() => bots) as GetAllBots } as ReturnType<
+      typeof BotConfigurationManager.getInstance
+    >);
+}
+
+describe('MCP admin call-tool guard enforcement', () => {
+  const serverName = 'test-server';
+
+  afterEach(() => {
+    connectedClients.delete(serverName);
+    jest.restoreAllMocks();
+  });
+
+  it('executes a non-sensitive tool (no admin lockout)', async () => {
+    const callTool = jest.fn().mockResolvedValue({ content: 'ok', isError: false });
+    injectFakeClient(serverName, callTool);
+    mockBots([{ mcpGuard: { enabled: true, type: 'owner', sensitiveTools: ['danger'] } }]);
+
+    const res = await request(buildApp())
+      .post(`/servers/${serverName}/call-tool`)
+      .send({ toolName: 'safe-tool', arguments: { q: 'hello' } });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(callTool).toHaveBeenCalledWith({ name: 'safe-tool', arguments: { q: 'hello' } });
+  });
+
+  it('refuses a sensitive tool with 403 and never calls the client', async () => {
+    const callTool = jest.fn().mockResolvedValue({ content: 'ok', isError: false });
+    injectFakeClient(serverName, callTool);
+    mockBots([{ mcpGuard: { enabled: true, type: 'owner', sensitiveTools: ['danger'] } }]);
+
+    const res = await request(buildApp())
+      .post(`/servers/${serverName}/call-tool`)
+      .send({ toolName: 'danger', arguments: {} });
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('MCP_TOOL_SENSITIVE');
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
+  it('ignores sensitiveTools from a disabled guard', () => {
+    mockBots([
+      { mcpGuard: { enabled: false, type: 'owner', sensitiveTools: ['danger'] } },
+      { mcpGuard: { enabled: true, type: 'custom', sensitiveTools: ['live'] } },
+      { mcpGuard: undefined },
+    ]);
+
+    const sensitive = getGuardedSensitiveTools();
+    expect(sensitive.has('live')).toBe(true);
+    expect(sensitive.has('danger')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What
Adds guard parity to the admin `POST /api/mcp/servers/:name/call-tool` route. Previously it executed `client.callTool()` directly with no MCPGuard enforcement (only `authenticate + requireAdmin` at the router). Tools an operator flagged as sensitive (`mcpGuard.sensitiveTools`) are now refused on this route with HTTP 403 (`code: MCP_TOOL_SENSITIVE`).

New helpers in `src/server/routes/mcp/shared.ts`:
- `getGuardedSensitiveTools()` aggregates `sensitiveTools` across all *enabled* bot guard configs.
- `isToolGuardedAsSensitive(toolName)` used by the route to refuse direct execution.

## Why
`sensitiveTools` is a human-in-the-loop (HITL) approval guardrail (see `ToolManager.ts` / `PendingActionManager`). The LLM tool path honors it; the direct admin route bypassed it entirely, so a tool an operator explicitly marked "requires admin approval" could be run unattended via the WebUI API.

The owner/custom user-allow-list portion of `MCPGuard` is intentionally **not** applied here, and this is documented in `shared.ts`: those checks gate which chat users in a bot's forum may trigger a tool and require a bot/forum/owner/user context that does not exist for a direct admin request. That router is already locked behind `authenticate + requireAdmin`.

## Behavior
- Non-sensitive tool, admin call: executes as before (no lockout, conservative).
- Tool flagged sensitive by any enabled bot guard: 403, client never invoked.
- Disabled guards contribute no sensitive tools. Lookup failure is swallowed (logged) and treated as "no sensitive tools" so admins are never locked out.

## Verification
- `npx tsc --noEmit` clean.
- New suite `tests/unit/server/routes/mcp/callToolGuard.test.ts` (3 tests) passes; existing `MCPService` and `enrichMcpServers` suites still pass (14 tests).
- ESLint could not run in this environment (pre-existing ajv/eslintrc breakage in the shared node_modules, fails identically on unchanged files); changes mirror the surrounding file's import/error/debug patterns.
- Frontend untouched (backend-only change).
