### PR TITLE
fix(letta): robust session-mode resolution via SDK capability detection

### DIFF
--- a/packages/llm-letta/src/lettaProvider.test.ts
+++ b/packages/llm-letta/src/lettaProvider.test.ts
@@ -191,6 +191,70 @@ describe('LettaProvider session modes', () => {
     expect(mockConvCreate).not.toHaveBeenCalled();
   });
 
+  it('falls back to default when the SDK lacks the conversations API', async () => {
+    // Simulate an older/stubbed SDK build with no conversations resource.
+    MockLetta.mockImplementationOnce(
+      () =>
+        ({
+          agents: { messages: { create: mockCreate } },
+          // No `conversations` property at all.
+        }) as any
+    );
+    mockCreate.mockResolvedValue({
+      messages: [{ role: 'assistant', content: 'default fallback response' }],
+    });
+
+    const provider = LettaProvider.getInstance({
+      agentId: 'agent-123',
+      sessionMode: 'per-channel',
+    });
+
+    const result = await provider.generateChatCompletion('hello', [], {
+      agentId: 'agent-123',
+      channelId: '456',
+    });
+
+    // Capability gap is handled gracefully: routes through the default agent API.
+    expect(result).toBe('default fallback response');
+    expect(mockCreate).toHaveBeenCalledWith('agent-123', { input: 'hello' });
+    // No attempt to list/create conversations on an unsupported SDK.
+    expect(mockConvList).not.toHaveBeenCalled();
+    expect(mockConvCreate).not.toHaveBeenCalled();
+  });
+
+  it('falls back to default when conversations.create is not a function', async () => {
+    // Partial SDK: list exists but create is missing/non-callable.
+    MockLetta.mockImplementationOnce(
+      () =>
+        ({
+          agents: { messages: { create: mockCreate } },
+          conversations: {
+            list: mockConvList,
+            create: undefined,
+            messages: { create: mockConvMessageCreate },
+          },
+        }) as any
+    );
+    mockCreate.mockResolvedValue({
+      messages: [{ role: 'assistant', content: 'partial fallback response' }],
+    });
+
+    const provider = LettaProvider.getInstance({
+      agentId: 'agent-123',
+      sessionMode: 'per-user',
+    });
+
+    const result = await provider.generateChatCompletion('hello', [], {
+      agentId: 'agent-123',
+      userId: 'user-789',
+    });
+
+    expect(result).toBe('partial fallback response');
+    expect(mockCreate).toHaveBeenCalledWith('agent-123', { input: 'hello' });
+    // Capability check short-circuits before calling list when the API is incomplete.
+    expect(mockConvList).not.toHaveBeenCalled();
+  });
+
   it('cache hit avoids duplicate conversation creation calls', async () => {
     mockConvList.mockResolvedValue([]);
     mockConvCreate.mockResolvedValue({ id: 'conv-cached', summary: 'channel-789' });

--- a/packages/llm-letta/src/lettaProvider.ts
+++ b/packages/llm-letta/src/lettaProvider.ts
@@ -12,6 +12,41 @@ export interface LettaProviderConfig {
   conversationId?: string;
 }
 
+/**
+ * Minimal structural type for a Letta conversation. The SDK ships a richer
+ * `Conversation` type, but we only depend on `id` and `summary`; declaring our
+ * own surface keeps the provider resilient to non-breaking SDK shape changes.
+ */
+interface LettaConversation {
+  id: string;
+  summary?: string | null;
+}
+
+/**
+ * The conversations sub-API we rely on for non-default session modes. Older
+ * SDK versions (or stubbed/self-hosted servers) may not expose `list`/`create`.
+ * We detect this at runtime via {@link getConversationsApi} rather than assuming
+ * the methods exist.
+ */
+interface LettaConversationsApi {
+  list?: (query: { agent_id: string }) => Promise<LettaConversation[] | undefined>;
+  create?: (body: { agent_id: string; summary: string }) => Promise<LettaConversation | undefined>;
+}
+
+/**
+ * Runtime capability check: returns the typed conversations API only when both
+ * `list` and `create` are callable. Returns null when the SDK build in use does
+ * not support session modes, so callers can surface (debug) the degradation
+ * instead of silently behaving as if creation merely "failed".
+ */
+function getConversationsApi(client: Letta): LettaConversationsApi | null {
+  const api = (client as unknown as { conversations?: LettaConversationsApi }).conversations;
+  if (api && typeof api.list === 'function' && typeof api.create === 'function') {
+    return api;
+  }
+  return null;
+}
+
 export class LettaProvider implements ILlmProvider {
   name = 'letta';
   private client: Letta;
@@ -101,13 +136,25 @@ export class LettaProvider implements ILlmProvider {
       return cached;
     }
 
-    try {
-      const clientAny = this.client as any;
+    // Detect whether the installed SDK exposes the conversations API. When it
+    // does not, surface (debug) the capability gap explicitly instead of
+    // treating it as an ordinary create failure — the two are different and a
+    // missing API is a deployment/version issue worth diagnosing.
+    const conversations = getConversationsApi(this.client);
+    if (!conversations) {
+      debug(
+        'Letta SDK does not expose conversations.list/create; session mode unavailable, ' +
+          'falling back to default conversation for key %s',
+        cacheKey
+      );
+      return 'default';
+    }
 
+    try {
       // Try to list existing conversations and find by summary
-      const existing = await clientAny.conversations?.list?.({ agent_id: agentId });
+      const existing = await conversations.list?.({ agent_id: agentId });
       if (existing && Array.isArray(existing)) {
-        const match = existing.find((conv: any) => conv.summary === summary);
+        const match = existing.find((conv) => conv.summary === summary);
         if (match?.id) {
           debug('Found existing conversation for key %s: %s', cacheKey, match.id);
           this.conversationCache.set(cacheKey, match.id);
@@ -116,7 +163,7 @@ export class LettaProvider implements ILlmProvider {
       }
 
       // Create new conversation with human-readable summary
-      const created = await clientAny.conversations?.create?.({
+      const created = await conversations.create?.({
         agent_id: agentId,
         summary,
       });


### PR DESCRIPTION
@
## What
Make Letta session-mode (`per-channel`/`per-user`/`fixed`) resolution robust by detecting whether the installed `@letta-ai/letta-client` SDK actually exposes the `conversations` API, instead of accessing it through `as any` and silently falling back to the `default` conversation.

## Why
`resolveConversationId` / `getOrCreateConversation` in `packages/llm-letta/src/lettaProvider.ts` reached `conversations.list`/`create` via `this.client as any` and returned `default` whenever those methods were absent — indistinguishable from a normal create failure. A missing API is a deployment/SDK-version issue worth diagnosing, not silent degradation. The SDK (v1.10.2) does type these methods, so the `as any` was also unnecessary.

## Behavior
- Added `getConversationsApi(client)`: a runtime capability check returning a properly-typed `LettaConversationsApi` only when both `list` and `create` are callable functions, otherwise `null`.
- When the API is unavailable, `getOrCreateConversation` now emits a distinct `debug` message ("Letta SDK does not expose conversations.list/create; session mode unavailable...") and falls back to `default` — surfacing the gap rather than hiding it.
- Replaced the `as any` on the list/create path with structural `LettaConversation` / `LettaConversationsApi` types. No `any` is newly introduced (net reduction).
- No behavior change for working SDKs: `per-channel`/`per-user`/`fixed` and caching all behave identically.

## Verification
- Backend `tsc --noEmit` (root tsconfig): 0 errors.
- `packages/llm-letta/src/lettaProvider.test.ts`: 17/17 pass, including 2 new tests:
  - falls back to default when the SDK has no `conversations` resource at all
  - falls back to default when `conversations.create` is missing/non-callable (partial SDK)
- Frontend checks N/A (backend-only package change).
- ESLint could not run in this environment due to a pre-existing ajv/eslintrc breakage unrelated to this change; the diff introduces no new lint-relevant patterns and removes `any` usage.
@