### PR TITLE
feat(botConfig): complete two-phase approval workflow (list/approve/reject)

### DIFF
--- a/src/server/routes/botConfig.ts
+++ b/src/server/routes/botConfig.ts
@@ -114,6 +114,194 @@ router.get(
 );
 
 /**
+ * GET /webui/api/bot-config/approvals
+ * List bot-configuration approval requests (admin only).
+ * Optional query param `status` filters by 'pending' | 'approved' | 'rejected'
+ * (or 'all'). Defaults to listing pending requests so the WebUI can render an
+ * approval queue. Registered BEFORE `/:botId` so it is not shadowed by the
+ * single-segment param route.
+ */
+router.get(
+  '/approvals',
+  requireRole('admin'),
+  asyncErrorHandler(async (req, res) => {
+    try {
+      const dbManager = DatabaseManager.getInstance();
+      if (!dbManager.isConnected()) {
+        return res
+          .status(HTTP_STATUS.SERVICE_UNAVAILABLE)
+          .json(ApiResponse.error('Database not connected', undefined, 503));
+      }
+
+      const statusParam = typeof req.query.status === 'string' ? req.query.status : 'pending';
+      const allowedStatuses = ['pending', 'approved', 'rejected', 'all'];
+      if (!allowedStatuses.includes(statusParam)) {
+        return res
+          .status(HTTP_STATUS.BAD_REQUEST)
+          .json(ApiResponse.error('Invalid status filter', undefined, 400));
+      }
+
+      const statusFilter = statusParam === 'all' ? undefined : statusParam;
+      const approvals = await dbManager.getApprovalRequests(
+        'BotConfiguration',
+        undefined,
+        statusFilter
+      );
+
+      return res.json(ApiResponse.success({ approvals, total: approvals.length }));
+    } catch (error: unknown) {
+      const hivemindError = ErrorUtils.toHivemindError(error);
+      debug('Error listing approval requests:', hivemindError);
+      return res
+        .status(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+        .json(ApiResponse.error('Failed to list approval requests', undefined, 500));
+    }
+  })
+);
+
+/**
+ * POST /webui/api/bot-config/approvals/:approvalId/approve
+ * Approve a pending bot-configuration change request (admin only).
+ * Transitions status pending -> approved so it can be applied via apply-update.
+ */
+router.post(
+  '/approvals/:approvalId/approve',
+  configLimiter,
+  requireRole('admin'),
+  asyncErrorHandler(async (req, res) => {
+    const { approvalId } = req.params;
+    try {
+      const dbManager = DatabaseManager.getInstance();
+      if (!dbManager.isConnected()) {
+        return res
+          .status(HTTP_STATUS.SERVICE_UNAVAILABLE)
+          .json(ApiResponse.error('Database not connected', undefined, 503));
+      }
+
+      const id = parseInt(approvalId, 10);
+      if (Number.isNaN(id)) {
+        return res
+          .status(HTTP_STATUS.BAD_REQUEST)
+          .json(ApiResponse.error('Invalid approval request id', undefined, 400));
+      }
+
+      const approvalRequest = await dbManager.getApprovalRequest(id);
+      if (!approvalRequest) {
+        return res
+          .status(HTTP_STATUS.NOT_FOUND)
+          .json(ApiResponse.error('Approval request not found', undefined, 404));
+      }
+
+      if (approvalRequest.status !== 'pending') {
+        return res
+          .status(HTTP_STATUS.BAD_REQUEST)
+          .json(
+            ApiResponse.error(
+              `Approval request is not pending (status: ${approvalRequest.status})`,
+              undefined,
+              400
+            )
+          );
+      }
+
+      await dbManager.updateApprovalRequest(id, {
+        status: 'approved',
+        reviewedBy: req.user?.username,
+        reviewedAt: new Date(),
+        reviewComments: typeof req.body?.comments === 'string' ? req.body.comments : undefined,
+      });
+
+      logConfigChange(
+        req,
+        'UPDATE',
+        String(approvalRequest.resourceId),
+        'success',
+        'Bot configuration change approved'
+      );
+
+      return res.json(ApiResponse.success({ approvalId: id, status: 'approved' }));
+    } catch (error: unknown) {
+      const hivemindError = ErrorUtils.toHivemindError(error);
+      debug('Error approving approval request:', hivemindError);
+      return res
+        .status(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+        .json(ApiResponse.error('Failed to approve approval request', undefined, 500));
+    }
+  })
+);
+
+/**
+ * POST /webui/api/bot-config/approvals/:approvalId/reject
+ * Reject a pending bot-configuration change request (admin only).
+ * Transitions status pending -> rejected; the change is never applied.
+ */
+router.post(
+  '/approvals/:approvalId/reject',
+  configLimiter,
+  requireRole('admin'),
+  asyncErrorHandler(async (req, res) => {
+    const { approvalId } = req.params;
+    try {
+      const dbManager = DatabaseManager.getInstance();
+      if (!dbManager.isConnected()) {
+        return res
+          .status(HTTP_STATUS.SERVICE_UNAVAILABLE)
+          .json(ApiResponse.error('Database not connected', undefined, 503));
+      }
+
+      const id = parseInt(approvalId, 10);
+      if (Number.isNaN(id)) {
+        return res
+          .status(HTTP_STATUS.BAD_REQUEST)
+          .json(ApiResponse.error('Invalid approval request id', undefined, 400));
+      }
+
+      const approvalRequest = await dbManager.getApprovalRequest(id);
+      if (!approvalRequest) {
+        return res
+          .status(HTTP_STATUS.NOT_FOUND)
+          .json(ApiResponse.error('Approval request not found', undefined, 404));
+      }
+
+      if (approvalRequest.status !== 'pending') {
+        return res
+          .status(HTTP_STATUS.BAD_REQUEST)
+          .json(
+            ApiResponse.error(
+              `Approval request is not pending (status: ${approvalRequest.status})`,
+              undefined,
+              400
+            )
+          );
+      }
+
+      await dbManager.updateApprovalRequest(id, {
+        status: 'rejected',
+        reviewedBy: req.user?.username,
+        reviewedAt: new Date(),
+        reviewComments: typeof req.body?.comments === 'string' ? req.body.comments : undefined,
+      });
+
+      logConfigChange(
+        req,
+        'UPDATE',
+        String(approvalRequest.resourceId),
+        'success',
+        'Bot configuration change rejected'
+      );
+
+      return res.json(ApiResponse.success({ approvalId: id, status: 'rejected' }));
+    } catch (error: unknown) {
+      const hivemindError = ErrorUtils.toHivemindError(error);
+      debug('Error rejecting approval request:', hivemindError);
+      return res
+        .status(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+        .json(ApiResponse.error('Failed to reject approval request', undefined, 500));
+    }
+  })
+);
+
+/**
  * GET /webui/api/bot-config/:botId
  * Get a specific bot configuration
  // eslint-disable-next-line unused-imports/no-unused-vars

--- a/tests/unit/server/routes/botConfigApprovals.test.ts
+++ b/tests/unit/server/routes/botConfigApprovals.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Tests for the bot-configuration two-phase approval workflow HTTP routes.
+ *
+ * Item (botconfig-approval-complete):
+ *  - PUT /api/bot-config/:botId creates an approval request (pending) instead of
+ *    applying the change.
+ *  - POST /api/bot-config/:botId/apply-update applies the change only once the
+ *    request is 'approved'.
+ *
+ * Before this change there was NO way to move a request from pending -> approved
+ * (or reject it) or to list pending requests, so apply-update was unreachable and
+ * the workflow was unusable end-to-end. These tests cover the new
+ * list / approve / reject routes that complete the workflow.
+ */
+
+import express from 'express';
+import request from 'supertest';
+
+// --- Stub the heavy config singletons constructed at module import time ---
+jest.mock('@src/config/BotConfigurationManager', () => ({
+  BotConfigurationManager: {
+    getInstance: jest.fn(() => ({
+      getBot: jest.fn(),
+      getWarnings: jest.fn(() => []),
+      isLegacyMode: jest.fn(() => false),
+      reload: jest.fn(),
+    })),
+  },
+}));
+
+jest.mock('@src/config/SecureConfigManager', () => ({
+  SecureConfigManager: {
+    getInstanceSync: jest.fn(() => ({ storeConfig: jest.fn() })),
+  },
+}));
+
+jest.mock('@src/config/UserConfigStore', () => ({
+  UserConfigStore: {
+    getInstance: jest.fn(() => ({
+      getAllBotOverrides: jest.fn(() => new Map()),
+      getBotOverride: jest.fn(),
+      setBotOverride: jest.fn(),
+    })),
+  },
+}));
+
+// --- Auth middleware: pass-through that attaches an admin user ---
+jest.mock('@src/auth/middleware', () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.user = { username: 'admin-user', role: 'admin' };
+    next();
+  },
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+  requireRole: () => (_req: any, _res: any, next: any) => next(),
+}));
+
+// --- Audit middleware: no-op ---
+jest.mock('@src/server/middleware/audit', () => ({
+  auditMiddleware: (_req: any, _res: any, next: any) => next(),
+  logConfigChange: jest.fn(),
+}));
+
+// --- Rate limiter: no-op ---
+jest.mock('@src/middleware/rateLimiter', () => ({
+  configLimiter: (_req: any, _res: any, next: any) => next(),
+}));
+
+// --- DatabaseManager: controllable approval-request store ---
+const isConnected = jest.fn(() => true);
+const getApprovalRequest = jest.fn();
+const getApprovalRequests = jest.fn();
+const updateApprovalRequest = jest.fn();
+
+jest.mock('@src/database/DatabaseManager', () => ({
+  DatabaseManager: {
+    getInstance: jest.fn(() => ({
+      isConnected,
+      getApprovalRequest,
+      getApprovalRequests,
+      updateApprovalRequest,
+    })),
+  },
+}));
+
+// Import the router AFTER the mocks are registered.
+import botConfigRouter from '@src/server/routes/botConfig';
+import { globalErrorHandler } from '@src/middleware/errorHandler';
+
+function createApp(): express.Application {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/bot-config', botConfigRouter);
+  app.use(globalErrorHandler);
+  return app;
+}
+
+const samplePending = {
+  id: 7,
+  resourceType: 'BotConfiguration',
+  resourceId: 1,
+  changeType: 'UPDATE',
+  requestedBy: 'admin-user',
+  diff: JSON.stringify({ old: {}, new: { persona: 'helpful' } }),
+  status: 'pending',
+  createdAt: new Date('2026-01-01T00:00:00.000Z').toISOString(),
+};
+
+describe('Bot configuration approval workflow routes', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isConnected.mockReturnValue(true);
+    app = createApp();
+  });
+
+  describe('GET /api/bot-config/approvals', () => {
+    it('lists pending bot-configuration approval requests by default', async () => {
+      getApprovalRequests.mockResolvedValue([samplePending]);
+
+      const res = await request(app).get('/api/bot-config/approvals');
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.approvals).toHaveLength(1);
+      expect(res.body.data.total).toBe(1);
+      // Defaults to BotConfiguration resourceType + 'pending' status.
+      expect(getApprovalRequests).toHaveBeenCalledWith('BotConfiguration', undefined, 'pending');
+    });
+
+    it('forwards an explicit status filter and supports "all"', async () => {
+      getApprovalRequests.mockResolvedValue([]);
+
+      await request(app).get('/api/bot-config/approvals?status=all');
+
+      expect(getApprovalRequests).toHaveBeenCalledWith('BotConfiguration', undefined, undefined);
+    });
+
+    it('rejects an invalid status filter with 400', async () => {
+      const res = await request(app).get('/api/bot-config/approvals?status=bogus');
+
+      expect(res.status).toBe(400);
+      expect(getApprovalRequests).not.toHaveBeenCalled();
+    });
+
+    it('is not shadowed by the /:botId route (route ordering)', async () => {
+      // If /approvals were treated as a botId, getApprovalRequests would never
+      // be called. Asserting it IS called proves the list route is reachable.
+      getApprovalRequests.mockResolvedValue([]);
+
+      const res = await request(app).get('/api/bot-config/approvals');
+
+      expect(res.status).toBe(200);
+      expect(getApprovalRequests).toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /api/bot-config/approvals/:approvalId/approve', () => {
+    it('transitions a pending request to approved', async () => {
+      getApprovalRequest.mockResolvedValue({ ...samplePending });
+      updateApprovalRequest.mockResolvedValue(true);
+
+      const res = await request(app)
+        .post('/api/bot-config/approvals/7/approve')
+        .send({ comments: 'looks good' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toMatchObject({ approvalId: 7, status: 'approved' });
+      expect(updateApprovalRequest).toHaveBeenCalledWith(
+        7,
+        expect.objectContaining({ status: 'approved', reviewedBy: 'admin-user' })
+      );
+    });
+
+    it('returns 404 when the approval request does not exist', async () => {
+      getApprovalRequest.mockResolvedValue(null);
+
+      const res = await request(app).post('/api/bot-config/approvals/99/approve').send({});
+
+      expect(res.status).toBe(404);
+      expect(updateApprovalRequest).not.toHaveBeenCalled();
+    });
+
+    it('refuses to approve a request that is not pending', async () => {
+      getApprovalRequest.mockResolvedValue({ ...samplePending, status: 'approved' });
+
+      const res = await request(app).post('/api/bot-config/approvals/7/approve').send({});
+
+      expect(res.status).toBe(400);
+      expect(updateApprovalRequest).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for a non-numeric approval id', async () => {
+      const res = await request(app).post('/api/bot-config/approvals/abc/approve').send({});
+
+      expect(res.status).toBe(400);
+      expect(getApprovalRequest).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /api/bot-config/approvals/:approvalId/reject', () => {
+    it('transitions a pending request to rejected', async () => {
+      getApprovalRequest.mockResolvedValue({ ...samplePending });
+      updateApprovalRequest.mockResolvedValue(true);
+
+      const res = await request(app)
+        .post('/api/bot-config/approvals/7/reject')
+        .send({ comments: 'no thanks' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toMatchObject({ approvalId: 7, status: 'rejected' });
+      expect(updateApprovalRequest).toHaveBeenCalledWith(
+        7,
+        expect.objectContaining({ status: 'rejected', reviewedBy: 'admin-user' })
+      );
+    });
+
+    it('refuses to reject a request that is not pending', async () => {
+      getApprovalRequest.mockResolvedValue({ ...samplePending, status: 'rejected' });
+
+      const res = await request(app).post('/api/bot-config/approvals/7/reject').send({});
+
+      expect(res.status).toBe(400);
+      expect(updateApprovalRequest).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## What
Adds the missing HTTP routes that complete the bot-configuration two-phase approval workflow:
- `GET  /api/bot-config/approvals` — list approval requests (optional `?status=pending|approved|rejected|all`, defaults to `pending`)
- `POST /api/bot-config/approvals/:approvalId/approve` — transition pending → approved
- `POST /api/bot-config/approvals/:approvalId/reject` — transition pending → rejected

## Why
`PUT /api/bot-config/:botId` creates a *pending* approval request (it does not apply the change), and `POST /api/bot-config/:botId/apply-update` applies a change only once its request is `approved`. But there was **no route** to move a request from pending → approved/rejected, nor to list pending requests. As a result `apply-update` was unreachable and the approval workflow was unusable end-to-end. The DB layer (`DatabaseManager`/`ApprovalRepository`) already supported `getApprovalRequests`/`updateApprovalRequest`; only the HTTP surface was missing.

## Behavior
- All three routes are admin-only (`requireRole('admin')`) and return the standard `ApiResponse` envelope.
- Approve/reject only act on `pending` requests (409-style 400 otherwise), validate a numeric id, set `reviewedBy`/`reviewedAt`/optional `reviewComments`, and audit via `logConfigChange`.
- The list route is registered **before** `/:botId` so `/approvals` is not shadowed by the single-segment param route; it is scoped to `resourceType = 'BotConfiguration'`.
- No change to startup, the default pipeline, auth, the live DB path, or existing routes.

## Verification
- Backend `npx tsc --noEmit`: clean.
- New Jest suite `tests/unit/server/routes/botConfigApprovals.test.ts`: **10/10 passing** (list default/filter/invalid/ordering, approve success/404/non-pending/bad-id, reject success/non-pending).
- ESLint could not be run: the environment's ESLint install crashes at module load (ajv `defaultMeta` TypeError) on **any** file including unchanged ones — pre-existing, unrelated to this change. New code mirrors the existing patterns in the same file.

Note: the frontend `ApprovalsTab.tsx` still renders mock data ("will connect to real API later"); wiring it to these endpoints is follow-up out of scope here.