### PR TITLE
fix(pipeline): de-duplicate pipeline:decision broadcast

### DIFF
--- a/src/message/helpers/processing/shouldReplyToMessage.ts
+++ b/src/message/helpers/processing/shouldReplyToMessage.ts
@@ -67,6 +67,20 @@ export interface ReplyDecision {
   meta?: Record<string, unknown>;
 }
 
+/**
+ * Options controlling side effects of {@link shouldReplyToMessage}.
+ */
+export interface ShouldReplyOptions {
+  /**
+   * When `true`, the `pipeline:decision` WebSocket event is NOT emitted from
+   * this function. Set by the pipeline's {@link DecisionStrategyAdapter} so that
+   * {@link DecisionStage} can own the broadcast (with full swarm/claim context)
+   * and avoid emitting the event twice per message. The legacy non-pipeline
+   * handler leaves this unset so the event is still emitted from here.
+   */
+  suppressBroadcast?: boolean;
+}
+
 export async function shouldReplyToMessage(
   message: MessageLike,
   botId: string,
@@ -74,7 +88,8 @@ export async function shouldReplyToMessage(
   botNameOrNames?: string | string[],
   historyMessages?: HistoryMessageLike[],
   defaultChannelId?: string,
-  botConfig?: Record<string, unknown>
+  botConfig?: Record<string, unknown>,
+  options?: ShouldReplyOptions
 ): Promise<ReplyDecision> {
   const result = await evaluateReplyDecision(
     message,
@@ -83,7 +98,8 @@ export async function shouldReplyToMessage(
     botNameOrNames,
     historyMessages,
     defaultChannelId,
-    botConfig
+    botConfig,
+    options
   );
 
   // Extract bot name for persistence
@@ -134,7 +150,8 @@ async function evaluateReplyDecision(
   botNameOrNames?: string | string[],
   historyMessages?: HistoryMessageLike[],
   defaultChannelId?: string,
-  botConfig?: Record<string, unknown>
+  botConfig?: Record<string, unknown>,
+  options?: ShouldReplyOptions
 ): Promise<ReplyDecision> {
   if (process.env.FORCE_REPLY && process.env.FORCE_REPLY.toLowerCase() === 'true') {
     debug('FORCE_REPLY env var enabled. Forcing reply.');
@@ -635,20 +652,24 @@ async function evaluateReplyDecision(
     hasPostedRecently
   );
 
-  // Emit orchestration decision for live thinking stream
-  const bus = MessageBus.getInstance();
-  bus.emit('pipeline:decision', {
-    botName: nameCandidates[0] || 'Unknown',
-    messageId: message.getMessageId(),
-    channelId: message.getChannelId(),
-    shouldReply: decision,
-    reason: prose,
-    probabilityRoll: Number(roll.toPrecision(3)),
-    threshold: Number(chance.toPrecision(3)),
-    meta: {
-      ...modsObject,
-    },
-  });
+  // Emit orchestration decision for live thinking stream.
+  // Skipped when invoked through the pipeline (DecisionStage owns the broadcast)
+  // to avoid emitting `pipeline:decision` twice per message.
+  if (!options?.suppressBroadcast) {
+    const bus = MessageBus.getInstance();
+    bus.emit('pipeline:decision', {
+      botName: nameCandidates[0] || 'Unknown',
+      messageId: message.getMessageId(),
+      channelId: message.getChannelId(),
+      shouldReply: decision,
+      reason: prose,
+      probabilityRoll: Number(roll.toPrecision(3)),
+      threshold: Number(chance.toPrecision(3)),
+      meta: {
+        ...modsObject,
+      },
+    });
+  }
 
   return {
     shouldReply: decision,

--- a/src/pipeline/DecisionStage.ts
+++ b/src/pipeline/DecisionStage.ts
@@ -20,7 +20,7 @@
 import Debug from 'debug';
 import { container } from 'tsyringe';
 import { type MessageBus } from '@src/events/MessageBus';
-import type { MessageContext, ReplyDecision } from '@src/events/types';
+import type { MessageContext, MessageEvents, ReplyDecision } from '@src/events/types';
 import { SwarmCoordinator } from '@src/services/SwarmCoordinator';
 import { type ActivityRecorder, DefaultActivityRecorder } from './ActivityRecorder';
 import { PipelineDebuggerService } from '../server/services/PipelineDebuggerService';
@@ -34,6 +34,49 @@ const debug = Debug('app:pipeline:decision');
  */
 function resolveServiceName(ctx: MessageContext): string {
   return String(ctx.botConfig.MESSAGE_PROVIDER || ctx.platform || 'generic');
+}
+
+type DecisionPayload = MessageEvents['pipeline:decision'];
+
+/**
+ * Build the single `pipeline:decision` payload broadcast for the live
+ * Orchestration Log. Promotes the probability `rolled`/`probability` fields out
+ * of the decision `meta` onto the top-level `probabilityRoll`/`threshold` keys
+ * (mirroring the shape the legacy `shouldReplyToMessage` emit produced) so the
+ * UI keeps the richer payload after de-duplicating the event.
+ */
+function buildDecisionPayload(args: {
+  botName: string;
+  messageId: string;
+  channelId: string;
+  shouldReply: boolean;
+  reason?: string;
+  meta?: Record<string, unknown>;
+}): DecisionPayload {
+  const { botName, messageId, channelId, shouldReply, reason, meta } = args;
+
+  const payload: DecisionPayload = {
+    botName,
+    messageId,
+    channelId,
+    shouldReply,
+    reason: reason ?? '',
+    meta: meta ?? {},
+  };
+
+  if (meta) {
+    if (meta.rolled !== undefined && Number.isFinite(Number(meta.rolled))) {
+      payload.probabilityRoll = Number(meta.rolled);
+    }
+    if (meta.probability !== undefined) {
+      const threshold = parseFloat(String(meta.probability).replace(/[<>]/g, ''));
+      if (Number.isFinite(threshold)) {
+        payload.threshold = threshold;
+      }
+    }
+  }
+
+  return payload;
 }
 
 // ---------------------------------------------------------------------------
@@ -169,33 +212,32 @@ export class DecisionStage {
         meta: decision.meta,
       };
 
+      // Build the single `pipeline:decision` payload for the live Orchestration
+      // Log. DecisionStage is the sole owner of this broadcast for the pipeline
+      // path; `shouldReplyToMessage` suppresses its own emit (via the
+      // DecisionStrategyAdapter) so the event is not emitted twice per message.
+      const decisionPayload = buildDecisionPayload({
+        botName,
+        messageId,
+        channelId,
+        shouldReply: decision.shouldReply,
+        reason: decision.reason,
+        meta: decision.meta,
+      });
+
       if (decision.shouldReply) {
         // Claim the message for this bot
         swarm.claimMessage(messageId, botName);
         debug('[DecisionStage] Message %s: claimed by %s', messageId, botId);
 
         // Broadcast decision to WebSocket for Live Orchestration Log
-        this.bus.emit('pipeline:decision', {
-          botName,
-          messageId,
-          channelId,
-          shouldReply: true,
-          reason: decision.reason,
-          ...(decision.meta || {}),
-        });
+        this.bus.emit('pipeline:decision', decisionPayload);
 
         await this.bus.emitAsync('message:accepted', { ...ctx, decision });
         debug('Message accepted: bot=%s reason=%s', ctx.botName, decision.reason);
       } else {
         // Broadcast decision to WebSocket for Live Orchestration Log
-        this.bus.emit('pipeline:decision', {
-          botName,
-          messageId,
-          channelId,
-          shouldReply: false,
-          reason: decision.reason,
-          ...(decision.meta || {}),
-        });
+        this.bus.emit('pipeline:decision', decisionPayload);
 
         await this.bus.emitAsync('message:skipped', { ...ctx, reason: decision.reason });
         debug('Message skipped: bot=%s reason=%s', ctx.botName, decision.reason);

--- a/src/pipeline/adapters/DecisionStrategyAdapter.ts
+++ b/src/pipeline/adapters/DecisionStrategyAdapter.ts
@@ -49,7 +49,11 @@ export class DecisionStrategyAdapter implements DecisionStrategy {
       ctx.history,
       defaultChannelId,
 
-      ctx.botConfig as Record<string, any>
+      ctx.botConfig as Record<string, any>,
+      // Suppress the broadcast here: DecisionStage owns the single
+      // `pipeline:decision` emit for the pipeline path (avoids a duplicate
+      // event in the live Orchestration Log).
+      { suppressBroadcast: true }
     );
 
     // The legacy ReplyDecision shape matches the pipeline's ReplyDecision,

--- a/tests/unit/pipeline/decisionBroadcastDedup.test.ts
+++ b/tests/unit/pipeline/decisionBroadcastDedup.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Regression test for the duplicate `pipeline:decision` broadcast.
+ *
+ * Before the fix, a `pipeline:decision` event was emitted TWICE per message in
+ * the default pipeline path:
+ *   1. inside `shouldReplyToMessage()` (full prose/roll/threshold/mods payload),
+ *      reached via the DecisionStrategyAdapter, and
+ *   2. inside `DecisionStage.process()` (reason + meta).
+ * The live Orchestration Log therefore showed duplicate decision entries.
+ *
+ * After the fix, DecisionStage is the SOLE owner of the broadcast for the
+ * pipeline path: the adapter passes `suppressBroadcast: true` to
+ * `shouldReplyToMessage`, and DecisionStage emits exactly once with the full
+ * payload (promoting `rolled`/`probability` from meta to the top-level
+ * `probabilityRoll`/`threshold` fields).
+ */
+
+import { MessageBus } from '@src/events/MessageBus';
+import type { MessageEvents } from '@src/events/types';
+import { DecisionStage, type DecisionStrategy } from '@src/pipeline/DecisionStage';
+import type { ActivityRecorder } from '@src/pipeline/ActivityRecorder';
+import { SwarmCoordinator } from '@src/services/SwarmCoordinator';
+import { IMessage } from '@message/interfaces/IMessage';
+
+type DecisionEvent = MessageEvents['pipeline:decision'];
+
+class StubMessage extends IMessage {
+  constructor(
+    private id = 'msg-dedup',
+    private fromBot = false
+  ) {
+    super({}, fromBot ? 'assistant' : 'user');
+    this.content = 'hello';
+    this.channelId = 'ch-dedup';
+    this.platform = 'discord';
+  }
+  getMessageId(): string {
+    return this.id;
+  }
+  getText(): string {
+    return this.content;
+  }
+  getTimestamp(): Date {
+    return new Date();
+  }
+  setText(t: string): void {
+    this.content = t;
+  }
+  getChannelId(): string {
+    return this.channelId;
+  }
+  getAuthorId(): string {
+    return this.fromBot ? 'bot-author' : 'user-1';
+  }
+  getChannelTopic(): string | null {
+    return null;
+  }
+  getUserMentions(): string[] {
+    return [];
+  }
+  getChannelUsers(): string[] {
+    return [];
+  }
+  mentionsUsers(): boolean {
+    return false;
+  }
+  isFromBot(): boolean {
+    return this.fromBot;
+  }
+  getAuthorName(): string {
+    return 'Tester';
+  }
+}
+
+function makeContext(message: IMessage) {
+  return {
+    message,
+    history: [],
+    botConfig: {},
+    botName: 'TestBot',
+    platform: 'discord',
+    channelId: message.getChannelId(),
+    metadata: {},
+  };
+}
+
+function noopRecorder(): ActivityRecorder {
+  return {
+    recordInteraction: jest.fn(),
+    recordBotResponse: jest.fn(),
+  };
+}
+
+describe('pipeline:decision broadcast de-duplication', () => {
+  let bus: MessageBus;
+  let events: DecisionEvent[];
+
+  beforeEach(() => {
+    MessageBus.getInstance().reset();
+    bus = MessageBus.getInstance();
+    SwarmCoordinator.resetInstance();
+    events = [];
+    bus.on('pipeline:decision', (e) => {
+      events.push(e);
+    });
+  });
+
+  afterEach(() => {
+    bus.reset();
+  });
+
+  it('emits pipeline:decision exactly once when accepted', async () => {
+    const strategy: DecisionStrategy = {
+      shouldReply: jest.fn().mockResolvedValue({
+        shouldReply: true,
+        reason: 'Chance roll success',
+        meta: { rolled: 0.12, probability: '<0.5', SomeMod: 0.3 },
+      }),
+    };
+    const stage = new DecisionStage(bus, strategy, noopRecorder());
+
+    await stage.process(makeContext(new StubMessage('m-accept', false)));
+
+    expect(events).toHaveLength(1);
+    const ev = events[0];
+    expect(ev.shouldReply).toBe(true);
+    expect(ev.botName).toBe('TestBot');
+    expect(ev.messageId).toBe('m-accept');
+    expect(ev.channelId).toBe('ch-dedup');
+    // meta fields promoted to top-level for the live log.
+    expect(ev.probabilityRoll).toBe(0.12);
+    expect(ev.threshold).toBe(0.5);
+    // meta is preserved.
+    expect(ev.meta).toMatchObject({ SomeMod: 0.3 });
+  });
+
+  it('emits pipeline:decision exactly once when skipped', async () => {
+    const strategy: DecisionStrategy = {
+      shouldReply: jest.fn().mockResolvedValue({
+        shouldReply: false,
+        reason: 'Chance roll failure',
+        meta: { rolled: 0.9, probability: '<0.1' },
+      }),
+    };
+    const stage = new DecisionStage(bus, strategy, noopRecorder());
+
+    await stage.process(makeContext(new StubMessage('m-skip', false)));
+
+    expect(events).toHaveLength(1);
+    expect(events[0].shouldReply).toBe(false);
+    expect(events[0].probabilityRoll).toBe(0.9);
+    expect(events[0].threshold).toBe(0.1);
+  });
+
+  it('emits pipeline:decision exactly once when another bot already claimed', async () => {
+    // Pre-claim the message under a different bot id.
+    SwarmCoordinator.getInstance().claimMessage('m-claimed', 'OtherBot');
+
+    const strategy: DecisionStrategy = {
+      shouldReply: jest.fn().mockResolvedValue({ shouldReply: true, reason: 'should not run' }),
+    };
+    const stage = new DecisionStage(bus, strategy, noopRecorder());
+
+    const ctx = makeContext(new StubMessage('m-claimed', false));
+    ctx.botConfig = { BOT_ID: 'ThisBot' } as Record<string, unknown>;
+    await stage.process(ctx);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].shouldReply).toBe(false);
+    // The strategy must not even run once the message is already claimed.
+    expect(strategy.shouldReply).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What
De-duplicates the `pipeline:decision` WebSocket event so the live Orchestration Log no longer shows two entries per message.

## Why
In the default (pipeline) message path the event was emitted **twice** per message:
1. inside `shouldReplyToMessage()` (`src/message/helpers/processing/shouldReplyToMessage.ts:640`) — full prose/roll/threshold/mods payload, reached via `DecisionStrategyAdapter`; and
2. inside `DecisionStage.process()` (`src/pipeline/DecisionStage.ts` accepted/skipped branches) — reason + meta.

Both fired for the same decision, so the Orchestration Log rendered duplicate decision events.

## Behavior
- `DecisionStage` is now the **sole owner** of the broadcast for the pipeline path. It already emits for every branch (already-claimed, accepted, skipped, error), so it owns the single emit and promotes `meta.rolled`/`meta.probability` to the top-level `probabilityRoll`/`threshold` fields so the live log keeps the richer payload.
- `DecisionStrategyAdapter` passes `{ suppressBroadcast: true }` to `shouldReplyToMessage`, which skips its own emit when invoked through the pipeline.
- The **legacy** non-pipeline handler (`replyDecision.ts`, `USE_LEGACY_HANDLER=true`) calls `shouldReplyToMessage` directly and leaves `suppressBroadcast` unset, so it still emits exactly once — no behavior change for that path.

## Verification
- `npx tsc --noEmit` clean.
- New test `tests/unit/pipeline/decisionBroadcastDedup.test.ts` asserts exactly one emit on the accept, skip, and already-claimed paths, and verifies the promoted `probabilityRoll`/`threshold` fields. Passes (3/3).
- Existing `pipelineActivityTracking.test.ts` (5/5) and `fullPipeline.integration.test.ts` (10/10) still pass — no regression.
- (eslint could not run: the repo's pinned eslint/ajv install crashes on load in this environment before linting any file — pre-existing, unrelated to this change.)