### PR TITLE
feat(mcp): persist tool favorites/recents/usage server-side

### DIFF
--- a/src/client/src/pages/MCPToolsPage/hooks/useToolRegistry.ts
+++ b/src/client/src/pages/MCPToolsPage/hooks/useToolRegistry.ts
@@ -1,9 +1,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import useUrlParams from '../../../hooks/useUrlParams';
 import { useLocalStorage } from '../../../hooks/useLocalStorage';
 import { apiService } from '../../../services/api';
 import type { MCPTool, RecentToolUsage, AlertState } from '../types';
+
+interface MCPFavoritesPayload {
+  favorites?: string[];
+  recentlyUsed?: RecentToolUsage[];
+  usageCounts?: Record<string, number>;
+}
 
 interface UseToolRegistryProps {
   setAlert: (alert: AlertState | null) => void;
@@ -46,6 +52,46 @@ export function useToolRegistry({ setAlert }: UseToolRegistryProps): {
   const [favorites, setFavorites] = useLocalStorage<string[]>('mcp-tools-favorites', []);
   const [recentlyUsed, setRecentlyUsed] = useLocalStorage<RecentToolUsage[]>('mcp-tools-recently-used', []);
   const [usageCounts, setUsageCounts] = useLocalStorage<Record<string, number>>('mcp-tools-usage-counts', {});
+
+  // Server-side persistence so favorites / recents / usage-counts survive across
+  // devices and sessions. We hydrate from the server on mount (falling back to
+  // the localStorage values when the request fails) and persist changes back.
+  // `hydratedRef` guards against the initial-state save overwriting server data.
+  const hydratedRef = useRef(false);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const resp: any = await apiService.get('/api/mcp/tools/favorites');
+        const data: MCPFavoritesPayload = resp?.data ?? {};
+        if (cancelled) return;
+        if (Array.isArray(data.favorites)) setFavorites(data.favorites);
+        if (Array.isArray(data.recentlyUsed)) setRecentlyUsed(data.recentlyUsed);
+        if (data.usageCounts && typeof data.usageCounts === 'object') setUsageCounts(data.usageCounts);
+      } catch {
+        // Server unavailable — keep the localStorage-backed values as fallback.
+      } finally {
+        if (!cancelled) hydratedRef.current = true;
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Persist registry preferences back to the server whenever they change
+  // (after the initial hydration). Debounced to coalesce rapid updates.
+  useEffect(() => {
+    if (!hydratedRef.current) return;
+    const handle = setTimeout(() => {
+      apiService
+        .put('/api/mcp/tools/favorites', { favorites, recentlyUsed, usageCounts })
+        .catch(() => {
+          // Ignore persistence errors — localStorage still holds the values.
+        });
+    }, 500);
+    return () => clearTimeout(handle);
+  }, [favorites, recentlyUsed, usageCounts]);
 
   useEffect(() => {
     const fetchTools = async () => {

--- a/src/server/ShutdownCoordinator.ts
+++ b/src/server/ShutdownCoordinator.ts
@@ -521,6 +521,18 @@ export class ShutdownCoordinator {
       debug('Error shutting down ToolPreferencesService:', error);
     }
 
+    // Stop MCPFavoritesService
+    try {
+      const { MCPFavoritesService } = require('@server/services/MCPFavoritesService');
+      const mcpFavorites = MCPFavoritesService.getInstance();
+      if (mcpFavorites && typeof mcpFavorites.shutdown === 'function') {
+        await mcpFavorites.shutdown();
+        debug('MCPFavoritesService shut down');
+      }
+    } catch (error) {
+      debug('Error shutting down MCPFavoritesService:', error);
+    }
+
     // Stop PerformanceProfiler
     try {
       const { PerformanceProfiler } = require('@utils/PerformanceProfiler');

--- a/src/server/routes/mcp/index.ts
+++ b/src/server/routes/mcp/index.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { authenticate, requireAdmin } from '../../../auth/middleware';
 import providersRouter from './providers';
 import serversRouter from './servers';
+import toolsRouter from './tools';
 
 const router = Router();
 
@@ -10,5 +11,6 @@ router.use(authenticate, requireAdmin);
 
 router.use('/', serversRouter);
 router.use('/', providersRouter);
+router.use('/', toolsRouter);
 
 export default router;

--- a/src/server/routes/mcp/tools.ts
+++ b/src/server/routes/mcp/tools.ts
@@ -1,0 +1,65 @@
+import Debug from 'debug';
+import { Router } from 'express';
+import { ErrorUtils } from '@src/types/errors';
+import { asyncErrorHandler } from '../../../middleware/errorHandler';
+import { MCPFavoritesService } from '../../services/MCPFavoritesService';
+
+const debug = Debug('app:webui:mcp:tools');
+const router = Router();
+
+/**
+ * GET /api/mcp/tools/favorites
+ *
+ * Server-side persistence for the MCP Tools page registry preferences
+ * (favorites, recently-used, usage counts). The WebUI hydrates from here on
+ * load and falls back to localStorage when the request fails.
+ */
+router.get(
+  '/tools/favorites',
+  asyncErrorHandler(async (_req, res) => {
+    try {
+      const service = MCPFavoritesService.getInstance();
+      await service.ready();
+      return res.json({ success: true, data: service.getAll() });
+    } catch (error: unknown) {
+      const hivemindError = ErrorUtils.toHivemindError(error);
+      debug('Error fetching MCP favorites:', ErrorUtils.getMessage(hivemindError));
+      return res.status(ErrorUtils.getStatusCode(hivemindError) || 500).json({
+        success: false,
+        error: ErrorUtils.getMessage(hivemindError),
+        code: ErrorUtils.getCode(hivemindError) || 'MCP_FAVORITES_FETCH_ERROR',
+        timestamp: new Date().toISOString(),
+      });
+    }
+  })
+);
+
+/**
+ * PUT /api/mcp/tools/favorites
+ *
+ * Persist a (partial) update of the registry preferences. Any omitted field is
+ * left unchanged so the client can save just the slice that changed.
+ */
+router.put(
+  '/tools/favorites',
+  asyncErrorHandler(async (req, res) => {
+    try {
+      const { favorites, recentlyUsed, usageCounts } = req.body ?? {};
+      const service = MCPFavoritesService.getInstance();
+      await service.ready();
+      const data = await service.setAll({ favorites, recentlyUsed, usageCounts });
+      return res.json({ success: true, data });
+    } catch (error: unknown) {
+      const hivemindError = ErrorUtils.toHivemindError(error);
+      debug('Error saving MCP favorites:', ErrorUtils.getMessage(hivemindError));
+      return res.status(ErrorUtils.getStatusCode(hivemindError) || 500).json({
+        success: false,
+        error: ErrorUtils.getMessage(hivemindError),
+        code: ErrorUtils.getCode(hivemindError) || 'MCP_FAVORITES_SAVE_ERROR',
+        timestamp: new Date().toISOString(),
+      });
+    }
+  })
+);
+
+export default router;

--- a/src/server/services/MCPFavoritesService.ts
+++ b/src/server/services/MCPFavoritesService.ts
@@ -1,0 +1,177 @@
+import fs from 'fs';
+import path from 'path';
+import Debug from 'debug';
+
+const debug = Debug('app:MCPFavoritesService');
+
+/**
+ * A single recently-used tool entry. Mirrors the client-side
+ * `RecentToolUsage` shape so the WebUI can hydrate directly from the API.
+ */
+export interface RecentToolUsage {
+  toolId: string;
+  timestamp: string;
+  arguments?: Record<string, unknown>;
+}
+
+/**
+ * The full set of per-user MCP tool registry preferences that previously
+ * lived only in the browser's localStorage. Persisting these server-side lets
+ * favorites / recents / usage counts survive across devices and sessions.
+ */
+export interface MCPFavoritesData {
+  favorites: string[];
+  recentlyUsed: RecentToolUsage[];
+  usageCounts: Record<string, number>;
+  lastUpdated: string;
+}
+
+const MAX_RECENT = 10;
+
+export class MCPFavoritesService {
+  private static instance: MCPFavoritesService;
+  private dataFile: string;
+  private data: MCPFavoritesData;
+  private saveTimeout: NodeJS.Timeout | null = null;
+  private initialized: Promise<void>;
+
+  private constructor(dataFile?: string) {
+    const dataDir = path.join(process.cwd(), 'data');
+    this.dataFile = dataFile ?? path.join(dataDir, 'mcp-favorites.json');
+    this.data = {
+      favorites: [],
+      recentlyUsed: [],
+      usageCounts: {},
+      lastUpdated: new Date().toISOString(),
+    };
+    this.initialized = this.initializeData();
+  }
+
+  public static getInstance(): MCPFavoritesService {
+    if (!MCPFavoritesService.instance) {
+      MCPFavoritesService.instance = new MCPFavoritesService();
+    }
+    return MCPFavoritesService.instance;
+  }
+
+  /**
+   * Test helper: build an isolated instance backed by a specific file so unit
+   * tests do not touch the shared singleton or the real `data/` directory.
+   */
+  public static createForTesting(dataFile: string): MCPFavoritesService {
+    return new MCPFavoritesService(dataFile);
+  }
+
+  /** Resolves once the backing file has been read (or created). */
+  public async ready(): Promise<void> {
+    return this.initialized;
+  }
+
+  private async initializeData(): Promise<void> {
+    try {
+      const dataDir = path.dirname(this.dataFile);
+      await fs.promises.mkdir(dataDir, { recursive: true });
+
+      try {
+        const content = await fs.promises.readFile(this.dataFile, 'utf8');
+        const parsed = JSON.parse(content) as Partial<MCPFavoritesData>;
+        this.data = {
+          favorites: Array.isArray(parsed.favorites) ? parsed.favorites : [],
+          recentlyUsed: Array.isArray(parsed.recentlyUsed) ? parsed.recentlyUsed : [],
+          usageCounts:
+            parsed.usageCounts && typeof parsed.usageCounts === 'object' ? parsed.usageCounts : {},
+          lastUpdated: parsed.lastUpdated ?? new Date().toISOString(),
+        };
+        debug('Loaded MCP favorites from file');
+      } catch (error: unknown) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          debug('No existing MCP favorites file, starting fresh');
+          await this.saveData();
+        } else {
+          throw error;
+        }
+      }
+    } catch (error) {
+      debug('Failed to initialize MCP favorites data: %O', error);
+    }
+  }
+
+  private async saveData(): Promise<void> {
+    try {
+      this.data.lastUpdated = new Date().toISOString();
+      await fs.promises.writeFile(this.dataFile, JSON.stringify(this.data, null, 2), 'utf8');
+      debug('Saved MCP favorites to file');
+    } catch (error) {
+      debug('Failed to save MCP favorites: %O', error);
+      throw error;
+    }
+  }
+
+  private debouncedSave(): void {
+    if (this.saveTimeout) {
+      clearTimeout(this.saveTimeout);
+    }
+    this.saveTimeout = setTimeout(() => {
+      this.saveData().catch((error) => {
+        debug('Failed to save MCP favorites: %O', error);
+      });
+    }, 1000);
+  }
+
+  /** Return the full preferences payload (defensive copy). */
+  public getAll(): MCPFavoritesData {
+    return {
+      favorites: [...this.data.favorites],
+      recentlyUsed: this.data.recentlyUsed.map((r) => ({ ...r })),
+      usageCounts: { ...this.data.usageCounts },
+      lastUpdated: this.data.lastUpdated,
+    };
+  }
+
+  /**
+   * Replace the stored preferences. Any field omitted from the patch is left
+   * unchanged, so the WebUI can persist just the slice that changed.
+   * Saves immediately (awaitable) so callers/tests can rely on durability.
+   */
+  public async setAll(patch: Partial<Omit<MCPFavoritesData, 'lastUpdated'>>): Promise<MCPFavoritesData> {
+    if (Array.isArray(patch.favorites)) {
+      // De-duplicate while preserving insertion order.
+      this.data.favorites = Array.from(new Set(patch.favorites));
+    }
+    if (Array.isArray(patch.recentlyUsed)) {
+      this.data.recentlyUsed = patch.recentlyUsed.slice(0, MAX_RECENT).map((r) => ({ ...r }));
+    }
+    if (patch.usageCounts && typeof patch.usageCounts === 'object') {
+      this.data.usageCounts = { ...patch.usageCounts };
+    }
+    await this.saveData();
+    return this.getAll();
+  }
+
+  /** Toggle a tool's favorite status and persist. Returns the new list. */
+  public async toggleFavorite(toolId: string): Promise<string[]> {
+    if (this.data.favorites.includes(toolId)) {
+      this.data.favorites = this.data.favorites.filter((id) => id !== toolId);
+    } else {
+      this.data.favorites = [...this.data.favorites, toolId];
+    }
+    await this.saveData();
+    return [...this.data.favorites];
+  }
+
+  /**
+   * Shutdown and cleanup resources, flushing any pending debounced write.
+   */
+  public async shutdown(): Promise<void> {
+    if (this.saveTimeout) {
+      clearTimeout(this.saveTimeout);
+      this.saveTimeout = null;
+    }
+    await this.saveData().catch((err) => {
+      debug('Failed to save data during shutdown: %O', err);
+    });
+    debug('MCPFavoritesService shutdown completed');
+  }
+}
+
+export default MCPFavoritesService;

--- a/tests/unit/server/services/MCPFavoritesService.test.ts
+++ b/tests/unit/server/services/MCPFavoritesService.test.ts
@@ -1,0 +1,109 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { MCPFavoritesService } from '../../../../src/server/services/MCPFavoritesService';
+
+/**
+ * Tests for MCPFavoritesService — the server-side store that persists the MCP
+ * Tools page registry preferences (favorites, recently-used, usage counts) so
+ * they survive across devices/sessions instead of living only in localStorage.
+ *
+ * Each test uses an isolated temp file via `createForTesting` so the shared
+ * singleton and the real `data/` directory are never touched.
+ */
+describe('MCPFavoritesService', () => {
+  let tmpDir: string;
+  let dataFile: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mcp-fav-'));
+    dataFile = path.join(tmpDir, 'mcp-favorites.json');
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('starts empty and creates the backing file', async () => {
+    const service = MCPFavoritesService.createForTesting(dataFile);
+    await service.ready();
+
+    const data = service.getAll();
+    expect(data.favorites).toEqual([]);
+    expect(data.recentlyUsed).toEqual([]);
+    expect(data.usageCounts).toEqual({});
+    expect(fs.existsSync(dataFile)).toBe(true);
+  });
+
+  it('persists a partial update and leaves omitted fields unchanged', async () => {
+    const service = MCPFavoritesService.createForTesting(dataFile);
+    await service.ready();
+
+    await service.setAll({ favorites: ['srv-toolA'], usageCounts: { 'srv-toolA': 3 } });
+    // Update only recentlyUsed — favorites/usageCounts must remain.
+    const result = await service.setAll({
+      recentlyUsed: [{ toolId: 'srv-toolA', timestamp: '2026-01-01T00:00:00.000Z' }],
+    });
+
+    expect(result.favorites).toEqual(['srv-toolA']);
+    expect(result.usageCounts).toEqual({ 'srv-toolA': 3 });
+    expect(result.recentlyUsed).toHaveLength(1);
+  });
+
+  it('de-duplicates favorites', async () => {
+    const service = MCPFavoritesService.createForTesting(dataFile);
+    await service.ready();
+
+    const result = await service.setAll({ favorites: ['a', 'b', 'a'] });
+    expect(result.favorites).toEqual(['a', 'b']);
+  });
+
+  it('toggles a favorite on and off', async () => {
+    const service = MCPFavoritesService.createForTesting(dataFile);
+    await service.ready();
+
+    expect(await service.toggleFavorite('srv-toolX')).toEqual(['srv-toolX']);
+    expect(await service.toggleFavorite('srv-toolX')).toEqual([]);
+  });
+
+  it('reloads persisted data from disk into a fresh instance', async () => {
+    const writer = MCPFavoritesService.createForTesting(dataFile);
+    await writer.ready();
+    await writer.setAll({
+      favorites: ['srv-toolA'],
+      usageCounts: { 'srv-toolA': 7 },
+      recentlyUsed: [{ toolId: 'srv-toolA', timestamp: '2026-01-01T00:00:00.000Z' }],
+    });
+
+    // Simulate a new process / device picking up the same backing file.
+    const reader = MCPFavoritesService.createForTesting(dataFile);
+    await reader.ready();
+    const data = reader.getAll();
+
+    expect(data.favorites).toEqual(['srv-toolA']);
+    expect(data.usageCounts).toEqual({ 'srv-toolA': 7 });
+    expect(data.recentlyUsed[0].toolId).toBe('srv-toolA');
+  });
+
+  it('caps recently-used entries at the configured maximum', async () => {
+    const service = MCPFavoritesService.createForTesting(dataFile);
+    await service.ready();
+
+    const many = Array.from({ length: 25 }, (_v, i) => ({
+      toolId: `srv-tool${i}`,
+      timestamp: '2026-01-01T00:00:00.000Z',
+    }));
+    const result = await service.setAll({ recentlyUsed: many });
+
+    expect(result.recentlyUsed).toHaveLength(10);
+    expect(result.recentlyUsed[0].toolId).toBe('srv-tool0');
+  });
+
+  it('tolerates a corrupt backing file by starting fresh', async () => {
+    await fs.promises.writeFile(dataFile, '{ not valid json', 'utf8');
+    const service = MCPFavoritesService.createForTesting(dataFile);
+    await service.ready();
+
+    expect(service.getAll().favorites).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What
Adds server-side persistence for the MCP Tools page registry preferences — favorites, recently-used tools, and per-tool usage counts.

- New `MCPFavoritesService` (file-backed singleton at `data/mcp-favorites.json`, debounced save, shutdown flush) modeled on the existing `ToolPreferencesService`.
- New `GET`/`PUT /api/mcp/tools/favorites` endpoints (`src/server/routes/mcp/tools.ts`), mounted under the existing admin-secured `/api/mcp` router.
- `useToolRegistry` now hydrates from the server on mount and persists changes back (debounced), keeping localStorage as the fallback.
- Registered in `ShutdownCoordinator` so the debounced write flushes on shutdown.

## Why
Previously favorites/recents/usage-counts lived **only** in browser `localStorage` (`useToolRegistry.ts:46-48`), so they did not survive across devices or sessions. This adds durable server-side storage while preserving the offline/localStorage fallback.

## Behavior
- On page load, the hook fetches `/api/mcp/tools/favorites`; if it succeeds, server values seed the UI (and localStorage). If the request fails, the existing localStorage values are kept.
- Any change to favorites / recents / usage counts is PUT back to the server (debounced 500ms). Persistence failures are swallowed — localStorage still holds the values.
- `PUT` accepts a partial payload; omitted fields are left unchanged. Favorites are de-duplicated; recents are capped at 10.

## Verification
- Backend `npx tsc --noEmit`: clean.
- New jest suite `tests/unit/server/services/MCPFavoritesService.test.ts`: **7/7 passing** (empty init, partial update, de-dup, toggle, reload-from-disk, recents cap, corrupt-file recovery).
- Frontend `npx tsc --noEmit` (src/client): clean.
- Vitest harness verified (existing CommandPalette routes suite passes).
- ESLint could not run: the repo's installed ESLint 9 fails environment-wide with an ajv `defaultMeta` error before linting any file (reproduced on an untouched existing file). New code follows the conventions of neighboring route/service files.

## Deferrals
- Storage is global (single-tenant), matching `ToolPreferencesService`. Per-user scoping is deferred — wire `req.user` into the service key when multi-user MCP preferences are needed.
