### PR TITLE
fix(llm-routing): cover all wired provider types in task routing

### DIFF
--- a/src/llm/taskLlmRouter.ts
+++ b/src/llm/taskLlmRouter.ts
@@ -3,6 +3,7 @@ import { getLlmProfileByKey } from '@src/config/llmProfiles';
 import ProviderConfigManager, { type ProviderInstance } from '@src/config/ProviderConfigManager';
 import { UserConfigStore } from '@src/config/UserConfigStore';
 import { MetricsCollector } from '@src/monitoring/MetricsCollector';
+import { instantiateLlmProvider, loadPlugin } from '@src/plugins/PluginLoader';
 import llmTaskConfig from '@config/llmTaskConfig';
 import { FlowiseProvider } from '@integrations/flowise/flowiseProvider';
 import * as openWebUIImport from '@integrations/openwebui/runInference';
@@ -100,6 +101,36 @@ const openWebUI: ILlmProvider = {
   },
 };
 
+/**
+ * Resolve a provider type to an ILlmProvider.
+ *
+ * The few types with bespoke wiring in this module (a shared `openwebui`
+ * singleton, the direct `flowise`/`openai` constructors) keep their fast
+ * paths; every other wired type (`letta`, `openswarm`, …) is resolved
+ * through the same plugin loader that `getLlmProvider` uses, so task-based
+ * routing supports all wired provider types rather than a hardcoded subset.
+ */
+async function buildProviderForType(
+  type: string,
+  cfg: Record<string, unknown>
+): Promise<ILlmProvider | undefined> {
+  switch (type) {
+    case 'openai': {
+      const { OpenAiProvider } = await import('@hivemind/llm-openai');
+
+      return new OpenAiProvider(cfg as any);
+    }
+    case 'flowise':
+      return new FlowiseProvider(cfg);
+    case 'openwebui':
+      return openWebUI;
+    default: {
+      const mod = await loadPlugin(`llm-${type}`);
+      return instantiateLlmProvider(mod, cfg);
+    }
+  }
+}
+
 async function createProviderFromInstance(
   instance: ProviderInstance,
   modelOverride?: string
@@ -109,21 +140,9 @@ async function createProviderFromInstance(
     const baseConfig = instance.config || {};
     const cfg = modelOverride ? { ...baseConfig, model: modelOverride } : baseConfig;
 
-    let provider: ILlmProvider | undefined;
-    switch (type) {
-      case 'openai':
-        const { OpenAiProvider } = await import('@hivemind/llm-openai');
-
-        provider = new OpenAiProvider(cfg as any);
-        break;
-      case 'flowise':
-        provider = new FlowiseProvider(cfg);
-        break;
-      case 'openwebui':
-        provider = openWebUI;
-        break;
-      default:
-        return null;
+    const provider = await buildProviderForType(type, cfg as Record<string, unknown>);
+    if (!provider) {
+      return null;
     }
 
     return withTokenCounting(provider, instance.id);
@@ -177,21 +196,17 @@ async function createProviderFromProfile(profileKey: string): Promise<ILlmProvid
     const cfg = profile.config || {};
 
     let provider: ILlmProvider | undefined;
-    switch (type) {
-      case 'openai':
-        const { OpenAiProvider } = await import('@hivemind/llm-openai');
-
-        provider = new OpenAiProvider(cfg as any);
-        break;
-      case 'flowise':
-        provider = new FlowiseProvider(cfg);
-        break;
-      case 'openwebui':
-        provider = openWebUI;
-        break;
-      default:
-        debug(`Profile "${profileKey}" has unsupported provider type "${type}"`);
-        return null;
+    try {
+      provider = await buildProviderForType(type, cfg as Record<string, unknown>);
+    } catch (err) {
+      debug(
+        `Profile "${profileKey}" provider type "${type}" failed to load: ${err instanceof Error ? err.message : String(err)}`
+      );
+      return null;
+    }
+    if (!provider) {
+      debug(`Profile "${profileKey}" has unsupported provider type "${type}"`);
+      return null;
     }
 
     return withTokenCounting(provider, `profile:${profileKey}`);

--- a/tests/unit/llm/taskLlmRouter.test.ts
+++ b/tests/unit/llm/taskLlmRouter.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Unit tests for {@link getTaskLlm} provider-construction coverage.
+ *
+ * Focus: task-based routing must be able to construct providers for ALL
+ * wired LLM provider types, not just the hardcoded `openai`/`flowise`/
+ * `openwebui` fast paths. Previously the switch statements in
+ * `createProviderFromInstance` / `createProviderFromProfile` returned `null`
+ * for types like `letta` and `openswarm`, silently falling back to the
+ * default provider. These now resolve through the shared plugin loader.
+ */
+
+import { getTaskLlm } from '@src/llm/taskLlmRouter';
+import type { ILlmProvider } from '@llm/interfaces/ILlmProvider';
+
+// --- Mocks for collaborators ----------------------------------------------
+
+const mockLoadPlugin = jest.fn();
+const mockInstantiateLlmProvider = jest.fn();
+
+jest.mock('@src/plugins/PluginLoader', () => ({
+  loadPlugin: (...args: unknown[]) => mockLoadPlugin(...args),
+  instantiateLlmProvider: (...args: unknown[]) => mockInstantiateLlmProvider(...args),
+}));
+
+const mockGetAllProviders = jest.fn();
+jest.mock('@src/config/ProviderConfigManager', () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => ({
+      getAllProviders: (...args: unknown[]) => mockGetAllProviders(...args),
+    }),
+  },
+}));
+
+const mockGetGeneralSettings = jest.fn();
+jest.mock('@src/config/UserConfigStore', () => ({
+  UserConfigStore: {
+    getInstance: () => ({
+      getGeneralSettings: (...args: unknown[]) => mockGetGeneralSettings(...args),
+    }),
+  },
+}));
+
+const mockGetLlmProfileByKey = jest.fn();
+jest.mock('@src/config/llmProfiles', () => ({
+  getLlmProfileByKey: (...args: unknown[]) => mockGetLlmProfileByKey(...args),
+}));
+
+const mockGetLlmProvider = jest.fn();
+jest.mock('@llm/getLlmProvider', () => ({
+  getLlmProvider: (...args: unknown[]) => mockGetLlmProvider(...args),
+}));
+
+// Task overrides are read via convict, which snapshots env at construction.
+// Drive them directly through this mutable store instead.
+const taskOverrides: Record<string, string> = {};
+jest.mock('@config/llmTaskConfig', () => ({
+  __esModule: true,
+  default: {
+    get: (key: string) => taskOverrides[key] ?? '',
+  },
+}));
+
+// Avoid pulling MetricsCollector singleton side-effects into the test.
+jest.mock('@src/monitoring/MetricsCollector', () => ({
+  MetricsCollector: {
+    getInstance: () => ({ recordLlmTokenUsage: jest.fn() }),
+  },
+}));
+
+function makeProvider(name: string): ILlmProvider {
+  return {
+    name,
+    supportsChatCompletion: () => true,
+    supportsCompletion: () => false,
+    generateChatCompletion: jest.fn().mockResolvedValue('ok'),
+    generateCompletion: jest.fn().mockResolvedValue('ok'),
+  } as unknown as ILlmProvider;
+}
+
+describe('taskLlmRouter provider-construction coverage', () => {
+  const fallback = makeProvider('fallback');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Clear any task overrides + back-compat alias env vars.
+    for (const k of Object.keys(taskOverrides)) {
+      delete taskOverrides[k];
+    }
+    for (const t of ['SEMANTIC', 'SUMMARY', 'FOLLOWUP', 'IDLE']) {
+      delete process.env[`LLM_${t}_PROVIDER`];
+      delete process.env[`LLM_${t}_MODEL`];
+    }
+    mockGetLlmProvider.mockResolvedValue([fallback]);
+    mockGetGeneralSettings.mockReturnValue({ perUseCaseEnabled: false, taskProfiles: {} });
+  });
+
+  it.each(['letta', 'openswarm'])(
+    'constructs a provider-instance override of previously-uncovered type "%s" via the plugin loader',
+    async (type) => {
+      const pluginProvider = makeProvider(type);
+      const fakeMod = { create: jest.fn() };
+      mockLoadPlugin.mockResolvedValue(fakeMod);
+      mockInstantiateLlmProvider.mockReturnValue(pluginProvider);
+
+      mockGetAllProviders.mockReturnValue([
+        { id: 'inst-1', name: type, type, enabled: true, config: { apiKey: 'x' } },
+      ]);
+
+      taskOverrides.LLM_TASK_SEMANTIC_PROVIDER = type;
+
+      const result = await getTaskLlm('semantic');
+
+      // Routed via plugin loader for the right package, not the default fallback.
+      expect(mockLoadPlugin).toHaveBeenCalledWith(`llm-${type}`);
+      expect(mockInstantiateLlmProvider).toHaveBeenCalledWith(fakeMod, { apiKey: 'x' });
+      expect(result.source).toBe('override');
+      expect(result.provider.name).toBe(type);
+    }
+  );
+
+  it('constructs a per-use-case profile of a previously-uncovered type via the plugin loader', async () => {
+    const pluginProvider = makeProvider('letta');
+    const fakeMod = { create: jest.fn() };
+    mockLoadPlugin.mockResolvedValue(fakeMod);
+    mockInstantiateLlmProvider.mockReturnValue(pluginProvider);
+
+    mockGetGeneralSettings.mockReturnValue({
+      perUseCaseEnabled: true,
+      taskProfiles: { summary: 'my-letta-profile' },
+    });
+    mockGetLlmProfileByKey.mockReturnValue({
+      key: 'my-letta-profile',
+      provider: 'letta',
+      config: { baseUrl: 'http://letta' },
+    });
+
+    const result = await getTaskLlm('summary');
+
+    expect(mockLoadPlugin).toHaveBeenCalledWith('llm-letta');
+    expect(mockInstantiateLlmProvider).toHaveBeenCalledWith(fakeMod, { baseUrl: 'http://letta' });
+    expect(result.source).toBe('override');
+    expect(result.provider.name).toBe('letta');
+  });
+
+  it('falls back to the default provider when the plugin loader cannot resolve an unknown type', async () => {
+    mockLoadPlugin.mockRejectedValue(new Error('Cannot find module llm-nonsense'));
+    mockGetAllProviders.mockReturnValue([
+      { id: 'inst-x', name: 'nonsense', type: 'nonsense', enabled: true, config: {} },
+    ]);
+
+    taskOverrides.LLM_TASK_SEMANTIC_PROVIDER = 'nonsense';
+
+    const result = await getTaskLlm('semantic');
+
+    expect(result.source).toBe('default');
+    expect(result.provider).toBe(fallback);
+  });
+});


### PR DESCRIPTION
## What
Complete provider-construction coverage in `src/llm/taskLlmRouter.ts` so task-based LLM routing works for **all** wired provider types.

## Why
`createProviderFromInstance` and `createProviderFromProfile` each used a hardcoded `switch` covering only `openai`, `flowise`, and `openwebui`. The repo wires five LLM provider packages (`packages/llm-*`): `openai`, `flowise`, `openwebui`, **`letta`**, and **`openswarm`**. A task override (`LLM_TASK_<TASK>_PROVIDER`) or a per-use-case profile pointing at `letta` or `openswarm` hit the `default` arm, returned `null`, and silently fell back to the default provider — so task routing never honored those types.

## Behavior
- The bespoke fast paths (`openai`, `flowise`, `openwebui`) are unchanged.
- Any other wired type now resolves through the same plugin loader (`loadPlugin('llm-<type>')` + `instantiateLlmProvider`) that `getLlmProvider` already uses, via a shared `buildProviderForType` helper used by both call sites.
- Genuinely unknown types still fall back to the default provider (the loader throws "Cannot find module" and the existing try/catch returns `null`).

## Verification
- Backend `npx tsc --noEmit`: clean
- `npx eslint src/llm/taskLlmRouter.ts tests/unit/llm/taskLlmRouter.test.ts`: 0 errors
- New suite `tests/unit/llm/taskLlmRouter.test.ts`: 4 passing (instance override + per-use-case profile for `letta`/`openswarm` route through the plugin loader; unknown type falls back to default)
- Consumer regression check `tests/unit/pipeline/pipelineActivityTracking.test.ts`: passing
- Frontend `cd src/client && npx tsc --noEmit`: clean (no frontend code touched)
