### PR TITLE
perf(BotsPage): memoize hook event handlers with useCallback

### DIFF
--- a/src/client/src/pages/BotsPage/hooks/useBotActions.ts
+++ b/src/client/src/pages/BotsPage/hooks/useBotActions.ts
@@ -21,7 +21,7 @@ export const useBotActions = (
    * Stores the previous order for rollback.
    */
   const previousBotsRef = { current: bots };
-  const handleToggleBotStatus = async (bot: BotConfig) => {
+  const handleToggleBotStatus = useCallback(async (bot: BotConfig) => {
     try {
       const newStatus = bot.status === 'active' ? 'inactive' : 'active';
       setBots((prev) => prev.map((b) => (b.id === bot.id ? { ...b, status: newStatus } : b)));
@@ -38,9 +38,9 @@ export const useBotActions = (
       }
       toastError(err instanceof Error ? err.message : 'Failed to toggle bot status');
     }
-  };
+  }, [setBots, previewBot, setPreviewBot, toastSuccess, toastError]);
 
-  const handleUpdateBot = async (updatedBot: BotConfig) => {
+  const handleUpdateBot = useCallback(async (updatedBot: BotConfig) => {
     try {
       await apiService.put(`/api/bots/${updatedBot.id}`, updatedBot);
       setBots((prev) => prev.map((b) => (b.id === updatedBot.id ? updatedBot : b)));
@@ -53,9 +53,9 @@ export const useBotActions = (
     } catch (err) {
       toastError(err instanceof Error ? err.message : 'Failed to update bot');
     }
-  };
+  }, [setBots, previewBot, setPreviewBot, toastSuccess, toastError, showStamp, setEditingBot]);
 
-  const handleCreateBot = async (botData: Partial<BotConfig>) => {
+  const handleCreateBot = useCallback(async (botData: Partial<BotConfig>) => {
     try {
       const response = await apiService.post<{ data: BotConfig }>('/api/bots', botData);
       setBots((prev) => [...prev, response.data]);
@@ -68,7 +68,7 @@ export const useBotActions = (
       toastError(err instanceof Error ? err.message : 'Failed to create bot');
       throw err;
     }
-  };
+  }, [setBots, toastSuccess, toastError, showStamp, setIsCreateModalOpen, fetchBots]);
 
   const handleReorder = useCallback(
     async (reordered: BotConfig[]) => {
@@ -87,7 +87,7 @@ export const useBotActions = (
     [setBots, bots, toastError]
   );
 
-  const handleBulkDelete = async () => {
+  const handleBulkDelete = useCallback(async () => {
     if (bulk.selectedCount === 0) return;
 
     // Snapshot current state for rollback
@@ -114,7 +114,7 @@ export const useBotActions = (
     } finally {
       setBulkDeleting(false);
     }
-  };
+  }, [bulk, bots, previewBot, setBots, setPreviewBot, toastSuccess, toastError, setBulkDeleting]);
 
   return {
     handleToggleBotStatus,

--- a/src/client/src/pages/BotsPage/hooks/useBotPreview.ts
+++ b/src/client/src/pages/BotsPage/hooks/useBotPreview.ts
@@ -55,7 +55,7 @@ export const useBotPreview = (): {
     }
   }, []);
 
-  const handlePreviewBot = async (bot: BotConfig) => {
+  const handlePreviewBot = useCallback(async (bot: BotConfig) => {
     setPreviewBot(bot);
     setPreviewTab('activity');
     setActivityLogs([]);
@@ -64,7 +64,7 @@ export const useBotPreview = (): {
     setChatError(null);
 
     await Promise.allSettled([fetchPreviewActivity(bot.id), fetchPreviewChat(bot.id)]);
-  };
+  }, [fetchPreviewActivity, fetchPreviewChat]);
 
   return {
     previewBot,


### PR DESCRIPTION
## What

Wraps the async event handlers returned by the `BotsPage` hooks in `useCallback` so they keep **stable references** across renders:

- `useBotActions`: `handleToggleBotStatus`, `handleUpdateBot`, `handleCreateBot`, `handleBulkDelete`
- `useBotPreview`: `handlePreviewBot`

## Why

`BotCard` is already wrapped in `React.memo` on main. Previously these handlers were re-created on every `BotsPage` render, so any memoized child receiving them re-rendered anyway. Stabilizing the references lets `memo` actually skip re-renders, and keeps the handlers safe to use in downstream `useEffect`/`useMemo` dependency arrays.

## Note

The original revision of this PR committed `patch_useBotActions.diff` / `patch_useBotPreview.diff` — literal `<<<<<<< SEARCH / >>>>>>> REPLACE` blocks that were **never applied to the source**, so it changed nothing functional. This revision drops those artifacts and applies the real edits, verified with `tsc --noEmit` and the BotsPage vitest suite (17 passing).