### PR TITLE
docs: document session, Slack typing, tracing, and webhook env vars

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -322,6 +322,13 @@ DISCORD_BOT_TOKEN=your-discord-token
 # Optional. Example: C12345678
 # SLACK_DEFAULT_CHANNEL_ID=
 
+# SLACK_FAKE_TYPING: When RTM is unavailable (Socket Mode / Web API), post a
+# transient "is typing..." placeholder message to simulate typing. Set to
+# "false" to disable. Has no effect when an RTM client (which sends a native
+# typing indicator) is available.
+# Optional. Default: true (enabled)
+# SLACK_FAKE_TYPING=true
+
 # WELCOME_RESOURCE_URL: URL used in Slack welcome messages.
 # Optional. Default: https://university.example.com/resources
 # WELCOME_RESOURCE_URL=https://university.example.com/resources
@@ -355,8 +362,9 @@ DISCORD_BOT_TOKEN=your-discord-token
 
 # WEBHOOK_IP_WHITELIST: Comma-separated list of IPs allowed to call webhook endpoints.
 # ⚠️ BREAKING CHANGE: An empty value now BLOCKS all requests (default-deny).
-# Previously an empty value allowed all IPs. To restore open access use: 0.0.0.0/0
-# Supports exact IPv4 and IPv6 addresses. CIDR notation is NOT currently supported.
+# Matching is exact string equality on the request IP. CIDR notation and ranges
+# are NOT supported (e.g. 0.0.0.0/0 matches nothing real — list each IP explicitly).
+# IPv4-mapped IPv6 (::ffff:a.b.c.d) is normalized to its IPv4 form before matching.
 # Example (restrict to two IPs): WEBHOOK_IP_WHITELIST=203.0.113.10,203.0.113.11
 # Example (loopback only):       WEBHOOK_IP_WHITELIST=127.0.0.1,::1,::ffff:127.0.0.1
 # WEBHOOK_IP_WHITELIST=
@@ -624,6 +632,20 @@ IDLE_RESPONSE_MAX_DELAY=3600000
 # ALERT_MANAGER_MAX_FAILURE_COUNTS: Max unique failure events to track.
 # Optional. Default: 100
 # ALERT_MANAGER_MAX_FAILURE_COUNTS=100
+
+# --- Distributed Tracing / Span Export ---
+# A console span exporter is always active. The following enable additional
+# exporters; each is opt-in and activated only when its variable is set.
+
+# TRACE_LOG_FILE: Path to a file that trace spans are appended to as JSON lines.
+# Enables the JSON file span exporter when set.
+# Optional. Default: (unset — file exporter disabled)
+# TRACE_LOG_FILE=./logs/traces.jsonl
+
+# OTEL_EXPORTER_OTLP_ENDPOINT: OTLP collector endpoint to export spans to.
+# Enables the OTLP span exporter when set.
+# Optional. Default: (unset — OTLP exporter disabled)
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 
 # ------------------------------------------------------------------------------
 # Tooling & Extensibility

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,38 @@
 | `WELCOME_MESSAGE_TEXT` | `''` | Text of the startup welcome message (requires `ENABLE_WELCOME_MESSAGE=true`) |
 | `DATABASE_PATH` | `data/hivemind.db` | Path to the SQLite database file |
 
+## Session & Auth Env Vars
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SESSION_SECRET` | _(none)_ | Secret used to sign session cookies. **Required in production** (must be ≥32 chars); a short value logs a warning and the app refuses to start without it in production. |
+| `SESSION_COOKIE_NAME` | `hivemind.sid` | Name of the session cookie. |
+| `SESSION_MAX_AGE` | `86400000` (24h) | Session cookie lifetime, in milliseconds. |
+| `SESSION_IDLE_TIMEOUT` | `1800000` (30m) | Idle timeout, in milliseconds; sessions are invalidated after this much inactivity. |
+| `SESSION_STORE_MAX_SESSIONS` | `10000` | Max sessions retained in the in-memory store. |
+| `SESSION_STORE_CLEANUP_INTERVAL_MS` | `300000` (5m) | Interval, in milliseconds, for purging expired sessions. |
+
+## Slack Typing Env Vars
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SLACK_FAKE_TYPING` | `true` | When RTM is unavailable (Socket Mode / Web API), post a transient "is typing..." placeholder message to simulate typing. Set to `false` to disable. No effect when an RTM client (native typing indicator) is available. |
+
+## Tracing / Span Export Env Vars
+
+A console span exporter is always active. The following enable additional exporters; each is opt-in and activated only when set.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TRACE_LOG_FILE` | _(unset)_ | Path to a file that trace spans are appended to as JSON lines; enables the JSON file span exporter. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | _(unset)_ | OTLP collector endpoint; enables the OTLP span exporter. |
+
+## Webhook Env Vars
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WEBHOOK_IP_WHITELIST` | _(empty → default-deny)_ | Comma-separated list of **exact** IPv4/IPv6 addresses allowed to call webhook endpoints (matched by exact string equality — CIDR notation and ranges are not supported). An empty value **blocks all** requests. IPv4-mapped IPv6 (`::ffff:a.b.c.d`) is normalized to its IPv4 form before matching. |
+
 ## Screenshot Convention
 
 ### Directory roles


### PR DESCRIPTION
## What

Documents recently-added environment variables in `CLAUDE.md` and `.env.sample`, verified against the consuming code.

### Added to CLAUDE.md (new env-var tables)
- **Session & Auth**: `SESSION_SECRET` (required in prod, >=32 chars), `SESSION_COOKIE_NAME` (`hivemind.sid`), `SESSION_MAX_AGE` (24h), `SESSION_IDLE_TIMEOUT` (30m), `SESSION_STORE_MAX_SESSIONS` (10000), `SESSION_STORE_CLEANUP_INTERVAL_MS` (5m). Verified in `src/middleware/sessionMiddleware.ts`, `src/auth/SessionStore.ts`, `src/utils/envValidation.ts`.
- **Slack typing**: `SLACK_FAKE_TYPING` (default on; `false` disables the placeholder-message typing simulation used when RTM is unavailable). Verified in `packages/message-slack/src/SlackService.ts`.
- **Tracing**: `TRACE_LOG_FILE` (JSON file span exporter) and `OTEL_EXPORTER_OTLP_ENDPOINT` (OTLP exporter); console exporter is always on. Verified in `src/observability/TraceExporter.ts`.
- **Webhook**: `WEBHOOK_IP_WHITELIST` exact-match / default-deny semantics. Verified in `src/webhook/security/webhookSecurity.ts` + `src/config/webhookConfig.ts`.

### Added to .env.sample
- `SLACK_FAKE_TYPING` entry in the Slack section.
- A Distributed Tracing section with `TRACE_LOG_FILE` and `OTEL_EXPORTER_OTLP_ENDPOINT`.

### Corrected (accuracy fix)
- The existing `.env.sample` note claimed `0.0.0.0/0` restores open webhook access. Matching is exact-string equality (no CIDR), so that value matches nothing. Updated both `.env.sample` and the new CLAUDE.md entry to state CIDR is unsupported and IPs must be listed explicitly.

## Verified-absent (intentionally NOT documented)
The campaign brief mentioned `SLACK_TYPING_STATUS_TEXT`, `SLACK_TYPING_PLACEHOLDER_TEXT`, and `TRACE_EXPORT`. None exist in the code:
- Slack placeholder text is hardcoded (`_is typing..._`) in `packages/message-slack/src/modules/ISlackMessageIO.ts`.
- Trace export is driven by `TRACE_LOG_FILE` / `OTEL_EXPORTER_OTLP_ENDPOINT`, not a `TRACE_EXPORT` switch.

The `SESSION_*` and `WEBHOOK_IP_WHITELIST` entries already present in `.env.sample` were left as-is (only the inaccurate CIDR note was fixed).

## Scope
Docs only. No source or test files changed.