### PR TITLE
docs: reflect config import/export (JSON/YAML/CSV) in user guide & FAQ

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -409,7 +409,8 @@ Manage system configuration backups and download API documentation.
 
 *   **Backup Overview**: View key metrics including total backups and storage usage.
 *   **System Backups**: Create, restore, and delete full system configuration backups.
-*   **Configuration Export**: Export the current running configuration as a JSON file.
+*   **Configuration Export**: Export the current running configuration as **JSON, YAML, or CSV**. Optional gzip compression and encryption are supported for exports.
+*   **Configuration Import**: Upload a previously exported JSON, YAML, or CSV file (including compressed `.gz` and encrypted `.enc` variants) to restore configuration. Imports can be validated before being applied, giving a full round-trip between formats.
 *   **API Specifications**: Download the OpenAPI specification (JSON/YAML) for development.
 
 ### [Sitemap](/admin/sitemap)

--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -102,6 +102,20 @@ FLOWISE_BASE_URL=http://localhost:3000
    - **System Instructions**: Behavior guidelines
 4. Save and assign to a bot
 
+Personas track a usage count so you can see how many bots reference each one.
+
+### How do I export or import my configuration?
+
+Open-Hivemind can export the running configuration to **JSON, YAML, or CSV**:
+
+- In the WebUI, go to **Developer & Tools → System Backups & Export**.
+- Via the API, `POST /api/import-export/export` accepts a `format` of `json`,
+  `yaml`, or `csv`, with optional gzip compression and encryption.
+
+Importing accepts the same formats (including compressed `.gz` and encrypted
+`.enc` files) and supports a full round-trip between them. Imports can be
+validated before they are applied so you can preview the changes safely.
+
 ---
 
 ## LLM Providers


### PR DESCRIPTION
@
## Summary

Updates the user-guide documentation domain (`docs/USER_GUIDE.md`, `docs/getting-started/*.md`) to reflect current, code-verified capabilities. Changes are conservative — every claim was checked against source before being added.

## What changed

### docs/USER_GUIDE.md — System Backups & Export
- Configuration export now documents **JSON, YAML, and CSV** formats (was JSON-only), with optional gzip compression and encryption.
- Added a **Configuration Import** bullet covering upload of JSON/YAML/CSV (including `.gz` / `.enc` variants), validation-before-apply, and full round-trip between formats.

### docs/getting-started/faq.md
- New FAQ entry: "How do I export or import my configuration?" documenting the WebUI path and the `POST /api/import-export/export` / import endpoints with `format` of json/yaml/csv.
- Noted that personas now track a usage count.

## Verification (code is source of truth)
- `src/server/routes/importExport.ts` — multer accepts `.json/.yaml/.yml/.csv/.gz/.enc`; routes `POST /export`, `POST /import`, `POST /validate`.
- `src/server/services/ConfigurationImportExportService.ts` — `convertToCSV/convertToYAML`, `parseCSV/parseYAML`, `detectFormat` confirm JSON/YAML/CSV round-trip.
- `src/server/server.ts:211` — router mounted at `/api/import-export`.

## Intentionally NOT changed
- FAQ "Full bot integration with voice" was **kept** — code in `packages/message-discord/src/voice/` (incl. Whisper-based `speechToText.ts` wired into `voiceCommandHandler.ts`) supports it, despite the campaign brief listing voice/STT as not done. Code overrode the brief.
- Live Chat Monitor "read-only" note kept (no send capability in code).
- Existing monitoring / MCP tools / audit sections were already accurate.

No code or tests touched.
@