### PR TITLE
docs: update API + architecture docs for new endpoints & pipeline activity recording

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,8 @@ This directory contains all documentation for Open Hivemind, organized by topic.
 - [Security Incident Response](operations/security.md)
 
 ## API Reference
-- [Pipeline & Config API](api/pipeline-api.md) - Config source introspection, health observability, and pipeline trace endpoints
+- [Bot, Audit, Import/Export & Webhook API](api/bot-and-system-endpoints.md) - Bot lifecycle (toggle, scheduled tasks), durable audit log, config import/export, inbound webhook ingress
+- [Pipeline & Config API](api/pipeline-api.md) - Config source introspection, health observability, pipeline activity recording, and trace export
 - [LLM Models API](api/llm-models-endpoint.md) - LLM provider model listing with pricing and capabilities
 
 ## 📚 Reference & Planning

--- a/docs/admin/bots.md
+++ b/docs/admin/bots.md
@@ -33,10 +33,22 @@ The **Bots** page (`/admin/bots`) lists all configured agents.
     *   **Disconnected** (Yellow): Bot is active but lost connection.
     *   **Disabled** (Gray): Bot is stopped.
 *   **Actions**:
-    *   **Toggle**: Start/Stop the bot.
+    *   **Toggle**: Start/Stop the bot. Backed by `POST /api/bots/{id}/toggle`, which flips the active state (start if stopped, stop if running) and returns the new state.
     *   **Edit**: Modify configuration (Provider, Persona, etc.).
     *   **Clone**: Create a copy of the bot's configuration.
     *   **Delete**: Remove the bot (unless defined by environment variables).
+
+## Scheduled Tasks
+
+Each bot can run recurring prompts on a fixed interval via the `BotTaskScheduler`.
+Tasks are managed through:
+
+*   `POST /api/bots/{id}/tasks` — schedule a task with a `prompt` and `intervalMinutes`.
+*   `GET /api/bots/{id}/tasks` — list scheduled tasks for the bot.
+*   `DELETE /api/bots/{id}/tasks/{taskId}` — remove a scheduled task.
+
+See the [Bot, Audit, Import/Export & Webhook API Reference](../api/bot-and-system-endpoints.md)
+for request/response shapes and the full bot endpoint list.
 
 ### WebUI Previews
 

--- a/docs/admin/export.md
+++ b/docs/admin/export.md
@@ -30,6 +30,18 @@ You can export the current running configuration as a raw JSON file. This is use
 2.  Click **Export Config**.
 3.  The `config-export-*.json` file will be downloaded.
 
+### Formats & Round-Trip
+
+The underlying import/export service (`/api/import-export/*`) supports full
+round-trip in **JSON, YAML, and CSV**, with optional gzip compression and AES
+encryption. Selected configuration IDs are exported via
+`POST /api/import-export/export`, and a previously exported file is re-imported via
+`POST /api/import-export/import` (multipart upload). Uploads accept `.json`,
+`.yaml`/`.yml`, `.csv`, `.gz`, and `.enc` files up to 50 MB. Use
+`POST /api/import-export/validate` to validate a file without importing it. See
+[Bot, Audit, Import/Export & Webhook API Reference](../api/bot-and-system-endpoints.md)
+for the full endpoint list.
+
 ## API Specifications
 
 For developers integrating with Open Hivemind, the OpenAPI specification is available for download.

--- a/docs/api/bot-and-system-endpoints.md
+++ b/docs/api/bot-and-system-endpoints.md
@@ -1,0 +1,209 @@
+# Bot, Audit, Import/Export & Webhook API Reference
+
+This reference covers the REST endpoints for bot lifecycle management (including
+toggle and scheduled tasks), the durable audit log, configuration import/export, and
+inbound webhook ingress.
+
+Unless noted otherwise, all `/api/*` endpoints require authentication
+(`authenticateToken`) and return the standard envelope:
+
+```jsonc
+{ "success": true,  "data": { /* ... */ } }
+{ "success": false, "error": "message", "code": "OPTIONAL_CODE" }
+```
+
+Source of truth: `src/server/routes/bots.ts`, `src/server/routes/admin/audit.ts`,
+`src/server/routes/importExport.ts`, and `src/webhook/routes/webhookRoutes.ts`.
+
+---
+
+## Bot Lifecycle
+
+Mounted at `/api/bots` (`authenticateToken`).
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/bots` | List all bots with status, message/error counts |
+| GET | `/api/bots/{id}` | Get a single bot (includes `config`, `isActive`) |
+| POST | `/api/bots` | Create a bot |
+| PUT | `/api/bots/{id}` | Update a bot |
+| DELETE | `/api/bots/{id}` | Delete a bot |
+| POST | `/api/bots/{id}/clone` | Clone a bot under a new name |
+| POST | `/api/bots/{id}/start` | Start a bot |
+| POST | `/api/bots/{id}/stop` | Stop a bot |
+| POST | `/api/bots/{id}/toggle` | Toggle active state (start if stopped, stop if running) |
+| PUT | `/api/bots/reorder` | Reorder bots by id list |
+| GET | `/api/bots/{id}/history` | Chat history (`limit` clamped 1–100, optional `channelId`) |
+| GET | `/api/bots/{id}/activity` | Recent activity events (PII redacted) |
+| GET | `/api/bots/{id}/versions` | Configuration version history |
+| POST | `/api/bots/{id}/versions/{versionId}/restore` | Restore a config version and restart the bot |
+| GET | `/api/bots/export` · `/api/bots/{id}/export` | Export bots (sensitive fields redacted) |
+| POST | `/api/bots/import` | Import bots, returns a create/update/error report |
+| POST | `/api/bots/generate-config` | AI-generate a bot config from a description |
+| GET | `/api/bots/{id}/diagnose` | Deep diagnostic |
+| POST | `/api/bots/test-chat` | Sandbox a persona/config |
+| GET | `/api/bots/{id}/insights` | AI performance insights |
+| POST | `/api/bots/{id}/benchmark` | Standardized performance benchmark |
+| POST | `/api/bots/{id}/stress-test` | Adversarial stress test |
+| POST | `/api/bots/{id}/tasks` | Schedule a recurring task |
+| GET | `/api/bots/{id}/tasks` | List scheduled tasks |
+| DELETE | `/api/bots/{id}/tasks/{taskId}` | Delete a scheduled task |
+
+### POST /api/bots/{id}/toggle
+
+Flips the bot's active state, reusing the same start/stop logic. Returns the new state.
+
+**Response (200):**
+
+```json
+{ "success": true, "data": { "id": "bot-1", "isActive": true, "status": "active" } }
+```
+
+Returns `404` if the bot does not exist.
+
+### Scheduled Tasks
+
+Backed by `BotTaskScheduler`. A task runs the given `prompt` against the bot on a
+fixed interval.
+
+**POST /api/bots/{id}/tasks**
+
+Request body:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `prompt` | string | Prompt to run on each interval |
+| `intervalMinutes` | number | Interval between runs, in minutes |
+
+Returns the created task object.
+
+**GET /api/bots/{id}/tasks**
+
+Returns the array of scheduled tasks for the bot.
+
+```json
+{ "success": true, "data": [ { "id": "task-1", "prompt": "...", "intervalMinutes": 60 } ] }
+```
+
+**DELETE /api/bots/{id}/tasks/{taskId}**
+
+Deletes a scheduled task. Returns `404` if the bot or task is not found.
+
+```json
+{ "success": true, "data": { "id": "task-1", "deleted": true } }
+```
+
+---
+
+## Audit Log
+
+`GET /api/admin/audit-logs` (admin sub-routes, mounted under `/api/admin`).
+
+Returns **real** audit events read from the durable audit log (JSONL on disk) via
+`AuditLogger`. Events are returned newest-first.
+
+**Query parameters** (all optional, AND-combined):
+
+| Name | Description |
+|------|-------------|
+| `limit` | Max events to return (default `100`) |
+| `offset` | Events to skip (default `0`) |
+| `search` | Free-text match |
+| `action` | Filter by action |
+| `resource` | Filter by resource |
+| `user` | Filter by user |
+| `dateFrom` / `dateTo` | Date range bounds |
+
+**Response (200):**
+
+```json
+{ "success": true, "data": { "auditEvents": [ /* ... */ ], "total": 42 } }
+```
+
+---
+
+## Configuration Import / Export
+
+Mounted at `/api/import-export` (`authenticateToken`; most routes additionally
+require admin). Backed by `ConfigurationImportExportService`. Supports JSON, YAML,
+and CSV round-trip, optional compression and AES encryption.
+
+| Method | Path | Notes |
+|--------|------|-------|
+| POST | `/api/import-export/export` | Export selected configs. Body: `configIds[]`, `format` (`json`\|`yaml`\|`csv`), `includeVersions`, `includeAuditLogs`, `includeTemplates`, `compress`, `encrypt`, `encryptionKey`, `fileName`. requireAdmin |
+| POST | `/api/import-export/import` | Multipart upload (`file`). Body: `format`, `overwrite`, `validateOnly`, `skipValidation`, `decryptionKey`. requireAdmin |
+| POST | `/api/import-export/validate` | Multipart upload; validates without importing (`authenticate`) |
+| POST | `/api/import-export/backup` | Create a full backup. requireAdmin |
+| GET | `/api/import-export/backups` | List backups (includes `count`). requireAdmin |
+| POST | `/api/import-export/backups/{backupId}/restore` | Restore from a backup. requireAdmin |
+| GET | `/api/import-export/backups/{backupId}/download` | Download a backup file. requireAdmin |
+| DELETE | `/api/import-export/backups/{backupId}` | Delete a backup. requireAdmin |
+
+Uploads accept `.json`, `.yaml`, `.yml`, `.csv`, `.gz`, `.enc` (incl. `.json.gz`,
+`.json.enc`), max 50 MB.
+
+**Export response (200):**
+
+```json
+{ "success": true, "data": { "filePath": "...", "size": 1234, "checksum": "..." } }
+```
+
+---
+
+## Inbound Webhook Ingress
+
+These endpoints are mounted at the **root** path (not under `/api`) by the webhook
+service and are only registered when `WEBHOOK_ENABLED=true`. They are protected by a
+shared-secret token and an IP whitelist rather than session auth.
+
+`configureWebhookRoutes()` (`src/webhook/routes/webhookRoutes.ts`) registers:
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/webhook` | `verifyWebhookToken` + `verifyIpWhitelist` | Replicate/prediction-style callback; sends a public announcement to the target channel |
+| POST | `/webhook/receive` | `verifyWebhookToken` + `verifyIpWhitelist` | **Inbound ingress** — forwards the payload to the messenger service's `handleIncomingWebhook` so externally-pushed messages reach the pipeline. Returns `501` if the configured messenger does not support inbound webhooks |
+| POST | `/webhook/slack` | `verifySlackSignature` | Slack-formatted payload; forwarded to `handleIncomingWebhook` when supported |
+
+### Authentication
+
+- **`verifyWebhookToken`** — requires `X-Webhook-Token` (or `Authorization: Bearer
+  <token>`) to match `WEBHOOK_TOKEN`, compared with a timing-safe equality check.
+- **`verifyIpWhitelist`** — the request IP must appear in `WEBHOOK_IP_WHITELIST`
+  (comma-separated). The list is matched by **exact IP** (IPv4 and IPv6; IPv4-mapped
+  IPv6 `::ffff:` addresses are normalized first). An **empty or unset whitelist
+  blocks all requests** (fail-closed), and malformed IPs are rejected with `403`.
+
+> Note: `WEBHOOK_IP_WHITELIST` is an exact-match allowlist. CIDR-range matching is
+> not currently implemented.
+
+### POST /webhook/receive
+
+**Response (200):**
+
+```json
+{ "success": true, "reply": "..." }
+```
+
+**Response (501)** — messenger service does not support inbound webhooks:
+
+```json
+{ "error": "Inbound webhooks are not supported by the configured messenger service" }
+```
+
+---
+
+## Webhook Scheduled Messages (admin API)
+
+Separate from inbound ingress, the admin webhook API at `/api/webhooks`
+(`authenticateToken`) manages scheduled outbound messages. Note these are held in an
+**in-memory** store and are not persisted across restarts.
+
+| Method | Path | Role | Description |
+|--------|------|------|-------------|
+| GET | `/api/webhooks/scheduled` | any | List scheduled messages |
+| GET | `/api/webhooks/scheduled/{id}` | any | Get a scheduled message |
+| POST | `/api/webhooks/scheduled` | admin | Create a scheduled message |
+| DELETE | `/api/webhooks/scheduled/{id}` | admin | Delete a scheduled message |
+
+Webhook event inspection (`/api/webhooks/events*`) is served by a separate
+`webhookEventsRouter` mounted ahead of this router.

--- a/docs/api/pipeline-api.md
+++ b/docs/api/pipeline-api.md
@@ -2,6 +2,11 @@
 
 Endpoints added as part of the 5-stage pipeline refactor. These provide config source introspection, extended health observability, and pipeline trace statistics.
 
+The 5-stage pipeline (`receive → decision → enrich → inference → send`) is the
+**default** message-processing path; set `USE_LEGACY_HANDLER=true` to revert to the
+monolithic `handleMessage()`. Pipeline registration is idempotent per `MessageBus`
+instance (`createPipeline()` is a no-op on a bus that already has a pipeline wired).
+
 ## Config Source Introspection
 
 ### GET /api/config/sources
@@ -127,12 +132,56 @@ The authenticated response includes an optional `pipeline` object with trace sta
 
 ---
 
+## Pipeline Activity Recording
+
+When the pipeline runs, two collaborators feed real activity signals — replacing
+the previous behaviour where these signals were either dead or only produced by the
+demo simulator:
+
+1. **`observability/ActivityRecorder`** subscribes to the `MessageBus` lifecycle
+   events (`message:incoming`, `message:sent`, `message:error`) and writes a
+   `MessageFlowEvent` to both:
+   - the persistent `ActivityLogger` (JSONL on disk), which backs
+     `DashboardService.getActivity` and the WebUI Activity page; and
+   - the live `WebSocketService` feed (when HTTP is enabled) so the dashboard
+     updates in real time.
+
+   This is why `/api/bots/{id}/activity` and the Activity page now surface real
+   pipeline traffic rather than only demo events.
+
+2. **`pipeline/ActivityRecorder` (DefaultActivityRecorder)** is invoked by the
+   `DecisionStage` / `SendStage` to feed the response-scoring subsystems that the
+   legacy handler fed:
+   - `GlobalActivityTracker.recordActivity` — the global "fatigue" penalty;
+   - `recordBotActivity` — per-channel grace-window / crosstalk signals;
+   - `IdleResponseManager.recordInteraction` / `recordBotResponse` — idle-response
+     scheduling.
+
+   All recordings are best-effort and never block message delivery.
+
+---
+
+## Trace Export
+
+When the pipeline is created, a `PipelineTracer` is registered and exposed via the
+observability singleton (consumed by `GET /api/health/detailed`). Completed traces
+are routed through a `TraceExportManager` to a set of exporters built by
+`createExporters()`:
+
+| Exporter | Enabled when | Output |
+|----------|--------------|--------|
+| `ConsoleExporter` | always | `debug('app:trace-export')` tree-format logs |
+| `JsonFileExporter` | `TRACE_LOG_FILE` is set | NDJSON appended to that file path |
+| `OtlpExporter` | `OTEL_EXPORTER_OTLP_ENDPOINT` is set | OTLP JSON `POST`ed to `<endpoint>/v1/traces` |
+
+---
+
 ## Feature Flags
 
 These flags control pipeline and observability behavior:
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `USE_LEGACY_HANDLER` | `false` | Revert to the monolithic `handleMessage()` instead of the 5-stage pipeline |
-| `TRACE_LOG_FILE` | unset | File path for NDJSON trace log output |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | unset | OTLP HTTP endpoint for OpenTelemetry trace export |
+| `USE_LEGACY_HANDLER` | `false` | Revert to the monolithic `handleMessage()` instead of the 5-stage pipeline (the pipeline is the default) |
+| `TRACE_LOG_FILE` | unset | File path for NDJSON trace log output (enables `JsonFileExporter`) |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | unset | OTLP HTTP endpoint for OpenTelemetry trace export (enables `OtlpExporter`) |

--- a/docs/architecture/layered-overview.md
+++ b/docs/architecture/layered-overview.md
@@ -23,8 +23,9 @@ Mattermost.
 ├─────────────────────────────────────────────────────────────┤
 │                    Messaging Connectors                     │
 │  ├─ DiscordService (solo & swarm)                          │
-│  ├─ SlackService (Socket Mode)                             │
-│  └─ MattermostService (REST, experimental)                 │
+│  ├─ SlackService (Socket Mode + RTM receive, native typing) │
+│  ├─ MattermostService (REST send + WebSocket receive, typing) │
+│  └─ WebhookService (inbound ingress, opt-in)               │
 ├─────────────────────────────────────────────────────────────┤
 │                     Intelligence Providers                  │
 │  ├─ OpenAIProvider                                         │
@@ -49,6 +50,18 @@ Mattermost.
   limiter, and health checks while sharing configuration via the orchestrator.
 - **Consistent voice** – outbound responses are formatted as `*AgentName*: message`
   to present a single persona regardless of the responding instance.
+
+## Message Processing Pipeline
+- Inbound messages flow through a 5-stage pipeline — `receive → decision → enrich →
+  inference → send` — which is the **default** processing path. Set
+  `USE_LEGACY_HANDLER=true` to revert to the monolithic `handleMessage()`.
+- The pipeline records real activity to the persistent `ActivityLogger` and the live
+  WebSocket feed (via `observability/ActivityRecorder`), and feeds response-scoring
+  signals — global fatigue, per-channel grace window, and idle-response scheduling —
+  via `pipeline/ActivityRecorder`.
+- A `PipelineTracer` captures per-stage timing; trace stats are surfaced at
+  `GET /api/health/detailed`, and completed traces can be exported to console, an
+  NDJSON file (`TRACE_LOG_FILE`), or an OTLP endpoint (`OTEL_EXPORTER_OTLP_ENDPOINT`).
 
 ## Context Sharing & Memory
 - Up to ten recent messages per channel are cached in the `ContextCache` and

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -184,12 +184,18 @@ graph LR
 
 ```mermaid
 graph TB
-    subgraph Public["Public Routes (no auth)"]
+    subgraph Public["Public Routes (no session auth)"]
         Health["/health"]
         Sitemap["/"]
         ApiHealth["/api/health"]
         ApiDocs["/api/docs"]
         ApiErrors["/api/errors"]
+    end
+
+    subgraph Ingress["Inbound Webhook Ingress (token + IP whitelist, opt-in via WEBHOOK_ENABLED)"]
+        Webhook["/webhook"]
+        WebhookReceive["/webhook/receive"]
+        WebhookSlack["/webhook/slack"]
     end
 
     subgraph Protected["Protected Routes (authenticateToken)"]
@@ -221,7 +227,7 @@ graph TB
         Backup["/backup"]
         Maintenance["/maintenance"]
         SystemInfo["/system-info"]
-        AuditLog["/audit"]
+        AuditLog["/audit-logs (durable JSONL)"]
         Approvals["/approvals"]
         GuardProfiles["/guard-profiles"]
         MCP["/mcp/*"]
@@ -486,6 +492,35 @@ sequenceDiagram
     Broadcast->>WSServer: emit event
     WSServer->>WSClient: WebSocket message
     WSClient->>Client: update UI state
+```
+
+### Message Processing Pipeline
+
+Inbound platform messages are processed by a 5-stage pipeline (the default path;
+`USE_LEGACY_HANDLER=true` reverts to the monolithic `handleMessage()`). Stages are
+wired onto a `MessageBus` by `createPipeline()` — registration is idempotent per bus.
+
+```mermaid
+graph LR
+    Incoming["message:incoming"]
+    Receive["ReceiveStage"]
+    Decision["DecisionStage"]
+    Enrich["EnrichStage"]
+    Inference["InferenceStage"]
+    Send["SendStage"]
+
+    Incoming --> Receive --> Decision --> Enrich --> Inference --> Send
+
+    Tracer["PipelineTracer<br/>→ /api/health/detailed<br/>→ TraceExporter (console/file/OTLP)"]
+    ActRec["observability/ActivityRecorder<br/>→ ActivityLogger (JSONL)<br/>→ WebSocket feed"]
+    ScoreRec["pipeline/ActivityRecorder<br/>→ fatigue / grace window / idle response"]
+
+    Receive -.-> Tracer
+    Send -.-> Tracer
+    Receive -.-> ActRec
+    Send -.-> ActRec
+    Decision -.-> ScoreRec
+    Send -.-> ScoreRec
 ```
 
 ## Key Statistics


### PR DESCRIPTION
## Summary

Updates **markdown documentation only** (no code changes) to reflect the current code state after the recent ~50-PR campaign. All claims were verified against the source — the code is the source of truth.

## What changed

**docs/api/bot-and-system-endpoints.md (new)**
- Full reference for bot lifecycle, audit log, import/export, and inbound webhook endpoints, verified against `src/server/routes/bots.ts`, `admin/audit.ts`, `importExport.ts`, and `src/webhook/routes/webhookRoutes.ts`.
- Documents now-implemented endpoints: `POST /api/bots/{id}/toggle`, bot scheduled tasks (`POST`/`GET` `/api/bots/{id}/tasks`, `DELETE .../tasks/{taskId}`), the durable `GET /api/admin/audit-logs`, JSON/YAML/CSV import/export, and the inbound `POST /webhook/receive` ingress route.

**docs/api/pipeline-api.md**
- Notes the 5-stage pipeline is the default path and registration is idempotent per bus.
- Adds a **Pipeline Activity Recording** section (observability `ActivityRecorder` → ActivityLogger JSONL + WebSocket feed; pipeline `ActivityRecorder` → fatigue/grace-window/idle-response scoring).
- Adds a **Trace Export** table documenting the env-gated exporters (`TRACE_LOG_FILE`, `OTEL_EXPORTER_OTLP_ENDPOINT`).

**docs/architecture/overview.md**
- Adds inbound webhook ingress (`/webhook`, `/webhook/receive`, `/webhook/slack`) to the route tree (token + IP whitelist, opt-in via `WEBHOOK_ENABLED`).
- Corrects the admin audit path to `/audit-logs` and notes it is durable JSONL.
- Adds a Message Processing Pipeline diagram.

**docs/architecture/layered-overview.md**
- Updates messaging connectors: Slack (Socket Mode + RTM receive, native typing), Mattermost (REST send + WebSocket receive, typing), and adds inbound WebhookService.
- Adds a Message Processing Pipeline section.

**docs/admin/bots.md** — documents the toggle endpoint and adds a Scheduled Tasks section.

**docs/admin/export.md** — documents JSON/YAML/CSV round-trip, compression/encryption, and the `/api/import-export/*` endpoints.

**docs/README.md** — links the new API reference and updates descriptions.

## Accuracy notes (kept honest)
- `WEBHOOK_IP_WHITELIST` is documented as an **exact-match** allowlist (fail-closed when empty). The code (`webhookSecurity.ts`) does *not* implement CIDR-range matching despite some campaign notes — documented as not currently supported.
- Trace export env vars are `TRACE_LOG_FILE` and `OTEL_EXPORTER_OTLP_ENDPOINT` (a `TRACE_EXPORT` var referenced in campaign notes does not exist in code; not documented).
- Webhook *scheduled messages* (`/api/webhooks/scheduled`) remain an in-memory store — noted as such.

## Out of scope / unchanged
No source or test files were modified.