### PR TITLE
docs: align monitoring/memory/MCP feature docs with current code

### DIFF
--- a/docs/MCP_TOOLS_ENHANCEMENTS_SUMMARY.md
+++ b/docs/MCP_TOOLS_ENHANCEMENTS_SUMMARY.md
@@ -1,5 +1,11 @@
 # MCP Tools Page Enhancements - Summary
 
+> **Status:** Implemented and merged. The favorites, recently-used, usage-count,
+> filter tabs, and usage-based sorting described below are live in the MCP Tools
+> page (`src/client/src/pages/MCPToolsPage/`), backed by the
+> `useToolRegistry` hook with the `localStorage` keys documented under
+> "LocalStorage Persistence".
+
 ## Features Implemented:
 
 ### 1. Favorites Functionality
@@ -86,13 +92,11 @@
 
 ## File Locations:
 
-- **Enhanced Version**: `/home/ubuntu/open-hivemind/MCPToolsPage-enhanced.tsx`
-- **Original Location**: `/home/ubuntu/open-hivemind/src/client/src/pages/MCPToolsPage.tsx`
-- **Implementation Plan**: `/home/ubuntu/open-hivemind/mcp-tools-enhancements.md`
+- **Page**: `src/client/src/pages/MCPToolsPage/index.tsx` (plus `components/` and `hooks/`)
+- **State hook**: `src/client/src/pages/MCPToolsPage/hooks/useToolRegistry.ts` — owns the favorites, recently-used, and usage-count `localStorage` state and the filter/sort logic.
 
-## Next Steps:
+## Follow-ups (potential):
 
-1. Copy the enhanced version to the original location
-2. Test all new features
-3. Ensure localStorage persistence works correctly
-4. Verify UI responsiveness across screen sizes
+1. Server-side persistence of favorites/usage (currently `localStorage`-only, per-browser)
+2. Sync usage counts with the backend execution-history endpoint
+3. Verify UI responsiveness across screen sizes

--- a/docs/PERFORMANCE_MONITORING.md
+++ b/docs/PERFORMANCE_MONITORING.md
@@ -3,6 +3,13 @@
 ## Overview
 This document outlines the performance monitoring improvements implemented to track and optimize API call patterns, reduce excessive requests, and improve overall system efficiency.
 
+> **Status note:** Backend telemetry is no longer demo-only. Real provider
+> metrics (`ProviderMetricsCollector`), statistical anomaly detection
+> (`IntegrationAnomalyDetector`), and live process/runtime metrics are wired into
+> the running server and exported through real endpoints. See
+> [Backend Telemetry Collectors](#backend-telemetry-collectors) below and the
+> [Monitoring API](monitoring/api.md) reference for exact routes and payloads.
+
 ## Key Issues Identified
 
 ### 1. ModelAutocomplete Excessive API Calls
@@ -47,7 +54,51 @@ This document outlines the performance monitoring improvements implemented to tr
 - Data payload size monitoring
 - Connection stability tracking
 
+## Backend Telemetry Collectors
+
+These collectors run in the server process and feed the real monitoring
+endpoints (no random placeholder data on the live path).
+
+### 1. ProviderMetricsCollector (implemented)
+- Records per-provider signals from the message pipeline: messages received
+  (`recordMessageReceived`), outbound messages, and LLM request latency/outcomes
+  (`recordLlmRequest`). Wired into the input, inference, and output processors.
+- Exposes a Prometheus text export merged into `GET /health/metrics/prometheus`
+  (via `getPrometheusFormat()`), so provider counters appear alongside Node.js
+  process metrics.
+- Registered with the `ShutdownCoordinator` for clean shutdown.
+
+### 2. IntegrationAnomalyDetector (implemented)
+- Started during service initialization and runs on its own interval, reading
+  live signals from `ProviderMetricsCollector` to flag integration anomalies
+  (Discord, Slack, Mattermost, LLM providers, etc.).
+- Results are exposed via `GET /api/monitoring/anomalies` (summary + recent or
+  active anomalies, filterable by `integration` and `minutes`).
+- Can be disabled with `DISABLE_INTEGRATION_ANOMALY=true`; it is also skipped
+  automatically when `NODE_ENV=test` to avoid leaking timers.
+
+### 3. AnomalyDetectionService (implemented)
+- Statistical (z-score) anomaly detection over rolling metric windows. Powers
+  `GET /health/anomalies` and the `anomalyDetected` / `alert_update` WebSocket
+  events. See [Monitoring API](monitoring/api.md).
+
+### 4. BusinessKpiCollector (available, not auto-wired)
+- A KPI aggregation service (`src/monitoring/BusinessKpiCollector.ts`) supporting
+  engagement/performance/revenue/growth/retention/custom categories with
+  thresholds and aggregation types. The class is available for programmatic use
+  but is **not** currently started in service initialization or surfaced through
+  a dedicated HTTP route.
+
+### 5. Process & Runtime Metrics (implemented)
+- `GET /health/metrics` returns live process metrics (uptime, heap usage, CPU,
+  event-loop delay/utilization, request totals and rate).
+- `GET /health/metrics/prometheus` returns the same data plus collector exports
+  in Prometheus exposition format.
+
 ## Demo Mode Enhancements
+
+> The simulation features below apply to **demo mode** only. With real providers
+> configured, the collectors described above supply genuine telemetry.
 
 ### 1. Realistic Activity Simulation
 - Multi-turn conversation threads
@@ -151,8 +202,12 @@ This document outlines the performance monitoring improvements implemented to tr
 
 - ✅ ModelAutocomplete optimization
 - ✅ Demo mode conversation threads
-- ✅ Performance spike simulation
+- ✅ Performance spike simulation (demo mode)
 - ✅ Rate limiting configuration review
+- ✅ ProviderMetricsCollector wired into the message pipeline
+- ✅ IntegrationAnomalyDetector started and exposed via `/api/monitoring/anomalies`
+- ✅ Real process/runtime metrics (`/health/metrics`, `/health/metrics/prometheus`)
+- ✅ z-score AnomalyDetectionService (`/health/anomalies`)
+- ⏳ BusinessKpiCollector auto-wiring / dedicated KPI route
 - ⏳ Advanced caching implementation
 - ⏳ Predictive scaling setup
-- ⏳ Comprehensive monitoring dashboard

--- a/docs/features/MCP_TOOLS_TESTING.md
+++ b/docs/features/MCP_TOOLS_TESTING.md
@@ -20,17 +20,19 @@ The MCP Tools Testing UI provides an interactive interface for testing Model Con
 - **src/server/routes/mcpToolsTesting.ts** - API endpoints for listing tools and executing tests
 
 ### Tests
-- **tests/unit/client/pages/MCPToolsTestingPage.test.tsx** - Unit tests for form generation and display
+- **src/client/src/pages/MCPToolsTestingPage.test.tsx** - Unit tests for form generation and display
 - **tests/e2e/screenshot-mcp-tools-testing.spec.ts** - End-to-end tests with screenshot capture
 
 ## Routes
 
-### Frontend Route
-- `/admin/mcp/tools/testing` - Main testing interface
+### Frontend Component
+- `MCPToolsTestingPage` (`src/client/src/pages/MCPToolsTestingPage.tsx`) - testing interface component. The page calls the existing `/api/mcp/servers` discovery endpoint and `/api/mcp/servers/:name/call-tool` for execution (see Integration Points). It is not currently wired into the app router as a standalone page.
 
 ### API Endpoints
 
-#### GET /api/admin/mcp-tools/list
+> The dedicated testing router (`src/server/routes/mcpToolsTesting.ts`) is mounted at `/api/mcp-tools`, so its endpoints are `/api/mcp-tools/list` and `/api/mcp-tools/test`.
+
+#### GET /api/mcp-tools/list
 List all available MCP tools from connected servers.
 
 **Response:**
@@ -55,7 +57,7 @@ List all available MCP tools from connected servers.
 }
 ```
 
-#### POST /api/admin/mcp-tools/test
+#### POST /api/mcp-tools/test
 Execute a tool with provided parameters.
 
 **Request Body:**
@@ -118,7 +120,7 @@ Comprehensive error handling includes:
 
 ## Usage Example
 
-1. Navigate to `/admin/mcp/tools/testing`
+1. Open the MCP Tools Testing page (`MCPToolsTestingPage`)
 2. Select a tool from the "Available Tools" sidebar
 3. View the tool's schema and description
 4. Fill in the parameter form with test values
@@ -144,7 +146,7 @@ Run `npm run generate-docs` to capture the screenshot.
 ### Unit Tests
 Run unit tests with:
 ```bash
-npm test -- tests/unit/client/pages/MCPToolsTestingPage.test.tsx
+npm test -- src/client/src/pages/MCPToolsTestingPage.test.tsx
 ```
 
 Tests cover:

--- a/docs/monitoring/api.md
+++ b/docs/monitoring/api.md
@@ -6,18 +6,40 @@ Navigation: [Docs Index](../README.md) | [Monitoring Overview](overview.md) | [O
 ## Overview
 The Monitoring API provides endpoints for accessing system metrics, health status, anomalies, and alerts. It integrates with Prometheus for metrics export and supports real-time notifications via WebSocket. This API is crucial for the anomaly detection pipeline, allowing external systems to consume metrics and receive alerts.
 
+Telemetry is produced by in-process collectors:
+- `ProviderMetricsCollector` – per-provider message/LLM counters, exported in Prometheus format.
+- `AnomalyDetectionService` – z-score anomaly detection over rolling metric windows.
+- `IntegrationAnomalyDetector` – integration-level anomaly detection across messengers and LLM providers.
+
 ## Base URL
 All endpoints are relative to the server root (e.g., `http://localhost:3028`).
 
 ## Authentication
-Most endpoints require authentication via JWT tokens. Include `Authorization: Bearer <token>` header.
+The `/api/*` monitoring and anomaly endpoints require authentication via JWT tokens — include the `Authorization: Bearer <token>` header. The `/health/*` probe endpoints are public.
+
+## Endpoint Map (current paths)
+
+| Path | Method | Purpose |
+|------|--------|---------|
+| `/health/metrics` | GET | Live process/runtime metrics (JSON) |
+| `/health/metrics/prometheus` | GET | Prometheus text export incl. provider counters |
+| `/health/alerts` | GET | Active diagnostic alerts |
+| `/api/anomalies` | GET | Active statistical anomalies |
+| `/api/anomalies/history` | GET | Historical anomalies |
+| `/api/anomalies/:id/resolve` | POST | Resolve an anomaly |
+| `/api/monitoring/anomalies` | GET | Integration anomalies (messengers/LLM providers) |
+| `/api/monitoring/costs` | GET | Historical/daily LLM cost analytics |
+
+> The detailed sections below document the JSON shapes. Where an older path was
+> referenced (`/metrics`, `/metrics/json`, `/health/anomalies`) the current path
+> is noted inline.
 
 ## Endpoints
 
 ### 1. Metrics Export (Prometheus Format)
 - **Method**: GET
-- **Path**: `/metrics`
-- **Description**: Exports all collected metrics in the Prometheus exposition format for scraping by Prometheus servers.
+- **Path**: `/health/metrics/prometheus`
+- **Description**: Exports process metrics plus `ProviderMetricsCollector` counters in the Prometheus exposition format for scraping by Prometheus servers.
 - **Response Headers**: `Content-Type: text/plain; charset=utf-8`
 - **Status Codes**:
   - `200`: Success
@@ -38,22 +60,22 @@ Most endpoints require authentication via JWT tokens. Include `Authorization: Be
   ```
 - **Integration Note**: Used by Prometheus for time-series data collection in the anomaly detection pipeline.
 
-### 2. JSON Metrics
+### 2. JSON Metrics (Process/Runtime)
 - **Method**: GET
-- **Path**: `/metrics/json`
-- **Description**: Returns structured metrics data suitable for dashboard consumption.
+- **Path**: `/health/metrics`
+- **Description**: Returns the live process/runtime snapshot suitable for dashboard consumption.
 - **Query Parameters**: None
 - **Response**: `application/json`
 - **Status Codes**: `200`
 - **Schema**:
   ```json
   {
-    "messagesProcessed": 42,
-    "activeConnections": 5,
-    "responseTime": [100, 200, 150],
-    "errors": 3,
+    "timestamp": "2025-09-25T03:33:00.000Z",
     "uptime": 3600,
-    "llmTokenUsage": 1500
+    "memory": { "used": 120, "total": 256, "percentage": 47 },
+    "cpu": { "user": 1200, "system": 300 },
+    "eventLoop": { "delay": 1.2, "utilization": 0.18 },
+    "requests": { "total": 5042, "rate": 1.4 }
   }
   ```
 - **Integration Note**: Feeds data to dashboard components and anomaly detection services.
@@ -119,8 +141,8 @@ Most endpoints require authentication via JWT tokens. Include `Authorization: Be
 
 ### 5. Anomalies
 - **Method**: GET
-- **Path**: `/health/anomalies`
-- **Description**: Retrieves detected anomalies from the statistical detection system.
+- **Path**: `/api/anomalies`
+- **Description**: Retrieves active detected anomalies from the statistical (`AnomalyDetectionService`) detection system. Historical records are available at `GET /api/anomalies/history`.
 - **Query Parameters**: None
 - **Response**: `application/json`
 - **Status Codes**: `200`
@@ -150,7 +172,7 @@ Most endpoints require authentication via JWT tokens. Include `Authorization: Be
 
 ### 6. Resolve Anomaly
 - **Method**: POST
-- **Path**: `/health/anomalies/:id/resolve`
+- **Path**: `/api/anomalies/:id/resolve`
 - **Description**: Marks an anomaly as resolved.
 - **Path Parameters**:
   - `id` (string): Anomaly ID
@@ -166,12 +188,32 @@ Most endpoints require authentication via JWT tokens. Include `Authorization: Be
   ```
 - **Integration Note**: Called by dashboard when user acknowledges an anomaly.
 
-### 7. System Metrics (Detailed)
+### 7. Integration Anomalies
 - **Method**: GET
-- **Path**: `/health/metrics`
-- **Description**: Detailed metrics for system and application layers.
+- **Path**: `/api/monitoring/anomalies`
+- **Description**: Returns integration-level anomalies (Discord, Slack, Mattermost, LLM providers, etc.) detected by `IntegrationAnomalyDetector`, plus a summary.
 - **Query Parameters**:
-  - `limit` (optional, number, default: 100): Number of recent data points.
+  - `integration` (optional, string): Filter to a single integration.
+  - `minutes` (optional, number): When provided, returns anomalies within the last N minutes; otherwise returns currently-active anomalies.
+- **Response**: `application/json`
+- **Schema**:
+  ```json
+  {
+    "success": true,
+    "data": {
+      "summary": { },
+      "anomalies": [ ]
+    }
+  }
+  ```
+- **Integration Note**: Fed by `ProviderMetricsCollector`; the detector runs on its own interval and can be disabled with `DISABLE_INTEGRATION_ANOMALY=true`.
+
+### 8. Cost Analytics
+- **Method**: GET
+- **Path**: `/api/monitoring/costs`
+- **Description**: Historical and daily LLM cost analytics.
+- **Query Parameters**:
+  - `days` (optional, number, default: 7): Window size in days.
 - **Response**: `application/json`
 - **Status Codes**: `200`, `500`
 
@@ -222,11 +264,11 @@ For real-time updates, connect to `ws://localhost:3028/webui/socket.io` (or HTTP
   ```
 
 ## Integration with Anomaly Detection Pipeline
-1. **Metrics Collection**: Use `/metrics` for Prometheus scraping or `/metrics/json` for custom monitoring.
-2. **Detection**: Anomalies are computed using z-score on rolling windows of metrics data.
-3. **Alerting**: Detected anomalies trigger `alert_update` WebSocket events and are stored/queryable via `/health/alerts`.
-4. **Dashboard**: Poll `/health` and `/health/anomalies` or subscribe to WebSocket for live updates.
-5. **Resolution**: Use POST `/health/anomalies/:id/resolve` to acknowledge and resolve.
+1. **Metrics Collection**: Use `/health/metrics/prometheus` for Prometheus scraping or `/health/metrics` for the JSON process snapshot.
+2. **Detection**: Statistical anomalies are computed using z-score on rolling windows (`AnomalyDetectionService`); integration anomalies are computed by `IntegrationAnomalyDetector` from live provider metrics.
+3. **Alerting**: Detected anomalies trigger `alert_update` WebSocket events and active alerts are queryable via `/health/alerts`.
+4. **Dashboard**: Poll `/health`, `/api/anomalies`, and `/api/monitoring/anomalies`, or subscribe to WebSocket for live updates.
+5. **Resolution**: Use POST `/api/anomalies/:id/resolve` to acknowledge and resolve.
 
 ## Security Considerations
 - Rate limiting applied to all endpoints.

--- a/docs/monitoring/overview.md
+++ b/docs/monitoring/overview.md
@@ -3,20 +3,37 @@
 Navigation: [Docs Index](../README.md) | [Monitoring API](api.md) | [WebUI Dashboard](../webui/dashboard-overview.md)
 
 
-Open-Hivemind ships with basic health and metrics endpoints that power the
-WebUI dashboards and can be scraped by external observability stacks.
+Open-Hivemind ships with real health and metrics endpoints that power the
+WebUI dashboards and can be scraped by external observability stacks. Live
+telemetry comes from in-process collectors (`ProviderMetricsCollector`,
+`IntegrationAnomalyDetector`, the z-score `AnomalyDetectionService`) rather than
+placeholder data.
 
 ## Health Checks
 - `GET /health` – aggregated status for LLM providers, messenger connections,
-  and background workers.
-- `GET /health/anomalies` – outstanding anomaly reports raised by rate-limit or
-  connection issues.
-- `POST /health/anomalies/:id/resolve` – acknowledge and close an anomaly.
+  and background workers (also mounted at `/api/health`).
+- `GET /health/detailed` – detailed per-service health.
+- `GET /health/ready`, `GET /health/live` – readiness/liveness probes.
+- `GET /health/alerts` – active diagnostic alerts.
+
+## Anomalies
+- `GET /api/anomalies` – outstanding statistical anomalies from
+  `AnomalyDetectionService`.
+- `GET /api/anomalies/history` – historical anomaly records.
+- `POST /api/anomalies/:id/resolve` – acknowledge and close an anomaly.
+- `GET /api/monitoring/anomalies` – integration-level anomalies (Discord, Slack,
+  Mattermost, LLM providers) from `IntegrationAnomalyDetector`. Supports
+  `integration` and `minutes` query filters.
 
 ## Metrics
-- `GET /metrics` – Prometheus-compatible plaintext export.
-- `GET /metrics/json` – JSON payload for custom dashboards.
-- `GET /health/metrics` – lightweight snapshot consumed by the WebUI.
+- `GET /health/metrics` – live process/runtime snapshot (uptime, heap, CPU,
+  event-loop delay/utilization, request totals and rate) consumed by the WebUI.
+- `GET /health/metrics/prometheus` – Prometheus-compatible plaintext export,
+  including provider counters from `ProviderMetricsCollector`.
+- `GET /api/monitoring/costs` – historical/daily LLM cost analytics.
+
+> The `/api/*` monitoring and anomaly routes require authentication
+> (`Authorization: Bearer <token>`); the `/health/*` probes are public.
 
 ## WebSockets
 Subscribe to `ws://<host>/webui/socket.io` (namespace `/webui`) to receive live


### PR DESCRIPTION
@
## What

Updates the monitoring, MCP, and performance feature docs to match the **current** code state. Documentation-only; no source or tests changed. All claims were verified against the code (the code is the source of truth).

## Files updated

### docs/PERFORMANCE_MONITORING.md
- Added a **Backend Telemetry Collectors** section documenting the now-wired collectors:
  - `ProviderMetricsCollector` — fed by the input/inference/output processors; Prometheus export merged into `/health/metrics/prometheus`.
  - `IntegrationAnomalyDetector` — started in `initServices`, reads live provider metrics, exposed via `/api/monitoring/anomalies`; honors `DISABLE_INTEGRATION_ANOMALY`.
  - `AnomalyDetectionService` — z-score detection.
  - Real process/runtime metrics (`/health/metrics`, `/health/metrics/prometheus`).
- Marked `BusinessKpiCollector` honestly as **available but not auto-wired** (the class exists at `src/monitoring/BusinessKpiCollector.ts` but is not started or surfaced via a route).
- Clarified the simulation features are **demo-mode only**; updated Implementation Status.

### docs/monitoring/overview.md & docs/monitoring/api.md
- Corrected endpoint paths to match the code:
  - `/metrics` -> `/health/metrics/prometheus`; `/metrics/json` -> `/health/metrics` (with the real process/runtime JSON schema).
  - `/health/anomalies` -> `/api/anomalies` (+ `/api/anomalies/history`); resolve at `/api/anomalies/:id/resolve`.
  - Added `/api/monitoring/anomalies` (integration anomalies) and `/api/monitoring/costs` (cost analytics).
- Noted `/api/*` routes require auth while `/health/*` probes are public.

### docs/MCP_TOOLS_ENHANCEMENTS_SUMMARY.md
- Marked the favorites / recently-used / usage-count / sort features as **implemented** (live in `src/client/src/pages/MCPToolsPage/hooks/useToolRegistry.ts` with the documented `localStorage` keys).
- Replaced stale `/home/ubuntu/...` scratch paths and the "copy the enhanced version" next-steps with real file locations and realistic follow-ups.

### docs/features/MCP_TOOLS_TESTING.md
- Fixed the API paths: the testing router is mounted at `/api/mcp-tools`, so endpoints are `/api/mcp-tools/list` and `/api/mcp-tools/test` (not `/api/admin/mcp-tools/...`).
- Clarified the `MCPToolsTestingPage` is not currently wired into the app router and uses the existing `/api/mcp/servers` + `/api/mcp/servers/:name/call-tool` endpoints.
- Corrected unit-test file location to `src/client/src/pages/MCPToolsTestingPage.test.tsx`.

## Notes
- Memory summarization/eviction is implemented in code (`ConversationSummaryService`, `MemoryRepository.evictMemories`) but is documented in files outside this doc domain (e.g. FEATURE_STATUS), so no memory-specific feature doc was in scope here.
- No "MemVault" symbol exists in the codebase; not referenced.
@