### PR TITLE
docs: update config/provider docs for live models, streaming, Letta/OpenSwarm

### DIFF
--- a/docs/api/llm-models-endpoint.md
+++ b/docs/api/llm-models-endpoint.md
@@ -34,14 +34,19 @@ Returns a list of available models for the specified provider with comprehensive
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `modelType` | string | No | Filter by model type: `chat`, `embedding` |
+| `live` | boolean | No | When `true` (or `1`), query the provider's live model list instead of the curated static catalog. Supported for `openai` and `openwebui` only; ignored when combined with `modelType`. Falls back to the static list when the provider is unconfigured or the request fails. |
 
 #### Response Format
+
+The `source` field indicates whether the models came from a live provider
+query (`"live"`) or the curated static catalog (`"static"`).
 
 ```json
 {
   "success": true,
   "provider": "openai",
   "modelType": "all",
+  "source": "static",
   "count": 15,
   "models": [
     {
@@ -167,6 +172,43 @@ curl http://localhost:3000/api/admin/llm-providers/openai/models?modelType=embed
   ]
 }
 ```
+
+### Fetch Live Models (OpenAI / OpenWebUI)
+
+Opt into a live provider query with `?live=true`. The server uses the configured
+credentials (`OPENAI_API_KEY` / `OPENAI_BASE_URL` for OpenAI, the `OPEN_WEBUI_*`
+settings for OpenWebUI) to call the provider's OpenAI-compatible `GET /models`
+endpoint. If the provider is unconfigured, returns no models, or the request
+fails, the response transparently falls back to the static catalog with
+`"source": "static"`.
+
+```bash
+curl "http://localhost:3000/api/admin/llm-providers/openai/models?live=true"
+```
+
+**Response (live):**
+```json
+{
+  "success": true,
+  "provider": "openai",
+  "modelType": "all",
+  "source": "live",
+  "count": 42,
+  "models": [
+    {
+      "id": "gpt-4o",
+      "name": "GPT-4o",
+      "type": "chat",
+      ...
+    }
+  ]
+}
+```
+
+Live model ids that are not present in the static catalog are returned as
+minimal records (`id`/`name` only, `type: "chat"`); known ids are enriched with
+the curated metadata. The `live` flag is ignored when a `modelType` filter is
+supplied, since live ids do not carry reliable chat/embedding tags.
 
 ### Get Anthropic Models
 
@@ -314,6 +356,12 @@ function ModelSelector({ providerType }: { providerType: string }) {
 - Vision support available in GPT-4o and GPT-4 Turbo
 - Embedding models return 0 for output pricing
 - Context windows range from 8K to 128K tokens
+- Supports live model fetching via `?live=true` (queries the OpenAI `GET /models` endpoint)
+
+### OpenWebUI
+- Not in the curated static catalog, but supports live model fetching via `?live=true`
+  using its OpenAI-compatible `GET /v1/models` endpoint
+- Credentials resolved from `OPEN_WEBUI_API_URL` and `OPEN_WEBUI_PASSWORD`/`OPEN_WEBUI_API_KEY`
 
 ### Anthropic
 - Claude 3.5 Sonnet is the most capable model
@@ -333,11 +381,17 @@ function ModelSelector({ providerType }: { providerType: string }) {
 
 ## Data Source
 
-Model data is maintained in `/src/server/data/llmModels.ts` and includes:
+The curated static catalog is maintained in `/src/server/data/llmModels.ts`
+(providers: `openai`, `anthropic`, `google`, `perplexity`) and includes:
 - Current pricing (as of implementation date)
 - Context window limits
 - Capability flags (vision, function calling, streaming)
 - Deprecation status
+
+Live model fetching (`?live=true`) is implemented in
+`/src/server/services/LiveModelService.ts`, which calls the provider's
+OpenAI-compatible model-list endpoint and falls back to the static catalog on
+any failure.
 
 **Note:** Pricing and availability may change. Verify with provider documentation for latest information.
 

--- a/docs/configuration/dynamic-model-fetching.md
+++ b/docs/configuration/dynamic-model-fetching.md
@@ -80,11 +80,23 @@ All LLM provider schemas now include:
 
 ### 3. Model Fetching Endpoints
 
-The system automatically fetches models from:
+Two complementary sources back model selection:
 
-- **OpenAI**: `/v1/models` - Returns all available GPT models
-- **Ollama**: `/api/tags` - Returns locally installed models
-- **Anthropic**: Static list of Claude models (no public endpoint)
+- **Curated static catalog** — served from the admin endpoint
+  `GET /api/admin/llm-providers/:type/models` (providers `openai`, `anthropic`,
+  `google`, `perplexity`), with full metadata (pricing, context window,
+  vision/function-calling/streaming flags). See
+  [LLM Provider Models API](../api/llm-models-endpoint.md).
+- **Live model fetching** — opt in with `?live=true` on the same endpoint.
+  Implemented server-side in `LiveModelService` for providers that expose an
+  OpenAI-compatible `GET /models` endpoint:
+  - **OpenAI**: `GET /v1/models` — all available models for the configured key.
+  - **OpenWebUI**: `GET /v1/models` — models available on the local instance.
+  Live results fall back to the static catalog when the provider is
+  unconfigured, returns nothing, or the request fails.
+- **Ollama**: `GET /api/tags` — locally installed models (client-side fetch via
+  `ModelAutocomplete`).
+- **Anthropic**: static list of Claude models (no public list endpoint).
 
 ### 4. Validation System
 
@@ -258,19 +270,26 @@ Enable console logging to see:
 - Validation warnings
 - Network error details
 
-## Future Enhancements
+## Implemented & Planned
 
-### Planned Features
-- **Model Caching**: Local storage of fetched models
-- **Model Metadata**: Pricing, context length, capability information
-- **Provider Health Checks**: Automatic endpoint validation
-- **Batch Configuration**: Setup multiple providers simultaneously
-- **Import/Export**: Configuration sharing between environments
+### Implemented
+- **Model Metadata**: Pricing, context length, and capability flags
+  (vision / function-calling / streaming) are served from the static catalog —
+  see [LLM Provider Models API](../api/llm-models-endpoint.md).
+- **Live Model Fetching**: `?live=true` queries OpenAI / OpenWebUI directly and
+  falls back to the static catalog on failure.
+- **Google (Gemini)**: Gemini models are included in the static catalog.
+- **Import/Export**: Configuration import/export (YAML + CSV round-trip) is
+  available via the admin configuration tooling.
 
-### Provider Extensions
-- **Google AI Platform**: Gemini model support
-- **Cohere**: Command and Embed models
-- **Mistral AI**: Mistral and Mixtral models
+### Still Planned
+- **Model Caching**: Local storage of fetched models.
+- **Provider Health Checks**: Automatic endpoint validation.
+- **Batch Configuration**: Setup multiple providers simultaneously.
+
+### Provider Extensions (not yet in the static catalog)
+- **Cohere**: Command and Embed models.
+- **Mistral AI**: Mistral and Mixtral models.
 - **Local Providers**: LM Studio, LocalAI, etc.
 
 ## API Reference

--- a/docs/configuration/openwebui-setup.md
+++ b/docs/configuration/openwebui-setup.md
@@ -45,16 +45,27 @@ ollama serve
 
 #### Option A: Environment Variables
 
+> **Note on variable names:** the runtime config schema reads the
+> underscore-separated `OPEN_WEBUI_*` form (e.g. `OPEN_WEBUI_API_URL`), not
+> `OPENWEBUI_*`. The `OPEN_WEBUI_API_URL` should point at the instance's API
+> base (it defaults to `http://host.docker.internal:3000/api/`).
+
 ```bash
 # Required
 LLM_PROVIDER=openwebui
-OPENWEBUI_BASE_URL=http://localhost:8080
+OPEN_WEBUI_API_URL=http://localhost:3000/api/
 
-# Optional - for authenticated instances
-OPENWEBUI_API_KEY=your-api-key
+# Authentication — password mode (default)
+OPEN_WEBUI_AUTH_METHOD=password
+OPEN_WEBUI_USERNAME=admin
+OPEN_WEBUI_PASSWORD=your-password
+
+# Or API-key mode
+# OPEN_WEBUI_AUTH_METHOD=apiKey
+# OPEN_WEBUI_API_KEY=your-api-key
 
 # Model selection (if not using default)
-OPENWEBUI_MODEL=llama2
+OPEN_WEBUI_MODEL=llama3.2
 ```
 
 #### Option B: WebUI Configuration
@@ -71,10 +82,13 @@ OPENWEBUI_MODEL=llama2
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `OPENWEBUI_BASE_URL` | Yes | - | Base URL of your OpenWebUI instance |
-| `OPENWEBUI_API_KEY` | No | - | API key for authentication |
-| `OPENWEBUI_MODEL` | No | (server default) | Model to use for completions |
-| `OPENWEBUI_TIMEOUT` | No | `60000` | Request timeout in milliseconds |
+| `OPEN_WEBUI_API_URL` | Yes | `http://host.docker.internal:3000/api/` | API base URL of your OpenWebUI instance |
+| `OPEN_WEBUI_AUTH_METHOD` | No | `password` | Authentication method: `password` or `apiKey` |
+| `OPEN_WEBUI_USERNAME` | No* | `admin` | Username (*required when `OPEN_WEBUI_AUTH_METHOD=password`) |
+| `OPEN_WEBUI_PASSWORD` | No* | - | Password (*required when `OPEN_WEBUI_AUTH_METHOD=password`) |
+| `OPEN_WEBUI_API_KEY` | No* | - | API key (*used when `OPEN_WEBUI_AUTH_METHOD=apiKey`) |
+| `OPEN_WEBUI_MODEL` | No | `llama3.2` | Model to use for completions |
+| `OPEN_WEBUI_KNOWLEDGE_FILE` | No | - | Optional path to a knowledge file to upload |
 
 ## Connecting to OpenWebUI
 
@@ -82,31 +96,32 @@ OPENWEBUI_MODEL=llama2
 
 ```bash
 # Default local setup
-OPENWEBUI_BASE_URL=http://localhost:8080
+OPEN_WEBUI_API_URL=http://localhost:3000/api/
 ```
 
 ### Docker Network
 
 ```bash
 # If running in Docker Compose
-OPENWEBUI_BASE_URL=http://openwebui:8080
+OPEN_WEBUI_API_URL=http://openwebui:8080/api/
 ```
 
 ### Remote Server
 
 ```bash
 # Remote OpenWebUI instance
-OPENWEBUI_BASE_URL=https://openwebui.yourdomain.com
-OPENWEBUI_API_KEY=your-secure-api-key
+OPEN_WEBUI_API_URL=https://openwebui.yourdomain.com/api/
+OPEN_WEBUI_AUTH_METHOD=apiKey
+OPEN_WEBUI_API_KEY=your-secure-api-key
 ```
 
 ### With Ollama on Different Host
 
 ```bash
-# Ollama on remote machine
-OPENWEBUI_BASE_URL=http://ollama-server:8080
+# Ollama on remote machine, fronted by OpenWebUI
+OPEN_WEBUI_API_URL=http://ollama-server:8080/api/
 # Ensure Ollama is configured to accept connections:
-# O0.0.LLAMA_HOST=0.0
+# OLLAMA_HOST=0.0.0.0
 ```
 
 ## Authentication Setup
@@ -121,8 +136,9 @@ OPENWEBUI_BASE_URL=http://ollama-server:8080
 ### Using the API Key
 
 ```bash
-OPENWEBUI_BASE_URL=http://localhost:8080
-OPENWEBUI_API_KEY=sk-your-key-here
+OPEN_WEBUI_API_URL=http://localhost:3000/api/
+OPEN_WEBUI_AUTH_METHOD=apiKey
+OPEN_WEBUI_API_KEY=sk-your-key-here
 ```
 
 ## Model Management
@@ -141,9 +157,9 @@ curl http://localhost:8080/api/models -H "Authorization: Bearer sk-your-key"
 #### Via Environment Variable
 
 ```bash
-OPENWEBUI_MODEL=llama2
-OPENWEBUI_MODEL=mistral
-OPENWEBUI_MODEL=codellama
+OPEN_WEBUI_MODEL=llama2
+OPEN_WEBUI_MODEL=mistral
+OPEN_WEBUI_MODEL=codellama
 ```
 
 #### Via Metadata (Per-Request)
@@ -171,7 +187,7 @@ System: Use the codellama model for code-related queries
 **Solution**:
 1. Verify API key is correct
 2. Check if API key authentication is enabled in OpenWebUI
-3. Ensure `OPENWEBUI_API_KEY` is set in environment
+3. Ensure `OPEN_WEBUI_API_KEY` (with `OPEN_WEBUI_AUTH_METHOD=apiKey`) or `OPEN_WEBUI_USERNAME`/`OPEN_WEBUI_PASSWORD` is set in environment
 
 ### Error: "Model not found"
 
@@ -180,17 +196,17 @@ System: Use the codellama model for code-related queries
 **Solution**:
 1. List available models: `ollama list`
 2. Pull the model: `ollama pull <model-name>`
-3. Update `OPENWEBUI_MODEL` to match available models
+3. Update `OPEN_WEBUI_MODEL` to match available models
 
 ### Error: "Timeout"
 
 **Cause**: Model is taking too long to respond.
 
 **Solution**:
-1. Increase timeout: `OPENWEBUI_TIMEOUT=120000`
-2. Use a smaller/faster model
-3. Check system resources (RAM, GPU)
-4. Check Ollama logs for loading issues
+1. Use a smaller/faster model
+2. Check system resources (RAM, GPU)
+3. Check Ollama logs for loading issues
+4. Pre-load the model in Ollama so the first request does not pay the load cost
 
 ### Error: "Context length exceeded"
 
@@ -209,20 +225,11 @@ Configure different bots to use different models:
 ```bash
 # Bot 1 - General purpose
 BOTS_bot1_LLM_PROVIDER=openwebui
-BOTS_bot1_OPENWEBUI_MODEL=llama2
+BOTS_bot1_OPEN_WEBUI_MODEL=llama2
 
 # Bot 2 - Code-focused
 BOTS_bot2_LLM_PROVIDER=openwebui
-BOTS_bot2_OPENWEBUI_MODEL=codellama
-```
-
-### Streaming Responses
-
-OpenWebUI supports streaming for real-time output:
-
-```bash
-# Enable streaming (enabled by default)
-OPENWEBUI_ENABLE_STREAMING=true
+BOTS_bot2_OPEN_WEBUI_MODEL=codellama
 ```
 
 ### Custom Ollama Settings
@@ -286,7 +293,7 @@ OLLAMA_BASE_URL=http://localhost:11434
 
 # After (OpenWebUI)
 LLM_PROVIDER=openwebui
-OPENWEBUI_BASE_URL=http://localhost:8080
+OPEN_WEBUI_API_URL=http://localhost:3000/api/
 ```
 
 OpenWebUI provides additional features like:

--- a/docs/configuration/provider-cheatsheet.md
+++ b/docs/configuration/provider-cheatsheet.md
@@ -9,9 +9,16 @@ Navigation: [Docs Index](../README.md) | [Configuration Overview](overview.md) |
 
 | Provider | Config Key | Required Env Vars | Supports Chat | Supports Text | Notes |
 |----------|------------|-------------------|---------------|---------------|--------|
-| **OpenAI** | `openai` | `OPENAI_API_KEY` | ✅ | ✅ | Full OpenAI API support |
+| **OpenAI** | `openai` | `OPENAI_API_KEY` | ✅ | ✅ | Full OpenAI API support; native function calling and a streaming completion method (`generateStreamingChatCompletion`) |
 | **Flowise** | `flowise` | `FLOWISE_BASE_URL` | ✅ | ❌ | Requires `channelId` in metadata |
-| **OpenWebUI** | `openwebui` | `OPENWEBUI_BASE_URL` | ✅ | ❌ | Local instance only |
+| **OpenWebUI** | `openwebui` | `OPEN_WEBUI_API_URL` | ✅ | ❌ | Local instance; OpenAI-compatible API |
+| **Letta** | `letta` | `LETTA_SERVER_PASSWORD` (auth) | ✅ | ❌ | Stateful agent backend; agent via `LETTA_AGENT_ID`; base URL/API key set through the LLM profile / Providers UI (`LETTA_BASE_URL`, `LETTA_API_KEY` schema fields) |
+| **OpenSwarm** | `openswarm` | `OPENSWARM_BASE_URL` | ✅ | ❌ | Multi-agent team backend; `OPENSWARM_TEAM` selects the team/model |
+
+> **Live model listing:** the admin endpoint `GET /api/admin/llm-providers/:type/models`
+> serves a curated catalog for `openai`, `anthropic`, `google`, and `perplexity`,
+> and supports live provider queries with `?live=true` for `openai` and
+> `openwebui`. See [LLM Provider Models API](../api/llm-models-endpoint.md).
 
 ### Platform Services
 
@@ -19,7 +26,7 @@ Navigation: [Docs Index](../README.md) | [Configuration Overview](overview.md) |
 |----------|---------------|---------------|-----------|--------|
 | **Discord** | `DiscordService` | `DISCORD_BOT_TOKEN` | ✅ | Comma-separated tokens |
 | **Slack** | `SlackService` | Slack tokens | ✅ | OAuth setup required |
-| **Mattermost** | `MattermostService` | Mattermost config | ✅ | Webhook-based |
+| **Mattermost** | `MattermostService` | Mattermost config | ✅ | Receives messages over WebSocket; shows typing indicator |
 
 ## Environment Variable Quick Setup
 
@@ -68,8 +75,41 @@ FLOWISE_CONVERSATION_CHATFLOW_ID=your-chatflow-id
 
 ### OpenWebUI Provider
 ```bash
+# Required (note: OPEN_WEBUI_*, underscore-separated)
+OPEN_WEBUI_API_URL=http://localhost:3000/api/
+
+# Auth — password (default) or apiKey
+OPEN_WEBUI_AUTH_METHOD=password
+OPEN_WEBUI_USERNAME=admin
+OPEN_WEBUI_PASSWORD=your-password
+
+# Optional
+OPEN_WEBUI_MODEL=llama3.2
+```
+
+### Letta Provider
+```bash
+# Auth (read directly from env by the provider client)
+LETTA_SERVER_PASSWORD=your-server-password   # used for cloud and self-hosted auth
+
+# Default agent when none is supplied in message metadata
+LETTA_AGENT_ID=agent-uuid
+```
+
+Base URL and API key are configured through the LLM profile / Providers UI
+(schema fields `LETTA_BASE_URL`, `LETTA_API_KEY`), not as raw process env vars.
+The provider also supports a per-bot session mode (`default`, `per-channel`,
+`per-user`, `fixed`) so a bot can maintain isolated Letta conversations per
+channel or per user.
+
+### OpenSwarm Provider
+```bash
 # Required
-OPENWEBUI_BASE_URL=http://localhost:8080
+OPENSWARM_BASE_URL=http://localhost:8000/v1
+
+# Optional
+OPENSWARM_API_KEY=your-key
+OPENSWARM_TEAM=default-team      # team name used as the model identifier
 ```
 
 ## Common Configuration Patterns


### PR DESCRIPTION
## Summary

Updates the **config-providers** documentation domain to match the current code after the recent campaign. All changes are docs-only and verified against source.

## What changed and why

### `docs/api/llm-models-endpoint.md`
- Documented the new `?live=true` query param on `GET /api/admin/llm-providers/:type/models` (live model fetching for `openai` and `openwebui`, with static fallback). Verified against `src/server/routes/admin/systemInfo.ts` and `src/server/services/LiveModelService.ts`.
- Added the `source` response field (`"live"`/`"static"`) to the documented response shape and examples.
- Added an OpenWebUI provider-notes entry and corrected the Data Source section to list the static catalog providers (`openai`, `anthropic`, `google`, `perplexity`) and the live-fetch service file.

### `docs/configuration/dynamic-model-fetching.md`
- Rewrote "Model Fetching Endpoints" to distinguish the curated static catalog (admin endpoint) from server-side live fetching (`LiveModelService`, OpenAI + OpenWebUI).
- Replaced the stale "Future Enhancements / Planned" list: model metadata, live fetching, Google (Gemini), and import/export are now implemented; kept genuinely-pending items (caching, health checks, batch config) and not-yet-cataloged providers honestly labeled.

### `docs/configuration/openwebui-setup.md`
- **Corrected env var names**: the runtime convict schema (`src/config/openWebUIConfig.ts`, `packages/llm-openwebui/src/openWebUIConfig.ts`) reads `OPEN_WEBUI_*` (underscore-separated), not `OPENWEBUI_*`. Updated all examples, the env-var table, auth (`OPEN_WEBUI_AUTH_METHOD` password/apiKey), and the migration section.
- Removed references to non-existent `OPENWEBUI_TIMEOUT` and `OPENWEBUI_ENABLE_STREAMING` vars (not present in the schema).

### `docs/configuration/provider-cheatsheet.md`
- Added **Letta** and **OpenSwarm** to the LLM provider table and added quick-config blocks for both. Env vars verified against provider source (`OPENSWARM_BASE_URL`/`OPENSWARM_API_KEY`/`OPENSWARM_TEAM`; Letta auth via `LETTA_SERVER_PASSWORD` + `LETTA_AGENT_ID`, with `LETTA_BASE_URL`/`LETTA_API_KEY` as LLM-profile/Providers-UI schema fields). Noted Letta's per-bot session mode (default/per-channel/per-user/fixed).
- Corrected the OpenWebUI required env var to `OPEN_WEBUI_API_URL`.
- Added a note that OpenAI exposes native function calling and a `generateStreamingChatCompletion` streaming method.
- Added a "Live model listing" callout pointing at the models endpoint.
- Updated the Mattermost platform note from "Webhook-based" to WebSocket receive + typing indicator (now implemented in `MattermostService`).

## Accuracy notes
- Streaming is described as a **provider method/capability** (`generateStreamingChatCompletion`, defined on the OpenAI provider and the `ILlmProvider` interface as optional). It is not yet invoked by the message pipeline, so the docs deliberately do not claim bots stream replies end-to-end.
- Postgres native-vector memory (`getMemory` indexed lookup, embedding via the resolved LLM provider) lives in the memory docs domain, not config-providers, so no claims were added here beyond what this domain covers.

No code or tests were modified.