### PR TITLE
🎨 Palette: Add aria-labels to modal close buttons

### DIFF
--- a/src/client/src/components/BotManagement/BenchmarkModal.tsx
+++ b/src/client/src/components/BotManagement/BenchmarkModal.tsx
@@ -141,7 +141,7 @@ const BenchmarkModal: React.FC<BenchmarkModalProps> = ({ botId, botName, isOpen,
                    Benchmarks are indicative and based on standardized logic tests.
                 </p>
                 <div className="flex gap-2">
-                   <button onClick={onClose} className="btn btn-sm btn-ghost">Close</button>
+                   <button onClick={onClose} className="btn btn-sm btn-ghost" aria-label="Close modal">Close</button>
                    <button onClick={runBenchmark} className="btn btn-sm btn-primary gap-2">
                       <RotateCcw className="w-4 h-4" /> Re-Run
                    </button>

--- a/src/client/src/components/BotManagement/DiagnosticModal.tsx
+++ b/src/client/src/components/BotManagement/DiagnosticModal.tsx
@@ -141,7 +141,7 @@ const DiagnosticModal: React.FC<DiagnosticModalProps> = ({ botId, botName, isOpe
              <div className="pt-4 border-t border-base-300 flex justify-between items-center">
                 <div className="text-[10px] opacity-30 font-mono">ID: {botId}</div>
                 <div className="flex gap-2">
-                   <button onClick={onClose} className="btn btn-sm btn-ghost">Close</button>
+                   <button onClick={onClose} className="btn btn-sm btn-ghost" aria-label="Close modal">Close</button>
                    <button onClick={runDiagnostic} className="btn btn-sm btn-primary gap-2" disabled={loading}>
                       <Activity className="w-4 h-4" /> 
                       {loading ? 'Testing...' : 'Run Again'}

--- a/src/client/src/components/BotManagement/VersionHistoryModal.tsx
+++ b/src/client/src/components/BotManagement/VersionHistoryModal.tsx
@@ -148,7 +148,7 @@ const VersionHistoryModal: React.FC<VersionHistoryModalProps> = ({ botId, botNam
         )}
 
         <div className="flex justify-end pt-2">
-           <button onClick={onClose} className="btn btn-ghost">Close</button>
+           <button onClick={onClose} className="btn btn-ghost" aria-label="Close modal">Close</button>
         </div>
       </div>
     </Modal>


### PR DESCRIPTION
💡 What: Added `aria-label="Close modal"` to textual close buttons inside modals in the BotManagement section (`BenchmarkModal`, `DiagnosticModal`, `VersionHistoryModal`).
🎯 Why: Textual close buttons were missing explicit ARIA labels, which can cause inconsistent or ambiguous announcements by screen readers compared to icon-only close buttons. This ensures clear and consistent accessible descriptions across the application's dialogs.
♿ Accessibility: Improves screen reader experience by providing an explicit action context for standard "Close" buttons.

---
*PR created automatically by Jules for task [6702430902726752732](https://jules.google.com/task/6702430902726752732) started by @matthewhand*