### PR TITLE
🎨 Palette: Add target loading states to Delete Provider action

### DIFF
--- a/src/client/src/components/IntegrationsPanel.tsx
+++ b/src/client/src/components/IntegrationsPanel.tsx
@@ -80,6 +80,7 @@ const IntegrationsPanel: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [deletingKey, setDeletingKey] = useState<string | null>(null);
 
   // Edit/Configure Modal State (For Global Config)
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -231,13 +232,13 @@ const IntegrationsPanel: React.FC = () => {
       onConfirm: async () => {
         setConfirmModal(prev => ({ ...prev, isOpen: false }));
         try {
-          setSaving(true);
+          setDeletingKey(key);
           await apiService.delete(`/api/config/llm-profiles/${key}`);
           await fetchData();
         } catch (err: unknown) {
           errorToast('Delete Failed', `Failed to delete profile: ${(err instanceof Error ? err.message : String(err))}`);
         } finally {
-          setSaving(false);
+          setDeletingKey(null);
         }
       },
     });
@@ -428,6 +429,7 @@ const IntegrationsPanel: React.FC = () => {
                         className="btn-square btn-xs text-error"
                         aria-label={`Delete ${profile.name} provider`}
                         onClick={() => handleDeleteProfile(profile.key)}
+                        loading={deletingKey === profile.key}
                       >
                         <TrashIcon className="w-4 h-4" />
                       </Button>


### PR DESCRIPTION
### 💡 What:
Added a target-specific loading state to the "Delete" action button for individual provider profiles in the `IntegrationsPanel`.

### 🎯 Why:
To improve UX by providing clear, immediate visual feedback exactly on the button that the user clicked, confirming that their action (deletion) is actively being processed, rather than relying on a general processing state.

### ♿ Accessibility:
No significant changes to pure ARIA attributes were made, but the `Button` component dynamically adjusts `aria-busy` when `loading` is passed, making the intermediate state accessible to screen readers.

---
*PR created automatically by Jules for task [4489013905490949000](https://jules.google.com/task/4489013905490949000) started by @matthewhand*