### PR TITLE
🎨 Palette: Add keyboard focus rings to interactive buttons

### DIFF
--- a/src/client/src/components/SearchFilterBar.tsx
+++ b/src/client/src/components/SearchFilterBar.tsx
@@ -73,7 +73,7 @@ export const SearchFilterBar: React.FC<SearchFilterBarProps> = ({
             localSearch ? (
               <button
                 onClick={handleClearSearch}
-                className="btn btn-ghost btn-xs btn-circle pointer-events-auto relative z-10 animate-in fade-in zoom-in duration-200"
+                className="btn btn-ghost btn-xs btn-circle pointer-events-auto relative z-10 animate-in fade-in zoom-in duration-200 focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
                 aria-label="Clear search"
               >
                 <X className="w-3 h-3" />

--- a/src/client/src/components/mcp-tools/ToolRegistryPanel.tsx
+++ b/src/client/src/components/mcp-tools/ToolRegistryPanel.tsx
@@ -125,7 +125,7 @@ const ToolRegistryPanel: React.FC<ToolRegistryPanelProps> = ({
                 </div>
               </div>
               <button
-                className="btn btn-xs btn-ghost btn-circle"
+                className="btn btn-xs btn-ghost btn-circle focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
                 onClick={(e) => {
                   e.stopPropagation();
                   onToggleFavorite(tool.id);
@@ -142,7 +142,7 @@ const ToolRegistryPanel: React.FC<ToolRegistryPanelProps> = ({
             </div>
             <div className="flex gap-2 mt-2">
               <button
-                className="btn btn-xs btn-primary flex-1"
+                className="btn btn-xs btn-primary flex-1 focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none focus-visible:ring-offset-1 focus-visible:ring-offset-base-100"
                 onClick={() => {
                   const lastUsage = recentlyUsed.find(r => r.toolId === tool.id);
                   onRunTool(tool, lastUsage?.arguments);
@@ -169,7 +169,7 @@ const ToolRegistryPanel: React.FC<ToolRegistryPanelProps> = ({
             </div>
             <div className="flex items-center gap-2">
               <button
-                className="btn btn-sm btn-ghost btn-circle"
+                className="btn btn-sm btn-ghost btn-circle focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
                 onClick={() => onToggleFavorite(tool.id)}
                 title={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
                 aria-label={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
@@ -213,13 +213,13 @@ const ToolRegistryPanel: React.FC<ToolRegistryPanelProps> = ({
 
           <Card.Actions className="justify-between mt-auto">
             <button
-              className={`btn btn-sm ${tool.enabled ? 'btn-error btn-outline' : 'btn-success btn-outline'}`}
+              className={`btn btn-sm ${tool.enabled ? 'btn-error btn-outline' : 'btn-success btn-outline'} focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none focus-visible:ring-offset-1 focus-visible:ring-offset-base-100`}
               onClick={() => onToggleTool(tool.id)}
             >
               {tool.enabled ? 'Disable' : 'Enable'}
             </button>
             <button
-              className="btn btn-sm btn-primary"
+              className="btn btn-sm btn-primary focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none focus-visible:ring-offset-1 focus-visible:ring-offset-base-100"
               onClick={() => onRunTool(tool)}
               disabled={!tool.enabled}
             >


### PR DESCRIPTION
💡 **What**: Added `focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none` (and `ring-offset` where helpful) to several buttons in `SearchFilterBar.tsx` and `ToolRegistryPanel.tsx` (like 'Clear Search', 'Toggle Favorite', and 'Run').
🎯 **Why**: Many DaisyUI/Tailwind buttons, specifically `btn-ghost` and `btn-circle`, lack a distinct focus outline out-of-the-box, making keyboard navigation difficult for screen reader or keyboard-only users.
♿ **Accessibility**: Greatly improves keyboard focus visibility for key interactive tool actions.

---
*PR created automatically by Jules for task [12268917105948737599](https://jules.google.com/task/12268917105948737599) started by @matthewhand*