### PR TITLE
🎨 Palette: Add ARIA labels to copy buttons in ToolResultModal

### DIFF
--- a/src/client/src/components/ToolResultModal.tsx
+++ b/src/client/src/components/ToolResultModal.tsx
@@ -120,6 +120,7 @@ const ToolResultModal: React.FC<ToolResultModalProps> = ({ isOpen, onClose, resu
             <button
               className="btn btn-xs btn-ghost gap-2"
               onClick={() => handleCopy(JSON.stringify(result.arguments, null, 2), 'arguments')}
+              aria-label="Copy arguments to clipboard"
             >
               {copiedSection === 'arguments' ? (
                 <>
@@ -150,6 +151,7 @@ const ToolResultModal: React.FC<ToolResultModalProps> = ({ isOpen, onClose, resu
                     'error'
                   )
                 }
+                aria-label="Copy error to clipboard"
               >
                 {copiedSection === 'error' ? (
                   <>
@@ -186,6 +188,7 @@ const ToolResultModal: React.FC<ToolResultModalProps> = ({ isOpen, onClose, resu
               <button
                 className="btn btn-xs btn-ghost gap-2"
                 onClick={() => handleCopy(JSON.stringify(result.result, null, 2), 'result')}
+                aria-label="Copy result to clipboard"
               >
                 {copiedSection === 'result' ? (
                   <>


### PR DESCRIPTION
🎨 **Palette:** UX improvement for screen reader accessibility in `ToolResultModal`.

💡 **What:** Added descriptive `aria-label`s to the three icon-only "Copy" buttons in the `ToolResultModal` component.
🎯 **Why:** To prevent screen readers from generically announcing "Copy" or "Button" multiple times within the same modal without specifying *what* is being copied (arguments, error, or result).
♿ **Accessibility:** Screen reader users will now explicitly hear "Copy arguments to clipboard", "Copy error to clipboard", or "Copy result to clipboard".

---
*PR created automatically by Jules for task [3322162586368514621](https://jules.google.com/task/3322162586368514621) started by @matthewhand*