### PR TITLE
🛡️ Sentinel: [MEDIUM] Add rate limiting to marketplace routes

### DIFF
--- a/src/server/routes/marketplace.ts
+++ b/src/server/routes/marketplace.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import Debug from 'debug';
 import { Router } from 'express';
-import { configLimiter } from '@src/middleware/rateLimiter';
+import { apiLimiter, configLimiter } from '@src/middleware/rateLimiter';
 import {
   installPlugin,
   listInstalledPlugins,
@@ -331,6 +331,7 @@ function invalidateCache(): void {
  */
 router.get(
   '/packages',
+  apiLimiter,
   asyncErrorHandler(async (req, res) => {
     try {
       const packages = await getPackages();
@@ -352,6 +353,7 @@ router.get(
  */
 router.get(
   '/packages/:name',
+  apiLimiter,
   asyncErrorHandler(async (req, res) => {
     try {
       const name = req.params.name;


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Add rate limiting to marketplace routes

🎯 What
The marketplace API routes (`/api/marketplace/packages` and `/api/marketplace/packages/:name`) were missing explicit rate limiting, making them potentially vulnerable to denial-of-service or scraping attacks.

⚠️ Risk
Without rate limits, an attacker or misconfigured client could send an excessive number of requests to the marketplace endpoints, potentially exhausting server resources or triggering upstream rate limits if the backend makes external calls (e.g., to GitHub).

🛡️ Solution
Imported the `apiLimiter` from `@src/middleware/rateLimiter` and applied it to the `GET /packages` and `GET /packages/:name` routes in `src/server/routes/marketplace.ts`.

✅ Verification
Ran the test suite, linting, and verified the build successfully compiles with the new middleware imported and applied.

---
*PR created automatically by Jules for task [4876120196985565726](https://jules.google.com/task/4876120196985565726) started by @matthewhand*