### PR TITLE
⚡ Bolt: [performance improvement] Pre-compute lookup maps in server enrichment

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -43,3 +43,6 @@
 ## 2026-05-02 - ProviderConfigForm Re-rendering
 **Learning:** The form components re-render frequently (e.g., on every keystroke). Using `.reduce()` and `.filter()` on potentially large arrays within the component body without memoization leads to O(N) recalculations on every render, which can cause typing lag on complex configuration forms.
 **Action:** Use `useMemo` to wrap expensive array transformations inside React components, especially forms.
+## 2025-02-27 - O(N*M) Array Enrichment
+**Learning:** In backend routes that enrich one array with data from another, using `.find()` inside a `.map()` loop creates an O(N*M) time complexity bottleneck. This is especially prevalent when combining real-time status arrays (like connected servers) with stored configuration arrays.
+**Action:** Always pre-compute a lookup `Map` of the secondary array based on the join key (e.g., `name` or `id`) before the `.map()` loop to achieve O(N + M) complexity with O(1) lookups.

--- a/src/server/routes/admin/maintenance.ts
+++ b/src/server/routes/admin/maintenance.ts
@@ -224,10 +224,16 @@ router.get('/mcp-servers', async (req: Request, res: Response) => {
     // Get stored MCP server configurations
     const storedMcps = await webUIStorage.getMcps();
 
+    // Pre-compute lookup map for O(1) access
+    const storedMcpsMap = new Map<string, any>();
+    for (const mcp of storedMcps) {
+      storedMcpsMap.set(mcp.name, mcp);
+    }
+
     // Enrich connected servers with stored configuration data
 
     const enrichedServers = connectedServers.map((server) => {
-      const storedConfig = storedMcps.find((mcp: any) => mcp.name === server.name);
+      const storedConfig = storedMcpsMap.get(server.name);
       return {
         name: server.name,
         serverUrl: storedConfig?.serverUrl || storedConfig?.url || '',

--- a/src/server/routes/admin/mcpServers.ts
+++ b/src/server/routes/admin/mcpServers.ts
@@ -222,10 +222,16 @@ router.get('/mcp-servers', async (req: Request, res: Response) => {
     // Get stored MCP server configurations
     const storedMcps = await webUIStorage.getMcps();
 
+    // Pre-compute lookup map for O(1) access
+    const storedMcpsMap = new Map<string, any>();
+    for (const mcp of storedMcps) {
+      storedMcpsMap.set(mcp.name, mcp);
+    }
+
     // Enrich connected servers with stored configuration data
 
     const enrichedServers = connectedServers.map((server) => {
-      const storedConfig = storedMcps.find((mcp: any) => mcp.name === server.name);
+      const storedConfig = storedMcpsMap.get(server.name);
       return {
         name: server.name,
         serverUrl: storedConfig?.serverUrl || storedConfig?.url || '',


### PR DESCRIPTION
💡 **What**: Replaced `O(N*M)` array lookups with `O(N+M)` `Map` lookups in the admin routes for `mcpServers.ts` and `maintenance.ts`.
🎯 **Why**: When enriching the list of connected servers with stored configuration data, the code previously used `.find()` inside a `.map()` loop. As the number of connected servers and stored configurations grows, this nested iteration causes unnecessary CPU overhead. Pre-computing a lookup dictionary eliminates the inner loop.
📊 **Impact**: Reduces time complexity of the server enrichment logic from `O(N*M)` to `O(N + M)`.
🔬 **Measurement**: Verified by ensuring the endpoints continue to correctly merge the live server metadata with the persistent stored descriptions, while executing tests successfully. No functional changes, purely an internal performance refactor.

---
*PR created automatically by Jules for task [362499082018048462](https://jules.google.com/task/362499082018048462) started by @matthewhand*