### PR TITLE
feat(security): safe hardening — log redaction, cross-origin isolation headers, key-length guard

### DIFF
--- a/src/common/redactSensitiveInfo.ts
+++ b/src/common/redactSensitiveInfo.ts
@@ -24,6 +24,13 @@ export function redactSensitiveInfo(key: string, value: any): string {
     'secret',
     'token',
     'private_key',
+    'signing_key',
+    'encryption_key',
+    'session_secret',
+    'admin_password',
+    'signature',
+    'salt',
+    'credential',
   ];
   try {
     const lowerKey = key.toLowerCase();

--- a/src/config/SecureConfigManager.ts
+++ b/src/config/SecureConfigManager.ts
@@ -502,7 +502,17 @@ export class SecureConfigManager {
   private async getOrCreateEncryptionKey(): Promise<Buffer> {
     try {
       await fs.promises.access(this.keyPath);
-      return await fs.promises.readFile(this.keyPath);
+      const key = await fs.promises.readFile(this.keyPath);
+      // Guard against a truncated/corrupt key file: a key shorter than the
+      // AES-256 requirement would otherwise surface as an opaque crypto error
+      // at encrypt/decrypt time. This error has no ENOENT code, so the catch
+      // below re-throws it rather than silently regenerating the key.
+      if (key.length < 32) {
+        throw new Error(
+          `Encryption key at ${this.keyPath} is too short (${key.length} bytes; must be at least 32)`
+        );
+      }
+      return key;
     } catch (err: unknown) {
       if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
 

--- a/src/server/middleware/security.ts
+++ b/src/server/middleware/security.ts
@@ -29,6 +29,14 @@ export function securityHeaders(req: Request, res: Response, next: NextFunction)
   // Permissions Policy
   res.setHeader('Permissions-Policy', 'geolocation=(), microphone=(), camera=()');
 
+  // Cross-origin isolation headers (additive, same-origin app).
+  // NOTE: Cross-Origin-Embedder-Policy: require-corp is intentionally omitted —
+  // it would block cross-origin resources (e.g. Google Fonts) that don't send a
+  // CORP header and can break the WebUI.
+  res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+  res.setHeader('Cross-Origin-Resource-Policy', 'same-origin');
+  res.setHeader('Origin-Agent-Cluster', '?1');
+
   // Content Security Policy (CSP)
   // SECURITY NOTE: CSP with 'unsafe-eval' and 'unsafe-inline'
   //

--- a/tests/unit/common/redactSensitiveInfo.patterns.test.ts
+++ b/tests/unit/common/redactSensitiveInfo.patterns.test.ts
@@ -1,0 +1,44 @@
+import { redactSensitiveInfo } from '../../../src/common/redactSensitiveInfo';
+
+/**
+ * Verifies the sensitive-key pattern list: newly-added cryptographic material
+ * keys are redacted, while innocuous keys (which a too-broad substring like
+ * 'iv' would have falsely matched) are left intact.
+ */
+describe('redactSensitiveInfo sensitive patterns', () => {
+  const longValue = 'abcdefghijklmnopqrstuvwxyz0123456789';
+
+  it.each([
+    'signing_key',
+    'encryption_key',
+    'session_secret',
+    'admin_password',
+    'signature',
+    'salt',
+    'credential',
+    // pre-existing patterns still covered
+    'password',
+    'api_key',
+    'auth_token',
+  ])('redacts the value for sensitive key "%s"', (key) => {
+    const out = redactSensitiveInfo(key, longValue);
+    expect(out).not.toBe(longValue);
+    expect(out).toContain('*');
+  });
+
+  it.each([
+    // These contain the substring "iv" — they must NOT be redacted now that
+    // 'iv' was dropped from the pattern list.
+    'active',
+    'isActive',
+    'archiveSettings',
+    'privilegeLevel',
+    'deliveryStatus',
+    // unrelated innocuous keys
+    'username',
+    'displayName',
+    'channelId',
+  ])('does NOT redact the value for innocuous key "%s"', (key) => {
+    expect(redactSensitiveInfo(key, longValue)).toBe(longValue);
+  });
+});

--- a/tests/unit/middleware/security.test.ts
+++ b/tests/unit/middleware/security.test.ts
@@ -85,5 +85,20 @@ describe('security middleware', () => {
       expect(res.setHeader).toHaveBeenCalledWith('X-Frame-Options', 'DENY');
       expect(next).toHaveBeenCalled();
     });
+
+    it('sets the additive cross-origin isolation headers but NOT COEP', () => {
+      const req = {} as Request;
+      const res = { setHeader: jest.fn(), removeHeader: jest.fn() } as unknown as Response;
+      const next = jest.fn() as NextFunction;
+
+      securityHeaders(req, res, next);
+
+      expect(res.setHeader).toHaveBeenCalledWith('Cross-Origin-Opener-Policy', 'same-origin');
+      expect(res.setHeader).toHaveBeenCalledWith('Cross-Origin-Resource-Policy', 'same-origin');
+      expect(res.setHeader).toHaveBeenCalledWith('Origin-Agent-Cluster', '?1');
+      // COEP: require-corp is intentionally omitted (would break cross-origin fonts/images).
+      const headerNames = (res.setHeader as jest.Mock).mock.calls.map((c) => c[0]);
+      expect(headerNames).not.toContain('Cross-Origin-Embedder-Policy');
+    });
   });
 });


### PR DESCRIPTION
## Scope (rewritten)

The original revision bundled production-runtime changes that couldn't be validated by the test suite and carried deploy-breakage risk (fail-fast on missing secrets, strict CSP removing `unsafe-inline`/`unsafe-eval`, a Netlify `_headers` rewrite). Per maintainer decision those are **dropped**; this revision keeps only the safe, test-verified hardening.

## Changes
- **Log redaction** (`redactSensitiveInfo`): add `signing_key`, `encryption_key`, `session_secret`, `admin_password`, `signature`, `salt`, `credential`. The original also added `iv`, which is dropped — as a substring it falsely redacted innocuous keys (`active`, `archive`, `privilege`, …).
- **Cross-origin isolation headers** (`securityHeaders`): add `Cross-Origin-Opener-Policy: same-origin`, `Cross-Origin-Resource-Policy: same-origin`, `Origin-Agent-Cluster: ?1`. **`Cross-Origin-Embedder-Policy: require-corp` is intentionally omitted** — it would block cross-origin resources (e.g. Google Fonts) and break the WebUI.
- **Encryption-key guard** (`SecureConfigManager.getOrCreateEncryptionKey`): reject a truncated key file (<32 bytes) with a clear error instead of an opaque crypto failure later. This also **fixes the original PR's unreachable-code bug** (a production check placed *after* a `return`).

## Tests
- `redactSensitiveInfo.patterns.test.ts` — redaction of the new keys + explicit no-false-positive cases (`active`, `archive`, …).
- `security.test.ts` — asserts the three isolation headers are set and COEP is **not**.
- `tsc --noEmit` clean.

## Held for a separate decision
Fail-fast-on-missing-secrets and strict production CSP were intentionally not included — they change production deploy behavior and need an explicit owner decision before enforcement.