### PR TITLE
feat(memory): implement PostgresMemoryProvider.updateMemory (was a stub)

### DIFF
--- a/packages/memory-postgres/src/PostgresMemoryProvider.test.ts
+++ b/packages/memory-postgres/src/PostgresMemoryProvider.test.ts
@@ -17,6 +17,7 @@ describe('PostgresMemoryProvider (Mocked)', () => {
         ]),
       getMemories: jest.fn().mockResolvedValue([]),
       getMemoryById: jest.fn().mockResolvedValue(null),
+      updateMemory: jest.fn().mockResolvedValue(true),
       deleteMemory: jest.fn().mockResolvedValue(true),
       deleteAllMemories: jest.fn().mockResolvedValue(undefined),
       isConnected: jest.fn().mockReturnValue(true),
@@ -95,6 +96,40 @@ describe('PostgresMemoryProvider (Mocked)', () => {
     expect(mockDbManager.getMemoryById).toHaveBeenCalledWith('does-not-exist');
     expect(mockDbManager.getMemories).not.toHaveBeenCalled();
     expect(result).toBeNull();
+  });
+
+  it('should update a memory: re-embeds the new content and returns the fresh row', async () => {
+    mockDbManager.updateMemory.mockResolvedValue(true);
+    mockDbManager.getMemoryById.mockResolvedValue({
+      id: 7,
+      content: 'updated content',
+      metadata: { v: 2 },
+      userId: 'u1',
+      agentId: 'a1',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    const result = await provider.updateMemory('7', 'updated content', { v: 2 });
+
+    // New content is re-embedded so semantic search stays consistent.
+    expect(mockEmbeddingProvider.generateEmbedding).toHaveBeenCalledWith('updated content');
+    expect(mockDbManager.updateMemory).toHaveBeenCalledWith(
+      '7',
+      expect.objectContaining({
+        content: 'updated content',
+        metadata: { v: 2 },
+        embedding: expect.any(Array),
+      })
+    );
+    expect(result).toEqual(
+      expect.objectContaining({ id: '7', content: 'updated content', metadata: { v: 2 } })
+    );
+  });
+
+  it('should throw when updating a memory id that does not exist', async () => {
+    mockDbManager.updateMemory.mockResolvedValue(false);
+
+    await expect(provider.updateMemory('missing', 'x')).rejects.toThrow(/not found/);
   });
 
   it('should select a non-OpenAI provider that implements generateEmbedding', async () => {

--- a/packages/memory-postgres/src/PostgresMemoryProvider.ts
+++ b/packages/memory-postgres/src/PostgresMemoryProvider.ts
@@ -176,7 +176,25 @@ export class PostgresMemoryProvider implements IMemoryProvider {
     content: string,
     metadata?: Record<string, unknown>
   ): Promise<MemoryEntry> {
-    throw new Error('Update memory not implemented in PostgresMemoryProvider');
+    this.ensureInitialized();
+
+    // Re-embed the new content so semantic search stays consistent with the
+    // updated text, then update the row in place (preserving id / created_at).
+    const embedding = await this.embeddingProvider.generateEmbedding(content);
+    const updated = await this.dbManager.updateMemory(id, { content, metadata, embedding });
+    if (!updated) {
+      throw new Error(`PostgresMemoryProvider: memory ${id} not found`);
+    }
+
+    const row = await this.dbManager.getMemoryById(id);
+    return {
+      id: String(id),
+      content: row?.content ?? content,
+      metadata: row?.metadata ?? metadata,
+      userId: row?.userId,
+      agentId: row?.agentId,
+      timestamp: row?.createdAt ? new Date(row.createdAt).getTime() : Date.now(),
+    };
   }
 
   async deleteMemory(id: string): Promise<void> {

--- a/src/database/DatabaseManager.ts
+++ b/src/database/DatabaseManager.ts
@@ -593,6 +593,13 @@ export class DatabaseManager {
     return this.memoryRepo.getMemoryById(id);
   }
 
+  async updateMemory(
+    id: string | number,
+    fields: { content?: string; metadata?: Record<string, unknown>; embedding?: number[] }
+  ): Promise<boolean> {
+    return this.memoryRepo.updateMemory(id, fields);
+  }
+
   async deleteMemory(id: string | number): Promise<boolean> {
     return this.memoryRepo.deleteMemory(id);
   }

--- a/src/database/repositories/MemoryRepository.ts
+++ b/src/database/repositories/MemoryRepository.ts
@@ -188,6 +188,58 @@ export class MemoryRepository {
     }
   }
 
+  /**
+   * Update an existing memory row in place, preserving its id and created_at.
+   *
+   * Only the fields present in `fields` are written, so callers can update the
+   * content (and its re-computed embedding) without clobbering metadata, or
+   * vice-versa. Embeddings are encoded the same way as in {@link addMemory}
+   * (pgvector literal for Postgres, JSON string for SQLite).
+   *
+   * @returns true when a row was updated, false when no row matched or no
+   *          updatable field was supplied.
+   */
+  async updateMemory(
+    id: string | number,
+    fields: { content?: string; metadata?: Record<string, unknown>; embedding?: number[] }
+  ): Promise<boolean> {
+    if (!this.isConnected()) return false;
+    const db = this.getDb();
+    if (!db) return false;
+
+    try {
+      const isPg = this.isPostgres();
+      const sets: string[] = [];
+      const params: any[] = [];
+
+      if (fields.content !== undefined) {
+        sets.push('content = ?');
+        params.push(fields.content);
+      }
+      if (fields.metadata !== undefined) {
+        sets.push('metadata = ?');
+        params.push(fields.metadata ? JSON.stringify(fields.metadata) : null);
+      }
+      if (fields.embedding !== undefined) {
+        sets.push(`embedding = ${isPg ? '?::vector' : '?'}`);
+        params.push(isPg ? `[${fields.embedding.join(',')}]` : JSON.stringify(fields.embedding));
+      }
+
+      // Nothing to update — avoid issuing an empty SET clause.
+      if (sets.length === 0) return false;
+
+      params.push(id);
+      const result = await db.run(
+        `UPDATE memories SET ${sets.join(', ')} WHERE id = ?`,
+        params
+      );
+      return (result.changes ?? 0) > 0;
+    } catch (error) {
+      debug('Error updating memory:', error);
+      throw error;
+    }
+  }
+
   async deleteMemory(id: string | number): Promise<boolean> {
     if (!this.isConnected()) return false;
     const db = this.getDb();

--- a/tests/unit/repositories/MemoryRepository.update.test.ts
+++ b/tests/unit/repositories/MemoryRepository.update.test.ts
@@ -1,0 +1,91 @@
+import { MemoryRepository } from '../../../src/database/repositories/MemoryRepository';
+import type { IDatabase } from '../../../src/database/types';
+
+/**
+ * Focused tests for MemoryRepository.updateMemory, which updates an existing
+ * memory row in place (preserving id / created_at). Only the supplied fields
+ * are written, and embeddings are encoded per-dialect (pgvector vs JSON).
+ */
+function makeRepo(
+  runImpl: (sql: string, params: any[]) => Promise<any>,
+  opts: { connected?: boolean; postgres?: boolean } = {}
+) {
+  const run = jest.fn(runImpl);
+  const db = {
+    run,
+    get: jest.fn(),
+    all: jest.fn(),
+    exec: jest.fn(),
+    transaction: jest.fn(),
+    close: jest.fn(),
+  } as unknown as IDatabase;
+  const repo = new MemoryRepository(
+    () => db,
+    () => opts.connected ?? true,
+    () => opts.postgres ?? false
+  );
+  return { repo, run };
+}
+
+describe('MemoryRepository.updateMemory', () => {
+  it('writes only the supplied fields and returns true when a row changed', async () => {
+    const { repo, run } = makeRepo(async () => ({ changes: 1 }));
+
+    const ok = await repo.updateMemory('7', {
+      content: 'updated',
+      metadata: { foo: 'bar' },
+      embedding: [0.1, 0.2],
+    });
+
+    expect(ok).toBe(true);
+    expect(run).toHaveBeenCalledTimes(1);
+    const [sql, params] = run.mock.calls[0];
+    expect(sql).toBe('UPDATE memories SET content = ?, metadata = ?, embedding = ? WHERE id = ?');
+    // SQLite encodes the embedding as a JSON string; id is the final param.
+    expect(params).toEqual(['updated', JSON.stringify({ foo: 'bar' }), '[0.1,0.2]', '7']);
+  });
+
+  it('encodes the embedding as a pgvector literal on Postgres', async () => {
+    const { repo, run } = makeRepo(async () => ({ changes: 1 }), { postgres: true });
+
+    await repo.updateMemory(3, { embedding: [1, 2, 3] });
+
+    const [sql, params] = run.mock.calls[0];
+    expect(sql).toBe('UPDATE memories SET embedding = ?::vector WHERE id = ?');
+    expect(params).toEqual(['[1,2,3]', 3]);
+  });
+
+  it('updates content alone without clobbering metadata or embedding', async () => {
+    const { repo, run } = makeRepo(async () => ({ changes: 1 }));
+
+    await repo.updateMemory('9', { content: 'just text' });
+
+    const [sql, params] = run.mock.calls[0];
+    expect(sql).toBe('UPDATE memories SET content = ? WHERE id = ?');
+    expect(params).toEqual(['just text', '9']);
+  });
+
+  it('returns false (no query) when no updatable field is supplied', async () => {
+    const { repo, run } = makeRepo(async () => ({ changes: 1 }));
+    expect(await repo.updateMemory('1', {})).toBe(false);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('returns false when no row matched the id', async () => {
+    const { repo } = makeRepo(async () => ({ changes: 0 }));
+    expect(await repo.updateMemory('missing', { content: 'x' })).toBe(false);
+  });
+
+  it('returns false and does not query when not connected', async () => {
+    const { repo, run } = makeRepo(async () => ({ changes: 1 }), { connected: false });
+    expect(await repo.updateMemory('1', { content: 'x' })).toBe(false);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('propagates the error when the underlying query throws', async () => {
+    const { repo } = makeRepo(async () => {
+      throw new Error('db boom');
+    });
+    await expect(repo.updateMemory('1', { content: 'x' })).rejects.toThrow('db boom');
+  });
+});


### PR DESCRIPTION
## What

`PostgresMemoryProvider.updateMemory` was the **last incomplete piece** of the memory subsystem — it threw `Error('Update memory not implemented in PostgresMemoryProvider')`. The other three backends (mem0, mem4ai, memvault) already implement update fully.

## Changes
- **`MemoryRepository.updateMemory(id, {content?, metadata?, embedding?})`** — partial in-place `UPDATE` that preserves `id`/`created_at`, writes only supplied fields, and encodes the embedding per dialect (`?::vector` for Postgres, JSON for SQLite). No-op (returns false) when nothing to update or no row matches.
- **`DatabaseManager.updateMemory`** — thin delegation to the repository.
- **`PostgresMemoryProvider.updateMemory`** — re-embeds the new content (keeping semantic search consistent with the edited text), updates the row, and returns the refreshed entry; throws a clear `memory <id> not found` on a missing id.

## Tests
- `MemoryRepository.update.test.ts` — 7 cases (field selection, pgvector vs JSON encoding, content-only update, empty-fields no-op, no-match, not-connected, error propagation).
- `PostgresMemoryProvider.test.ts` — +2 (re-embed + fresh-row return; not-found throws).

Verified locally: `tsc --noEmit` clean; full memory suite 133 passing / 10 suites.