### PR TITLE
feat(memory): add WebUI config schemas for MemVault & Postgres backends

### DIFF
--- a/src/client/src/provider-configs/__tests__/memory-schemas.test.ts
+++ b/src/client/src/provider-configs/__tests__/memory-schemas.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { getProviderSchemasByType, getProviderSchema } from '../index';
+
+/**
+ * Guards that the WebUI exposes a config schema for every memory backend that
+ * ships as a packages/memory-* workspace package. The backend auto-discovers
+ * these packages at runtime; the UI must keep parity so each is configurable.
+ */
+describe('memory provider config schemas', () => {
+  const EXPECTED_BACKENDS = ['mem0', 'mem4ai', 'memvault', 'postgres'];
+
+  it('exposes a schema for all four memory backends', () => {
+    const memorySchemas = getProviderSchemasByType('memory');
+    const providerTypes = memorySchemas.map((s) => s.providerType).sort();
+    expect(providerTypes).toEqual([...EXPECTED_BACKENDS].sort());
+  });
+
+  it.each(EXPECTED_BACKENDS)('schema "%s" is well-formed and typed as memory', (providerType) => {
+    const schema = getProviderSchema(providerType);
+    expect(schema).toBeDefined();
+    expect(schema!.type).toBe('memory');
+    expect(schema!.providerType).toBe(providerType);
+    expect(schema!.displayName).toBeTruthy();
+    expect(schema!.description).toBeTruthy();
+    expect(Array.isArray(schema!.fields)).toBe(true);
+  });
+
+  it('every memory field declares a name, label, and supported type', () => {
+    const allowedTypes = new Set([
+      'text',
+      'password',
+      'number',
+      'url',
+      'json',
+      'select',
+      'multiselect',
+      'boolean',
+      'textarea',
+      'model-autocomplete',
+      'keyvalue',
+      'checkbox',
+    ]);
+    for (const schema of getProviderSchemasByType('memory')) {
+      for (const field of schema.fields) {
+        expect(field.name, `${schema.providerType} field name`).toBeTruthy();
+        expect(field.label, `${schema.providerType}.${field.name} label`).toBeTruthy();
+        expect(allowedTypes.has(field.type), `${schema.providerType}.${field.name} type`).toBe(true);
+      }
+    }
+  });
+});

--- a/src/client/src/provider-configs/index.ts
+++ b/src/client/src/provider-configs/index.ts
@@ -16,6 +16,8 @@ import { openWebUiProviderSchema } from './schemas/openwebui';
 import { lettaProviderSchema } from './schemas/letta';
 import { mem0ProviderSchema } from './schemas/mem0';
 import { mem4aiProviderSchema } from './schemas/mem4ai';
+import { memvaultProviderSchema } from './schemas/memvault';
+import { postgresMemoryProviderSchema } from './schemas/postgres';
 import { mcpToolsSchema } from './schemas/mcp-tools';
 import { customToolsSchema } from './schemas/custom-tools';
 
@@ -43,6 +45,8 @@ export const PROVIDER_SCHEMAS: Record<string, ProviderConfigSchema> = {
   // Memory providers
   mem0: mem0ProviderSchema,
   mem4ai: mem4aiProviderSchema,
+  memvault: memvaultProviderSchema,
+  postgres: postgresMemoryProviderSchema,
 };
 
 // Helper functions for working with provider schemas

--- a/src/client/src/provider-configs/schemas/memvault.ts
+++ b/src/client/src/provider-configs/schemas/memvault.ts
@@ -1,0 +1,72 @@
+import type { ProviderConfigSchema } from '../types';
+
+/**
+ * UI config schema for the MemVault memory backend
+ * (packages/memory-memvault). MemVault is a native, in-process RAG store that
+ * ranks recall with a hybrid score (vector similarity + recency decay) and
+ * needs no external infrastructure — so every field is optional and the
+ * defaults mirror MemVaultConfig in the package.
+ */
+export const memvaultProviderSchema: ProviderConfigSchema = {
+    type: 'memory',
+    providerType: 'memvault',
+    displayName: 'MemVault',
+    description:
+        'Native in-process RAG memory with hybrid scoring (vector similarity + recency decay). No external infrastructure required.',
+    icon: '🗄️',
+    color: '#8E44AD',
+    defaultConfig: {
+        vectorWeight: 0.8,
+        recencyWeight: 0.2,
+        defaultLimit: 10,
+    },
+    fields: [
+        {
+            name: 'embeddingProfile',
+            label: 'Embedding Provider',
+            type: 'text',
+            required: false,
+            description:
+                'Name of the LLM provider used to generate embeddings. Leave blank to auto-select the first embedding-capable provider.',
+            placeholder: 'openai',
+            group: 'Model',
+        },
+        {
+            name: 'vectorWeight',
+            label: 'Vector Weight',
+            type: 'number',
+            required: false,
+            description: 'Weight applied to vector similarity in the hybrid score (0–1).',
+            defaultValue: 0.8,
+            group: 'Scoring',
+        },
+        {
+            name: 'recencyWeight',
+            label: 'Recency Weight',
+            type: 'number',
+            required: false,
+            description: 'Weight applied to the recency-decay term in the hybrid score (0–1).',
+            defaultValue: 0.2,
+            group: 'Scoring',
+        },
+        {
+            name: 'recencyHalfLifeMs',
+            label: 'Recency Half-Life (ms)',
+            type: 'number',
+            required: false,
+            description:
+                'Half-life of the recency-decay term, in milliseconds. Default is 7 days (604800000).',
+            placeholder: '604800000',
+            group: 'Scoring',
+        },
+        {
+            name: 'defaultLimit',
+            label: 'Default Result Limit',
+            type: 'number',
+            required: false,
+            description: 'Number of results returned by searches that omit an explicit limit.',
+            defaultValue: 10,
+            group: 'Advanced',
+        },
+    ],
+};

--- a/src/client/src/provider-configs/schemas/postgres.ts
+++ b/src/client/src/provider-configs/schemas/postgres.ts
@@ -1,0 +1,31 @@
+import type { ProviderConfigSchema } from '../types';
+
+/**
+ * UI config schema for the Postgres (pgvector) memory backend
+ * (packages/memory-postgres). It stores embeddings in the application's
+ * configured Postgres database, so connection details come from the server's
+ * DATABASE_* configuration rather than this form — the only per-profile option
+ * is which LLM provider generates the embeddings.
+ */
+export const postgresMemoryProviderSchema: ProviderConfigSchema = {
+    type: 'memory',
+    providerType: 'postgres',
+    displayName: 'Postgres (pgvector)',
+    description:
+        'Durable vector memory backed by your Postgres database via pgvector. Uses the server DATABASE_* connection; choose which provider generates embeddings.',
+    icon: '🐘',
+    color: '#336791',
+    defaultConfig: {},
+    fields: [
+        {
+            name: 'embeddingProfile',
+            label: 'Embedding Provider',
+            type: 'text',
+            required: false,
+            description:
+                'Name of the LLM provider used to generate embeddings. Must implement generateEmbedding (e.g. OpenAI or OpenWebUI/Ollama). Leave blank to auto-select the first embedding-capable provider.',
+            placeholder: 'openai',
+            group: 'Model',
+        },
+    ],
+};


### PR DESCRIPTION
## What

Closes a UI/backend parity gap surfaced by the memory subsystem sweep.

The server auto-discovers every `packages/memory-*` workspace package at startup (`initProviders.ts`), so all four memory backends — **mem0, mem4ai, MemVault, Postgres** — are fully functional at runtime. But the WebUI's provider-config registry only shipped schemas for `mem0` and `mem4ai`, so **MemVault and Postgres (pgvector) could not be configured from the UI** even though both fully implement `IMemoryProvider`.

## Changes
- `schemas/memvault.ts` — `embeddingProfile` + hybrid-scoring knobs (`vectorWeight`, `recencyWeight`, `recencyHalfLifeMs`, `defaultLimit`), mirroring `MemVaultConfig` defaults.
- `schemas/postgres.ts` — `embeddingProfile` (DB connection comes from the server's `DATABASE_*` config).
- Register both in `PROVIDER_SCHEMAS`. Each `providerType` matches the provider's `id` field (`'memvault'`/`'postgres'`), which the backend maps to the `memory-<name>` package.

## Sweep result
The rest of the memory subsystem audited clean: all 4 backends implement the full 8-method `IMemoryProvider` contract, no stubs/TODOs remain (Postgres `updateMemory` was the last one, fixed in #2960), and the pipeline `MemoryStorer`/`MemoryRetriever` adapters are complete and wired to `MemoryManager`.

## Tests
`memory-schemas.test.ts` (6) — asserts `getProviderSchemasByType('memory')` returns all four backends and every field is well-formed. `tsc` (client) clean.