### PR TITLE
chore: remove stray update.bat redeploy script

### DIFF
--- a/update.bat
+++ b/update.bat
@@ -1,7 +1,0 @@
-timeout /t 3800 /nobreak
-git pull
-docker-compose down
-docker rmi discord-llm-bot --force
-docker-compose build
-docker-compose up -d
-docker-compose logs -f


### PR DESCRIPTION
## Summary

Removes `update.bat`, an unreferenced Docker redeploy helper script at the repo root.

The script just chains `git pull` + `docker-compose` down/rebuild/up after a 3800s timeout — a manual ops convenience that isn't part of the project's workflow.

## Verification

Confirmed it is unused before removal:
- `git grep -i update.bat` across all tracked files → **no matches**
- Not referenced by any `package.json` script
- Not invoked by any CI workflow (`.github/`)
- Not mentioned in any documentation

No code paths depend on it; this is a pure dead-cruft deletion.