### PR TITLE
fix(memory): expose mem4ai maxRetries in WebUI schema

### DIFF
--- a/src/client/src/provider-configs/__tests__/memory-schemas.test.ts
+++ b/src/client/src/provider-configs/__tests__/memory-schemas.test.ts
@@ -36,6 +36,12 @@ describe('memory provider config schemas', () => {
     }
   });
 
+  it('mem4ai exposes maxRetries (consumed by its retry loop)', () => {
+    const mem4ai = getProviderSchema('mem4ai')!;
+    const fieldNames = mem4ai.fields.map((f) => f.name);
+    expect(fieldNames).toContain('maxRetries');
+  });
+
   it('every memory field declares a name, label, and supported type', () => {
     const allowedTypes = new Set([
       'text',

--- a/src/client/src/provider-configs/schemas/mem4ai.ts
+++ b/src/client/src/provider-configs/schemas/mem4ai.ts
@@ -85,5 +85,14 @@ export const mem4aiProviderSchema: ProviderConfigSchema = {
             placeholder: '30000',
             group: 'Advanced',
         },
+        {
+            name: 'maxRetries',
+            label: 'Max Retries',
+            type: 'number',
+            required: false,
+            description: 'Maximum number of retries on transient (429 / 5xx) errors before failing',
+            defaultValue: 3,
+            group: 'Advanced',
+        },
     ],
 };


### PR DESCRIPTION
Companion to #2965. The frontend `mem4ai` provider-config schema had dropped `maxRetries`, which `Mem4aiProvider` reads (`config.maxRetries`, drives its 429/5xx retry loop) and which the backend's canonical `schema.ts` already lists — so it wasn't configurable from the WebUI Memory Providers page. Added it to the Advanced group + a regression test. `tsc` clean; memory-schemas 8/8. (Nested `circuitBreaker` config is intentionally left out — absent from both schemas, sensible defaults.)