### PR TITLE
fix(security): use trusted client IP for audit logs (prevent X-Forwarded-For spoofing)

### DIFF
--- a/src/server/middleware/audit.ts
+++ b/src/server/middleware/audit.ts
@@ -2,6 +2,7 @@ import Debug from 'debug';
 import { type NextFunction, type Response } from 'express';
 import type { AuthMiddlewareRequest } from '../../auth/types';
 import { AuditLogger } from '../../common/auditLogger';
+import { getClientIP } from './security';
 
 const debug = Debug('app:auditMiddleware');
 
@@ -25,18 +26,11 @@ export const auditMiddleware = (req: AuditedRequest, res: Response, next: NextFu
       user = userObj.username || userObj.email || userObj.id || 'authenticated-user';
     }
 
-    // Extract IP address
-    const reqWithConnection = req as AuditedRequest & {
-      connection?: { remoteAddress?: string };
-      socket?: { remoteAddress?: string };
-    };
-    const ipAddress =
-      req.ip ||
-      reqWithConnection.connection?.remoteAddress ||
-      reqWithConnection.socket?.remoteAddress ||
-      (req.headers['x-forwarded-for'] as string) ||
-      (req.headers['x-real-ip'] as string) ||
-      'unknown';
+    // Extract IP address securely. getClientIP only honours X-Forwarded-For /
+    // X-Real-IP when the direct connection comes from a trusted proxy; otherwise
+    // it uses the real socket address. Trusting those headers directly (as this
+    // did before) lets any client spoof the IP recorded in the audit trail.
+    const ipAddress = getClientIP(req as never) || 'unknown';
 
     // Extract user agent
     const userAgent = (req.headers['user-agent'] as string) || 'unknown';

--- a/src/server/middleware/auditLogger.ts
+++ b/src/server/middleware/auditLogger.ts
@@ -1,6 +1,7 @@
 import { type NextFunction, type Request, type Response } from 'express';
 import { type AuthMiddlewareRequest } from '@src/auth/types';
 import { Logger } from '@src/common/logger';
+import { getClientIP } from './security';
 
 interface ResponseWithAuditFlag extends Response {
   _auditLogged?: boolean;
@@ -324,11 +325,7 @@ export const auditMiddleware = (
             (req as AuthMiddlewareRequest).user?.id ||
             (req as AuthMiddlewareRequest).user?.username ||
             'anonymous',
-          ip:
-            req.ip ||
-            req.connection?.remoteAddress ||
-            (req.headers['x-forwarded-for'] as string) ||
-            'unknown',
+          ip: getClientIP(req) || 'unknown',
           userAgent: req.get('user-agent') || 'unknown',
           status: res.statusCode < 400 ? 'success' : 'failure',
           errorMessage:
@@ -382,11 +379,7 @@ export const auditMiddlewareWithChanges = (
             (req as AuthMiddlewareRequest).user?.id ||
             (req as AuthMiddlewareRequest).user?.username ||
             'anonymous',
-          ip:
-            req.ip ||
-            req.connection?.remoteAddress ||
-            (req.headers['x-forwarded-for'] as string) ||
-            'unknown',
+          ip: getClientIP(req) || 'unknown',
           userAgent: req.get('user-agent') || 'unknown',
           before: beforeValue,
           after:
@@ -434,11 +427,7 @@ export const logAuditEvent = (
       (req as AuthMiddlewareRequest).user?.id ||
       (req as AuthMiddlewareRequest).user?.username ||
       'anonymous',
-    ip:
-      req.ip ||
-      req.connection?.remoteAddress ||
-      (req.headers['x-forwarded-for'] as string) ||
-      'unknown',
+    ip: getClientIP(req) || 'unknown',
     userAgent: req.get('user-agent') || 'unknown',
     before: options.before,
     after: options.after,

--- a/tests/unit/server/middleware/audit.test.ts
+++ b/tests/unit/server/middleware/audit.test.ts
@@ -44,4 +44,24 @@ describe('auditMiddleware', () => {
     expect(emptyReq.auditIp).toBe('unknown');
     expect(emptyReq.auditUserAgent).toBe('unknown');
   });
+
+  it('does not let a spoofed X-Forwarded-For header override the real client IP', () => {
+    // Direct connection from a public (non-trusted-proxy) address, with an
+    // attacker-supplied X-Forwarded-For. The audit IP must be the real socket
+    // address, NOT the spoofed header — otherwise audit trails are forgeable.
+    const spoofReq: Partial<AuditedRequest> = {
+      headers: {
+        'user-agent': 'attacker-agent',
+        'x-forwarded-for': '1.2.3.4',
+        'x-real-ip': '5.6.7.8',
+      },
+      socket: { remoteAddress: '203.0.113.5' } as never,
+    };
+
+    auditMiddleware(spoofReq as AuditedRequest, res as Response, next);
+
+    expect(spoofReq.auditIp).toBe('203.0.113.5');
+    expect(spoofReq.auditIp).not.toBe('1.2.3.4');
+    expect(spoofReq.auditIp).not.toBe('5.6.7.8');
+  });
 });


### PR DESCRIPTION
## Vulnerability

The audit middleware (`audit.ts`) and `auditLogger.ts` recorded the client IP by falling back **directly** to `req.headers['x-forwarded-for']` / `['x-real-ip']`. Both are fully client-controlled, so any caller could set them to **forge the IP written to the audit trail** — defeating its forensic/security value.

## Fix

Route IP extraction through the existing `getClientIP()` (security middleware → `getClientKey`), which only honours `X-Forwarded-For` when the **direct connection is a trusted proxy**, and otherwise uses the real socket address.

- `audit.ts` — `auditMiddleware` IP extraction
- `auditLogger.ts` — all three log paths (config / bot / admin actions)

## Test

Added a regression test: a spoofed `X-Forwarded-For`/`X-Real-IP` from a non-proxy connection now records the real socket address (`203.0.113.5`), not the header.

`tsc` clean; audit suites 26/26 (25 existing + 1 new).

## Provenance

This is the **salvaged kernel** of #2971, which was a month-stale full-codebase revert (685 files / −29k lines) and was closed. Re-implemented cleanly as a 3-file change on current `main`.