### PR TITLE
🛡️ Sentinel: [HIGH] Fix argument injection in PluginManager git clone

### DIFF
--- a/src/plugins/PluginManager.ts
+++ b/src/plugins/PluginManager.ts
@@ -253,7 +253,7 @@ export async function installPlugin(repoUrl: string): Promise<PluginInfo> {
 
   try {
     debug('Cloning %s → %s', repoUrl, tempPath);
-    exec('git', ['clone', '--depth', '1', repoUrl, tempPath], PLUGINS_DIR);
+    exec('git', ['clone', '--depth', '1', '--', repoUrl, tempPath], PLUGINS_DIR);
 
     const name = await deriveNameFromPath(tempPath);
     const pluginPath = path.join(PLUGINS_DIR, name);


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Argument injection vulnerability in PluginManager when cloning plugins. The `repoUrl` could be crafted to begin with a dash (`-`), potentially bypassing validation through URL encoding or whitespace, and being interpreted as a command-line flag by `git clone` instead of a URL.
🎯 Impact: Could allow an attacker to inject arbitrary git flags, which can lead to command execution depending on the flags (e.g. `--upload-pack`).
🔧 Fix: Add the `--` end-of-options marker before the `repoUrl` argument to `git clone` to enforce that subsequent arguments are treated as paths/URLs, not flags.
✅ Verification: Tested locally by verifying the `--` correctly terminates options in `execFileSync('git', ['clone', '--depth', '1', '--', repoUrl, tempPath])`.

---
*PR created automatically by Jules for task [11636679653632617878](https://jules.google.com/task/11636679653632617878) started by @matthewhand*