### PR TITLE
fix(client): correct Logger references that would throw ReferenceError

### DIFF
--- a/src/client/src/components/DaisyUI/StepWizard.tsx
+++ b/src/client/src/components/DaisyUI/StepWizard.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import Input from './Input';
 import Checkbox from './Checkbox';
+import logger from '../../utils/logger';
 
 export interface Step {
   id: string;
@@ -53,7 +54,7 @@ const StepWizard: React.FC<StepWizardProps> = ({
       const isValid = await currentStepData.validation();
       return isValid;
     } catch (error) {
-      Logger.error('Step validation failed:', error);
+      logger.error('Step validation failed:', error);
       return false;
     } finally {
       setIsValidating(false);

--- a/src/client/src/components/IntegrationLoader.tsx
+++ b/src/client/src/components/IntegrationLoader.tsx
@@ -73,7 +73,7 @@ export class IntegrationLoader {
         try {
           return await this.loadIntegrationComponents(integrationId);
         } catch (error) {
-          Logger.warn(`Failed to load components for integration ${integrationId}:`, error);
+          logger.warn(`Failed to load components for integration ${integrationId}:`, error);
           return [];
         }
       });
@@ -132,7 +132,7 @@ export class IntegrationLoader {
                 icon: componentInfo.icon,
               };
             } catch (componentError) {
-              Logger.warn(
+              logger.warn(
                 `Failed to load component ${componentId} for integration ${integrationId}:`,
                 componentError,
               );


### PR DESCRIPTION
Two frontend components reference an undefined `Logger` symbol, throwing `ReferenceError: Logger is not defined` the instant their error path executes:

- **`IntegrationLoader.tsx`** imports `logger` (lowercase) but calls `Logger.warn(...)` in two catch blocks (integration-load and component-load failures).
- **`StepWizard.tsx`** calls `Logger.error(...)` in its validation catch with **no logger imported at all**.

Because these fire only on already-failing paths, the crash *replaced* the real error with a less useful one. Fixed both to the lowercase `logger` (StepWizard gets the missing import). Verified: no remaining capital-`Logger` refs in `src/client/src`; client `tsc` clean.

Found via a codebase audit sweep.