### PR TITLE
fix(security): repair SSRF guard bypass (5 sites) + count invalid TOTP toward lockout

### DIFF
--- a/src/auth/AuthManager.ts
+++ b/src/auth/AuthManager.ts
@@ -400,6 +400,10 @@ export class AuthManager {
         throw new AuthenticationError('Two-factor authentication code required', 'TOTP_REQUIRED');
       }
       if (!verifyTotpToken(credentials.totpCode, user.twoFactorSecret)) {
+        // Count an invalid second factor toward account lockout, otherwise the
+        // 6-digit TOTP space could be brute-forced past an already-verified
+        // password without ever tripping the lockout that guards password tries.
+        this.loginAttempts.recordFailure(lockoutKey);
         throw new AuthenticationError('Invalid two-factor code', 'INVALID_TOTP');
       }
     }

--- a/src/providers/MattermostProvider.ts
+++ b/src/providers/MattermostProvider.ts
@@ -373,7 +373,7 @@ export class MattermostProvider implements IMessageProvider<MattermostConfig> {
             const startTime = Date.now();
 
             const targetUrl = `${serverUrl}/api/v4/users/me`;
-            if (!(await isSafeUrl(targetUrl))) {
+            if (!(await isSafeUrl(targetUrl)).safe) {
               return {
                 name,
                 connected: false,

--- a/src/server/routes/admin/llmProviders.ts
+++ b/src/server/routes/admin/llmProviders.ts
@@ -340,7 +340,7 @@ router.post(
             if (config.baseUrl) {
               try {
                 new URL(config.baseUrl);
-                if (!(await isSafeUrl(config.baseUrl))) {
+                if (!(await isSafeUrl(config.baseUrl)).safe) {
                   testResult = {
                     success: false,
                     message: 'Base URL is blocked for security reasons',
@@ -379,7 +379,7 @@ router.post(
 
             try {
               new URL(config.baseUrl);
-              if (!(await isSafeUrl(config.baseUrl))) {
+              if (!(await isSafeUrl(config.baseUrl)).safe) {
                 testResult = {
                   success: false,
                   message: 'Base URL is blocked for security reasons',
@@ -417,7 +417,7 @@ router.post(
             if (config.baseUrl) {
               try {
                 new URL(config.baseUrl);
-                if (!(await isSafeUrl(config.baseUrl))) {
+                if (!(await isSafeUrl(config.baseUrl)).safe) {
                   testResult = {
                     success: false,
                     message: 'Base URL is blocked for security reasons',

--- a/src/server/routes/letta.ts
+++ b/src/server/routes/letta.ts
@@ -85,7 +85,7 @@ async function validateLettaUrl(url: string): Promise<{ isValid: boolean; error?
     }
 
     // 4. For non-local URLs also run full isSafeUrl check
-    if (!allowLocal && !(await isSafeUrl(url))) {
+    if (!allowLocal && !(await isSafeUrl(url)).safe) {
       return {
         isValid: false,
         error: 'Target URL is blocked for security reasons (private/local network access).',

--- a/tests/unit/auth/AuthManager.lockout.test.ts
+++ b/tests/unit/auth/AuthManager.lockout.test.ts
@@ -7,6 +7,7 @@
  * `test-hash-for-*` hashes) so we control the valid password precisely.
  */
 import { AuthManager } from '../../../src/auth/AuthManager';
+import { generateToken } from '../../../src/auth/TotpService';
 import { AuthenticationError } from '../../../src/types/errorClasses';
 
 type AuthManagerCtor = {
@@ -106,6 +107,36 @@ describe('AuthManager account lockout', () => {
     await expect(mgr.login({ username: 'carol', password: 'x' })).rejects.toBeTruthy();
     await expect(mgr.login({ username: 'carol', password: 'x' })).rejects.toBeTruthy();
     expect(mgr.isLockedOut('carol')).toBe(false);
+  });
+
+  it('counts an invalid TOTP code toward account lockout', async () => {
+    const mgr = makeManager({
+      AUTH_MAX_LOGIN_ATTEMPTS: '3',
+      AUTH_LOCKOUT_DURATION_SECONDS: '900',
+    });
+    const user = await mgr.register({
+      username: 'frank',
+      email: 'frank@example.com',
+      password: PASSWORD,
+    });
+
+    // Enrol and enable 2FA for frank.
+    const { secret } = mgr.startTwoFactorEnrollment(user.id)!;
+    expect(mgr.confirmTwoFactorEnrollment(user.id, generateToken(secret))).toBe(true);
+
+    // A code that is definitely NOT the current valid token.
+    const valid = generateToken(secret);
+    const wrongCode = valid === '000000' ? '111111' : '000000';
+
+    // Correct password but wrong second factor, repeated to the threshold,
+    // must lock the account — otherwise TOTP is brute-forceable.
+    for (let i = 0; i < 3; i++) {
+      await expect(
+        mgr.login({ username: 'frank', password: PASSWORD, totpCode: wrongCode })
+      ).rejects.toBeInstanceOf(AuthenticationError);
+    }
+
+    expect(mgr.isLockedOut('frank')).toBe(true);
   });
 
   it('auto-unlocks once the lockout duration elapses', async () => {


### PR DESCRIPTION
Two security bugs surfaced by a codebase audit sweep.

## 1. SSRF guard bypass (5 call sites)
`isSafeUrl()` returns a `SafeUrlResult` **object** (`{ safe: boolean }`), but five sites negated the object directly:

```ts
if (!(await isSafeUrl(url))) { /* unreachable: object is always truthy */ }
```

`!object` is always `false`, so the guard **never triggered** and private/internal/loopback URLs were allowed through:
- `providers/MattermostProvider.ts:376`
- `server/routes/admin/llmProviders.ts:343, 382, 420`
- `server/routes/letta.ts:88`

Fixed to `!(await isSafeUrl(url)).safe`. (The audit flagged only the Mattermost one; a follow-up scan found the other four. Sites that assign `const check = await isSafeUrl(...)` already used `.safe` correctly.)

## 2. TOTP not counted toward lockout
`AuthManager.login` called `recordFailure(lockoutKey)` on a bad password but **not** on an invalid TOTP code. With a verified password, the 6-digit second factor could be brute-forced without ever tripping the account lockout. Now records a failure on `INVALID_TOTP`.

## Tests
New regression test: correct password + repeated wrong TOTP locks the account. `tsc` clean; auth / mattermost / letta / llmProviders suites green (74).