### PR TITLE
fix: await async persona storage writes; remove duplicate password check

### DIFF
--- a/src/server/routes/admin/users.ts
+++ b/src/server/routes/admin/users.ts
@@ -79,12 +79,12 @@ router.get('/personas', async (req: Request, res: Response) => {
  *       200:
  *         description: Created persona
  */
-router.post('/personas', validateRequest(PersonaSchema), (req: Request, res: Response) => {
+router.post('/personas', validateRequest(PersonaSchema), async (req: Request, res: Response) => {
   try {
     const { key, name, systemPrompt } = req.body;
 
     // Save to persistent storage
-    webUIStorage.savePersona({ key, name, systemPrompt });
+    await webUIStorage.savePersona({ key, name, systemPrompt });
 
     return res.json(ApiResponse.success());
   } catch (error: unknown) {
@@ -99,13 +99,13 @@ router.post('/personas', validateRequest(PersonaSchema), (req: Request, res: Res
 router.put(
   '/personas/:key',
   validateRequest(UpdatePersonaSchema),
-  (req: Request, res: Response) => {
+  async (req: Request, res: Response) => {
     try {
       const { key } = req.params;
       const { name, systemPrompt } = req.body;
 
       // Save to persistent storage
-      webUIStorage.savePersona({ key, name, systemPrompt });
+      await webUIStorage.savePersona({ key, name, systemPrompt });
 
       return res.json(ApiResponse.success());
     } catch (error: unknown) {
@@ -121,12 +121,12 @@ router.put(
 router.delete(
   '/personas/:key',
   validateRequest(PersonaKeyParamSchema),
-  (req: Request, res: Response) => {
+  async (req: Request, res: Response) => {
     try {
       const { key } = req.params;
 
       // Delete from persistent storage
-      webUIStorage.deletePersona(key);
+      await webUIStorage.deletePersona(key);
 
       return res.json(ApiResponse.success());
     } catch (error: unknown) {

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -479,9 +479,6 @@ router.post(
       if (!isPasswordValid) {
         return res.status(HTTP_STATUS.UNAUTHORIZED).json(ApiResponse.error('Invalid old password'));
       }
-      if (!isPasswordValid) {
-        return res.status(HTTP_STATUS.UNAUTHORIZED).json(ApiResponse.error('Invalid old password'));
-      }
 
       const success = await authManager.changePassword(authReq.user.id, newPassword);
       if (success) {


### PR DESCRIPTION
Two correctness bugs from the audit sweep.

## 1. Missing `await` on async persona writes (`admin/users.ts`)
The `POST` / `PUT` / `DELETE` `/personas` handlers called the **async** `webUIStorage.savePersona` / `deletePersona` **without `await`** in non-async handlers:

```ts
router.post('/personas', ..., (req, res) => {
  try {
    webUIStorage.savePersona({ key, name, systemPrompt }); // not awaited
    return res.json(ApiResponse.success());                // returns before write completes
  } catch { ... }  // cannot catch the rejected promise
});
```

Consequences: a write failure became an **unhandled promise rejection** (the surrounding try/catch never saw it), and the handler returned **success before the write finished** — so a failed save reported success. Made the three handlers `async` and `await` the writes.

## 2. Duplicate dead check (`auth.ts`)
The change-password handler had two identical back-to-back `if (!isPasswordValid) return 401` blocks; the second was unreachable. Removed it.

tsc clean; users/auth route suites green (85).