### PR TITLE
fix(config): pass env to getDecryptedMainConfigSync in ConfigStore

### DIFF
--- a/src/config/ConfigStore.ts
+++ b/src/config/ConfigStore.ts
@@ -65,7 +65,7 @@ export class ConfigStore {
        
       const scm = (SecureConfigManager as any).getInstanceSync?.();
       if (scm && typeof scm.getDecryptedMainConfigSync === 'function') {
-        const decrypted = scm.getDecryptedMainConfigSync();
+        const decrypted = scm.getDecryptedMainConfigSync(process.env.NODE_ENV || 'default');
         if (decrypted && typeof decrypted === 'object' && key in decrypted) {
           return decrypted[key] as T;
         }
@@ -216,7 +216,7 @@ export class ConfigStore {
        
       const scm = (SecureConfigManager as any).getInstanceSync?.();
       if (scm && typeof scm.getDecryptedMainConfigSync === 'function') {
-        const decrypted = scm.getDecryptedMainConfigSync();
+        const decrypted = scm.getDecryptedMainConfigSync(process.env.NODE_ENV || 'default');
         if (decrypted && typeof decrypted === 'object' && key in decrypted) return 'secure';
       }
     } catch { /* not available */ }


### PR DESCRIPTION
`ConfigStore` called `scm.getDecryptedMainConfigSync()` with **no argument** at both lookup sites (lines 68, 219). The method requires `env: string` and builds its path as `${env}.json.enc`:

```ts
const configPath = PathSecurityUtils.getSafePath(this.mainConfigDir, `${env}.json.enc`);
```

With `env` undefined it looked for `undefined.json.enc`, which never exists, so the **encrypted main config was silently never loaded** through `ConfigStore` — every secure-config lookup missed and fell through to other sources.

Fixed to pass `process.env.NODE_ENV || 'default'`, matching the canonical call in `ConfigurationManager.ts:89` and the async `ConfigExporter` / `ConfigurationImportExportService` paths. `tsc` clean.