### PR TITLE
fix(db): emit Postgres-compatible upsert instead of INSERT OR REPLACE

### DIFF
--- a/src/database/DatabaseManager.ts
+++ b/src/database/DatabaseManager.ts
@@ -259,9 +259,9 @@ export class DatabaseManager {
     const ensure = (): void => this.ensureConnected();
     const isPg = (): boolean => this.config?.type === 'postgres';
 
-    this.messageRepo = new MessageRepository(getDb, isConn, ensure);
+    this.messageRepo = new MessageRepository(getDb, isConn, ensure, isPg);
     this.botConfigRepo = new BotConfigRepository(getDb, ensure);
-    this.anomalyRepo = new AnomalyRepository(getDb, isConn);
+    this.anomalyRepo = new AnomalyRepository(getDb, isConn, isPg);
     this.approvalRepo = new ApprovalRepository(getDb, ensure);
     this.auditEventRepo = new AuditEventRepository(getDb, isConn);
     this.aiFeedbackRepo = new AIFeedbackRepository(getDb, ensure);

--- a/src/database/repositories/AnomalyRepository.ts
+++ b/src/database/repositories/AnomalyRepository.ts
@@ -9,7 +9,8 @@ const debug = Debug('app:AnomalyRepository');
 export class AnomalyRepository {
   constructor(
     private getDb: () => Database | null,
-    private isConnected: () => boolean
+    private isConnected: () => boolean,
+    private isPostgres: () => boolean = () => false
   ) {}
 
   async storeAnomaly(anomaly: Anomaly): Promise<void> {
@@ -20,13 +21,31 @@ export class AnomalyRepository {
     }
 
     try {
-      await db.run(
-        `
+      // SQLite supports `INSERT OR REPLACE`; Postgres does not, so emit an
+      // equivalent `ON CONFLICT (id) DO UPDATE` upsert there. Without this the
+      // statement is a Postgres syntax error and the anomaly is silently lost.
+      const sql = this.isPostgres()
+        ? `
+        INSERT INTO anomalies (
+          id, timestamp, metric, value, expectedMean, standardDeviation,
+          zScore, threshold, severity, explanation, resolved, tenantId
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT (id) DO UPDATE SET
+          timestamp = EXCLUDED.timestamp, metric = EXCLUDED.metric,
+          value = EXCLUDED.value, expectedMean = EXCLUDED.expectedMean,
+          standardDeviation = EXCLUDED.standardDeviation, zScore = EXCLUDED.zScore,
+          threshold = EXCLUDED.threshold, severity = EXCLUDED.severity,
+          explanation = EXCLUDED.explanation, resolved = EXCLUDED.resolved,
+          tenantId = EXCLUDED.tenantId
+      `
+        : `
         INSERT OR REPLACE INTO anomalies (
           id, timestamp, metric, value, expectedMean, standardDeviation,
           zScore, threshold, severity, explanation, resolved, tenantId
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `,
+      `;
+      await db.run(
+        sql,
         [
           anomaly.id,
           anomaly.timestamp,

--- a/src/database/repositories/MessageRepository.ts
+++ b/src/database/repositories/MessageRepository.ts
@@ -17,7 +17,8 @@ export class MessageRepository {
   constructor(
     private getDb: () => Database | null,
     private isConnected: () => boolean,
-    private ensureConnected: () => void
+    private ensureConnected: () => void,
+    private isPostgres: () => boolean = () => false
   ) {}
 
   async saveMessage(
@@ -241,13 +242,32 @@ export class MessageRepository {
         throw new Error('Database not available');
       }
 
-      await db.run(
-        `
+      // SQLite supports `INSERT OR REPLACE`; Postgres does not. bot_metrics is
+      // keyed for upsert on its UNIQUE botName, so emit an `ON CONFLICT (botName)
+      // DO UPDATE` on Postgres — otherwise the statement is a syntax error and
+      // the metrics update is silently lost.
+      const sql = this.isPostgres()
+        ? `
+        INSERT INTO bot_metrics (
+          botName, messagesSent, messagesReceived, conversationsHandled,
+          averageResponseTime, lastActivity, provider, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+        ON CONFLICT (botName) DO UPDATE SET
+          messagesSent = EXCLUDED.messagesSent,
+          messagesReceived = EXCLUDED.messagesReceived,
+          conversationsHandled = EXCLUDED.conversationsHandled,
+          averageResponseTime = EXCLUDED.averageResponseTime,
+          lastActivity = EXCLUDED.lastActivity, provider = EXCLUDED.provider,
+          updated_at = CURRENT_TIMESTAMP
+      `
+        : `
         INSERT OR REPLACE INTO bot_metrics (
           botName, messagesSent, messagesReceived, conversationsHandled,
           averageResponseTime, lastActivity, provider, updated_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
-      `,
+      `;
+      await db.run(
+        sql,
         [
           metrics.botName,
           metrics.messagesSent,

--- a/tests/unit/repositories/upsertDialect.test.ts
+++ b/tests/unit/repositories/upsertDialect.test.ts
@@ -1,0 +1,89 @@
+import { AnomalyRepository } from '../../../src/database/repositories/AnomalyRepository';
+import { MessageRepository } from '../../../src/database/repositories/MessageRepository';
+import type { IDatabase } from '../../../src/database/types';
+
+/**
+ * Both repositories upsert with SQLite's `INSERT OR REPLACE`, which is a syntax
+ * error on Postgres. These tests assert each repo emits an `ON CONFLICT ... DO
+ * UPDATE` upsert when running against Postgres, and the original SQLite syntax
+ * otherwise — so the Postgres path no longer silently loses data.
+ */
+function mockDb() {
+  const run = jest.fn().mockResolvedValue({ changes: 1, lastID: 1 });
+  const db = {
+    run,
+    get: jest.fn(),
+    all: jest.fn().mockResolvedValue([]),
+    exec: jest.fn(),
+    transaction: jest.fn(),
+    close: jest.fn(),
+  } as unknown as IDatabase;
+  return { db, run };
+}
+
+const anomaly = {
+  id: 'a1',
+  timestamp: 1,
+  metric: 'cpu',
+  value: 9,
+  expectedMean: 1,
+  standardDeviation: 1,
+  zScore: 8,
+  threshold: 3,
+  severity: 'high',
+  explanation: 'spike',
+  resolved: false,
+  tenantId: 't1',
+} as never;
+
+describe('AnomalyRepository.storeAnomaly dialect upsert', () => {
+  it('emits ON CONFLICT (id) DO UPDATE on Postgres', async () => {
+    const { db, run } = mockDb();
+    const repo = new AnomalyRepository(() => db, () => true, () => true);
+    await repo.storeAnomaly(anomaly);
+    const sql = run.mock.calls[0][0] as string;
+    expect(sql).toContain('INSERT INTO anomalies');
+    expect(sql).toContain('ON CONFLICT (id) DO UPDATE SET');
+    expect(sql).not.toContain('INSERT OR REPLACE');
+  });
+
+  it('keeps INSERT OR REPLACE on SQLite', async () => {
+    const { db, run } = mockDb();
+    const repo = new AnomalyRepository(() => db, () => true, () => false);
+    await repo.storeAnomaly(anomaly);
+    const sql = run.mock.calls[0][0] as string;
+    expect(sql).toContain('INSERT OR REPLACE INTO anomalies');
+    expect(sql).not.toContain('ON CONFLICT');
+  });
+});
+
+const metrics = {
+  botName: 'bot-1',
+  messagesSent: 5,
+  messagesReceived: 7,
+  conversationsHandled: 2,
+  averageResponseTime: 12,
+  lastActivity: new Date(0),
+  provider: 'discord',
+} as never;
+
+describe('MessageRepository.updateBotMetrics dialect upsert', () => {
+  it('emits ON CONFLICT (botName) DO UPDATE on Postgres', async () => {
+    const { db, run } = mockDb();
+    const repo = new MessageRepository(() => db, () => true, () => {}, () => true);
+    await repo.updateBotMetrics(metrics);
+    const sql = run.mock.calls[0][0] as string;
+    expect(sql).toContain('INSERT INTO bot_metrics');
+    expect(sql).toContain('ON CONFLICT (botName) DO UPDATE SET');
+    expect(sql).not.toContain('INSERT OR REPLACE');
+  });
+
+  it('keeps INSERT OR REPLACE on SQLite', async () => {
+    const { db, run } = mockDb();
+    const repo = new MessageRepository(() => db, () => true, () => {}, () => false);
+    await repo.updateBotMetrics(metrics);
+    const sql = run.mock.calls[0][0] as string;
+    expect(sql).toContain('INSERT OR REPLACE INTO bot_metrics');
+    expect(sql).not.toContain('ON CONFLICT');
+  });
+});


### PR DESCRIPTION
## Bug

`AnomalyRepository.storeAnomaly` and `MessageRepository.updateBotMetrics` use SQLite's `INSERT OR REPLACE`, which is a **syntax error on PostgreSQL**. `postgresWrapper.translateSql` only rewrites `?`→`$n` placeholders — the `INSERT OR REPLACE → ON CONFLICT` translation was just a TODO comment, never implemented. So on a Postgres deployment both statements threw, the error was swallowed to `debug()`, and **anomalies and bot-metrics updates were silently lost**.

## Fix

Thread the existing `DatabaseManager` `isPg` predicate (already passed to `MemoryRepository`) into both repos and branch the SQL:
- **anomalies** → `ON CONFLICT (id) DO UPDATE SET ...` (`id` is the PRIMARY KEY)
- **bot_metrics** → `ON CONFLICT (botName) DO UPDATE SET ...` (`botName` carries a UNIQUE constraint)

The **SQLite path is unchanged** (`INSERT OR REPLACE` retained), so no regression there.

## Tests

`upsertDialect.test.ts` — asserts each repo emits `ON CONFLICT ... DO UPDATE` when `isPostgres()` is true and keeps `INSERT OR REPLACE` when false. tsc clean; existing repo suites green.