### PR TITLE
🎨 Palette: [UX improvement] Add aria-labels to repetitive buttons

### DIFF
--- a/src/client/src/components/AgentConfigurator/index.tsx
+++ b/src/client/src/components/AgentConfigurator/index.tsx
@@ -494,6 +494,7 @@ const AgentConfigurator: React.FC<AgentConfiguratorProps> = ({ title = 'Agent Co
             className="btn btn-outline"
             onClick={handleRefresh}
             disabled={isFetching}
+            aria-label={isFetching ? 'Refreshing agent status' : 'Refresh agent status'}
           >
             {isFetching && <LoadingSpinner />}
             {isFetching ? 'Refreshing…' : 'Refresh status'}

--- a/src/client/src/components/ToolResultHistory.tsx
+++ b/src/client/src/components/ToolResultHistory.tsx
@@ -93,6 +93,7 @@ const ToolResultHistory: React.FC<ToolResultHistoryProps> = ({
                     e.stopPropagation();
                     onViewResult(result);
                   }}
+                  aria-label={`View result for ${result.toolName} tool`}
                 >
                   <EyeIcon className="w-4 h-4" />
                   View


### PR DESCRIPTION
💡 What: Added dynamic \`aria-label\`s to repetitive/contextual buttons (the "View" button in \`ToolResultHistory\` and the "Refresh status" button in \`AgentConfigurator\`).
🎯 Why: Screen reader users need context when encountering multiple buttons with identical visual text like "View", otherwise it's impossible to tell which result will be viewed. Similarly, dynamic loading states like "Refreshing..." benefit from a clear aria label.
♿ Accessibility: Improves WCAG compliance for interactive elements by providing context.
📸 Before/After: Visuals are unchanged. Screen readers will now announce "View result for [tool name] tool" instead of just "View".

---
*PR created automatically by Jules for task [11723271139351517916](https://jules.google.com/task/11723271139351517916) started by @matthewhand*