### PR TITLE
a11y: label icon/refresh buttons + announce modal loading states

### DIFF
--- a/src/client/src/components/AgentConfigurator/index.tsx
+++ b/src/client/src/components/AgentConfigurator/index.tsx
@@ -494,6 +494,7 @@ const AgentConfigurator: React.FC<AgentConfiguratorProps> = ({ title = 'Agent Co
             className="btn btn-outline"
             onClick={handleRefresh}
             disabled={isFetching}
+            aria-label={isFetching ? 'Refreshing agent status' : 'Refresh agent status'}
           >
             {isFetching && <LoadingSpinner />}
             {isFetching ? 'Refreshing…' : 'Refresh status'}

--- a/src/client/src/components/BotManagement/DiagnosticModal.tsx
+++ b/src/client/src/components/BotManagement/DiagnosticModal.tsx
@@ -77,7 +77,13 @@ const DiagnosticModal: React.FC<DiagnosticModalProps> = ({ botId, botName, isOpe
       size="md"
       ariaLabelledBy="diagnostic-modal-title"
     >
-      <div className="space-y-6 p-4 sm:p-6" role="region" aria-label="Diagnostic results">
+      <div
+        className="space-y-6 p-4 sm:p-6"
+        role="region"
+        aria-label="Diagnostic results"
+        aria-live="polite"
+        aria-busy={loading}
+      >
         {loading && !results ? (
           <div className="py-12 text-center space-y-4">
              <LoadingSpinner lg />
@@ -87,7 +93,12 @@ const DiagnosticModal: React.FC<DiagnosticModalProps> = ({ botId, botName, isOpe
           <div className="alert alert-error">
              <XCircle className="w-6 h-6" />
              <span>{error}</span>
-             <button onClick={runDiagnostic} className="btn btn-xs btn-ghost" disabled={loading}>
+             <button
+               onClick={runDiagnostic}
+               className="btn btn-xs btn-ghost"
+               disabled={loading}
+               aria-label="Retry diagnostic"
+             >
                 {loading ? 'Retrying...' : 'Retry'}
              </button>
           </div>

--- a/src/client/src/components/BotManagement/InsightsModal.tsx
+++ b/src/client/src/components/BotManagement/InsightsModal.tsx
@@ -48,7 +48,13 @@ const InsightsModal: React.FC<InsightsModalProps> = ({ botId, botName, isOpen, o
       size="lg"
       ariaLabelledBy={`insights-title-${botId}`}
     >
-      <div className="space-y-4 p-4 sm:p-6" role="region" aria-label="Insights content">
+      <div
+        className="space-y-4 p-4 sm:p-6"
+        role="region"
+        aria-label="Insights content"
+        aria-live="polite"
+        aria-busy={loading}
+      >
         {loading && !insights ? (
           <div className="py-20 text-center space-y-4">
             <div className="flex justify-center">
@@ -66,7 +72,12 @@ const InsightsModal: React.FC<InsightsModalProps> = ({ botId, botName, isOpen, o
               <h3 className="font-bold">Error</h3>
               <div className="text-xs">{error}</div>
             </div>
-            <button onClick={fetchInsights} className="btn btn-sm btn-ghost" disabled={loading}>
+            <button
+              onClick={fetchInsights}
+              className="btn btn-sm btn-ghost"
+              disabled={loading}
+              aria-label="Retry loading insights"
+            >
               <RefreshCw className={`w-4 h-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
               {loading ? 'Retrying...' : 'Retry'}
             </button>

--- a/src/client/src/components/ToolResultHistory.tsx
+++ b/src/client/src/components/ToolResultHistory.tsx
@@ -93,6 +93,7 @@ const ToolResultHistory: React.FC<ToolResultHistoryProps> = ({
                     e.stopPropagation();
                     onViewResult(result);
                   }}
+                  aria-label={`View result for ${result.toolName} tool`}
                 >
                   <EyeIcon className="w-4 h-4" />
                   View


### PR DESCRIPTION
Salvaged kernels of #2980 and #2981 (both closed — their branches were a month-stale and carried ~29k-line reverts). Reapplied the actual a11y improvements on current `main`:

- **AgentConfigurator** refresh button + **ToolResultHistory** view button — descriptive `aria-label`s (icon/ambiguous-text buttons had no accessible name).
- **DiagnosticModal** / **InsightsModal** — `aria-live="polite"` + `aria-busy={loading}` on the result region so screen readers announce when loading completes, plus `aria-label`s on the Retry buttons.

Kept current main's existing (more advanced) Retry-button loading states. Client `tsc` clean.