### PR TITLE
🧹 Janitor: Fix TypeScript build errors blocking branch

### DIFF
--- a/src/database/DatabaseManager.ts
+++ b/src/database/DatabaseManager.ts
@@ -13,13 +13,10 @@ import { ApprovalRepository } from './repositories/ApprovalRepository';
 import { BotConfigRepository } from './repositories/BotConfigRepository';
 import { DecisionRepository } from './repositories/DecisionRepository';
 import { MessageRepository } from './repositories/MessageRepository';
-import { ActivityRepository, type ActivityLog } from './repositories/ActivityRepository';
-import { InferenceRepository, type InferenceLog } from './repositories/InferenceRepository';
+import { InferenceRepository } from './repositories/InferenceRepository';
 import { MemoryRepository } from './repositories/MemoryRepository';
-import { MessageRepository } from './repositories/MessageRepository';
 import { ActivitySchemas } from './schemas/ActivitySchemas';
 import { SQLiteWrapper } from './sqliteWrapper';
-import { PostgresWrapper } from './postgresWrapper';
 import { runMigrations } from './migrationRunner';
 import type {
   Anomaly,
@@ -32,9 +29,9 @@ import type {
   DatabaseConfig,
   DecisionRecord,
   IDatabase,
-  InferenceLog,
   MemoryRecord,
   MessageRecord,
+  InferenceLog,
 } from './types';
 
 // Re-export every type so existing `import { Foo } from '.../DatabaseManager'` keeps working.

--- a/src/message/interfaces/IMessengerService.ts
+++ b/src/message/interfaces/IMessengerService.ts
@@ -226,6 +226,7 @@ export interface IMessengerService {
    * ```
    */
   getForumOwner?(forumId: string): Promise<string>;
+  getChannels?(botName?: string): Promise<Array<{ id: string; name: string; type?: string }>>;
 
   /**
    * Optional: Returns extended sub-services managed by this provider.

--- a/src/utils/serviceDependencies.ts
+++ b/src/utils/serviceDependencies.ts
@@ -1,6 +1,7 @@
 import type { IServiceDependencies } from '@hivemind/shared-types';
 import Logger from '../common/logger';
 import { DatabaseManager } from '../database/DatabaseManager';
+import { BaseHivemindError, ConfigurationError, NetworkError, ValidationError, ApiError } from '../types/errorClasses';
 
 /**
  * Construct IServiceDependencies from the DI container and system services.
@@ -10,7 +11,7 @@ export function getServiceDependencies(context: string): IServiceDependencies {
   return {
     logger: Logger.withContext(context),
     errorTypes: {
-      HivemindError: BaseError as any,
+      HivemindError: BaseHivemindError as any,
       ConfigError: ConfigurationError as any,
       NetworkError: NetworkError as any,
       ValidationError: ValidationError as any,


### PR DESCRIPTION
🧹 Janitor: Fix TypeScript build errors blocking branch
💡 What: Added getChannels to IMessengerService, removed duplicate DatabaseManager imports, and fixed missing BaseHivemindError export in serviceDependencies.
🎯 Why: Failed type checks (pnpm run check-types) were blocking CI.
🚦 Status: Ready to rebase and merge.

---
*PR created automatically by Jules for task [3638067432686819266](https://jules.google.com/task/3638067432686819266) started by @matthewhand*