### PR TITLE
fix(providers): don't overwrite a corrupted messengers.json on addBot

### DIFF
--- a/src/providers/DiscordProvider.ts
+++ b/src/providers/DiscordProvider.ts
@@ -86,9 +86,27 @@ export class DiscordProvider implements IMessageProvider<DiscordConfig> {
     let cfg: any = { discord: { instances: [] } };
     try {
       const fileContent = await fs.promises.readFile(messengersPath, 'utf8');
-      cfg = JSON.parse(fileContent);
-    } catch {
-      // Ignore
+      // A JSON parse error means the file is corrupted — surface it instead of
+      // continuing, which would overwrite the file below with a fresh default
+      // and destroy every existing bot config.
+      try {
+        cfg = JSON.parse(fileContent);
+      } catch (parseErr: unknown) {
+        const parseMessage = parseErr instanceof Error ? parseErr.message : String(parseErr);
+        throw new Error(
+          `messengers.json is corrupted and cannot be parsed: ${parseMessage}. ` +
+            `Please fix or remove ${messengersPath} before adding a new bot.`
+        );
+      }
+    } catch (readErr: unknown) {
+      const isEnoent =
+        readErr instanceof Error &&
+        'code' in readErr &&
+        (readErr as NodeJS.ErrnoException).code === 'ENOENT';
+      if (!isEnoent) {
+        throw readErr;
+      }
+      // File doesn't exist yet — start with the default empty structure.
     }
     cfg.discord = cfg.discord || {};
     cfg.discord.instances = cfg.discord.instances || [];

--- a/src/providers/SlackProvider.ts
+++ b/src/providers/SlackProvider.ts
@@ -115,26 +115,45 @@ export class SlackProvider implements IMessageProvider<SlackConfig> {
     let cfg: SlackFileConfig = { slack: { instances: [] } };
     try {
       const fileContent = await fs.promises.readFile(messengersPath, 'utf8');
-      cfg = JSON.parse(fileContent) as SlackFileConfig;
-    } catch (e: unknown) {
-      if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
-        debug('Failed reading messengers.json', e);
+      // Distinguish a corrupted file (JSON parse error) from a missing one. A
+      // parse error must surface to the operator — silently continuing here
+      // would overwrite the corrupted file with a default and destroy every
+      // existing bot config.
+      try {
+        cfg = JSON.parse(fileContent) as SlackFileConfig;
+      } catch (parseErr: unknown) {
+        const parseMessage = parseErr instanceof Error ? parseErr.message : String(parseErr);
+        throw new Error(
+          `messengers.json is corrupted and cannot be parsed: ${parseMessage}. ` +
+            `Please fix or remove ${messengersPath} before adding a new bot.`
+        );
       }
+    } catch (readErr: unknown) {
+      const isEnoent =
+        readErr instanceof Error &&
+        'code' in readErr &&
+        (readErr as NodeJS.ErrnoException).code === 'ENOENT';
+      if (!isEnoent) {
+        throw readErr;
+      }
+      // File doesn't exist yet — start with the default empty structure.
     }
 
-    if (cfg.slack) {
-      cfg.slack.mode = cfg.slack.mode || mode || 'socket';
-      cfg.slack.instances = cfg.slack.instances || [];
-      cfg.slack.instances.push({
-        name,
-        token: botToken,
-        signingSecret,
-        llm,
-        appToken,
-        defaultChannelId,
-        joinChannels,
-      });
-    }
+    // Always ensure the slack section exists, so a config that parsed without a
+    // `slack` key still gets the new instance persisted (previously it was
+    // silently dropped when the key was absent).
+    cfg.slack = cfg.slack || { instances: [] };
+    cfg.slack.mode = cfg.slack.mode || mode || 'socket';
+    cfg.slack.instances = cfg.slack.instances || [];
+    cfg.slack.instances.push({
+      name,
+      token: botToken,
+      signingSecret,
+      llm,
+      appToken,
+      defaultChannelId,
+      joinChannels,
+    });
 
     try {
       await fs.promises.mkdir(path.dirname(messengersPath), { recursive: true });

--- a/tests/unit/providers/configCorruption.test.ts
+++ b/tests/unit/providers/configCorruption.test.ts
@@ -1,0 +1,44 @@
+import * as fs from 'fs';
+import { SlackProvider } from '../../../src/providers/SlackProvider';
+import { DiscordProvider } from '../../../src/providers/DiscordProvider';
+
+/**
+ * addBot() persists to config/providers/messengers.json. If that file exists
+ * but is corrupted (invalid JSON), the provider must surface the error rather
+ * than silently overwriting it with a fresh default — which would destroy every
+ * existing bot configuration. These tests assert addBot rejects with a clear
+ * "corrupted" error and never reaches the writeFile step.
+ */
+describe('messenger provider config-corruption safety', () => {
+  let readFileSpy: jest.SpyInstance;
+  let writeFileSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    // Existing file with invalid JSON content.
+    readFileSpy = jest
+      .spyOn(fs.promises, 'readFile')
+      .mockResolvedValue('{ this is : not valid json' as never);
+    writeFileSpy = jest.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined as never);
+    jest.spyOn(fs.promises, 'mkdir').mockResolvedValue(undefined as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('SlackProvider.addBot rejects on a corrupted messengers.json and does not overwrite it', async () => {
+    const provider = new SlackProvider({} as never);
+    await expect(
+      provider.addBot({ name: 'b1', botToken: 'x', signingSecret: 's' })
+    ).rejects.toThrow(/corrupted/i);
+    expect(readFileSpy).toHaveBeenCalled();
+    expect(writeFileSpy).not.toHaveBeenCalled();
+  });
+
+  it('DiscordProvider.addBot rejects on a corrupted messengers.json and does not overwrite it', async () => {
+    const provider = new DiscordProvider({} as never);
+    await expect(provider.addBot({ name: 'b1', token: 'x' })).rejects.toThrow(/corrupted/i);
+    expect(readFileSpy).toHaveBeenCalled();
+    expect(writeFileSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Data-loss bug

`SlackProvider.addBot` and `DiscordProvider.addBot` persist to `config/providers/messengers.json`. They read it inside a `try` whose `catch` swallowed **all** errors (Discord: `catch {}`; Slack: `catch { if (code !== 'ENOENT') debug(...) }`), then fell through to the default `{ instances: [] }` and **wrote it back**. So if the file existed but was **corrupted** (invalid JSON — truncation, a bad manual edit), adding one bot silently **overwrote the file and destroyed every existing bot config**.

## Fix

Both now mirror the already-correct `TelegramProvider` pattern: a nested try distinguishes a **JSON parse error** (file corrupted → throw a clear *"fix or remove the file"* error **before any write**) from **ENOENT** (file missing → start with the default). The throw propagates to the admin route's error handler (a 500) instead of causing data loss.

Also fixes a Slack-only bug: a parsed config without a top-level `slack` key made the `if (cfg.slack)` guard skip the push, so the new bot was **silently dropped**. The `slack` section is now ensured before the push.

## Test

`configCorruption.test.ts` — both providers' `addBot` reject with `/corrupted/` on invalid JSON and **never** call `writeFile`. tsc clean.

Found via a codebase audit sweep.