### PR TITLE
fix: guard null/undefined derefs on external API responses + parseInt radix

### DIFF
--- a/src/llm/llm/generateCompletion.ts
+++ b/src/llm/llm/generateCompletion.ts
@@ -17,5 +17,9 @@ export async function generateCompletion(prompt: string): Promise<string> {
     }
   );
 
-  return data.choices[0].text;
+  const text = data?.choices?.[0]?.text;
+  if (text == null) {
+    throw new Error('Completion response contained no choices');
+  }
+  return text;
 }

--- a/src/managers/PersonaManager.ts
+++ b/src/managers/PersonaManager.ts
@@ -162,8 +162,14 @@ export class PersonaManager extends EventEmitter {
         const data = await fs.promises.readFile(this.personasFilePath, 'utf8');
         const savedPersonas = JSON.parse(data);
 
+        // Guard against a file that parses to a non-object (string/number/array/
+        // null) — Object.values() on those yields garbage and `p.id` would throw.
+        if (!savedPersonas || typeof savedPersonas !== 'object' || Array.isArray(savedPersonas)) {
+          throw new Error('custom-personas.json must contain a JSON object of personas');
+        }
+
         Object.values(savedPersonas).forEach((p: any) => {
-          if (p.id) this.personas.set(p.id, p);
+          if (p && typeof p === 'object' && p.id) this.personas.set(p.id, p);
         });
         debug(`Loaded ${Object.keys(savedPersonas).length} personas from custom-personas.json`);
       } else {

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -276,8 +276,10 @@ export function setupGracefulShutdown(): void {
  */
 export function errorRecoveryMiddleware(req: Request, res: Response, next: NextFunction): void {
   // Check if this is a retry request
-  const retryCount = parseInt((req.headers['x-retry-count'] as string) || '0');
-  const maxRetries = parseInt((req.headers['x-max-retries'] as string) || '3');
+  // Always parse with an explicit radix; a NaN (non-numeric header) falls back
+  // to a safe default rather than poisoning the retry comparison below.
+  const retryCount = parseInt((req.headers['x-retry-count'] as string) || '0', 10) || 0;
+  const maxRetries = parseInt((req.headers['x-max-retries'] as string) || '3', 10) || 3;
 
   if (retryCount > 0) {
     debug(`Retry request ${req.method} ${req.path} - Attempt ${retryCount}/${maxRetries}`);

--- a/src/providers/TelegramProvider.ts
+++ b/src/providers/TelegramProvider.ts
@@ -362,8 +362,8 @@ export class TelegramProvider implements IMessageProvider<TelegramConfig> {
 
       const data = await response.json();
 
-      if (!data.ok) {
-        throw new Error(`Telegram API error: ${data.description || 'Unknown error'}`);
+      if (!data.ok || data.result?.message_id == null) {
+        throw new Error(`Telegram API error: ${data.description || 'Unknown or malformed response'}`);
       }
 
       return data.result.message_id.toString();
@@ -454,11 +454,16 @@ export class TelegramProvider implements IMessageProvider<TelegramConfig> {
         const owner = data.result.find(
           (admin: Record<string, unknown>) => admin.status === 'creator'
         );
-        if (owner) {
+        // Guard against admin entries that lack a nested `user` object — a
+        // malformed/partial Telegram response would otherwise throw on
+        // `.user.id` and be reported as an opaque error.
+        if (owner?.user?.id != null) {
           return owner.user.id.toString();
         }
         // Fallback to first admin if no explicit owner
-        return data.result[0].user.id.toString();
+        if (data.result[0]?.user?.id != null) {
+          return data.result[0].user.id.toString();
+        }
       }
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);


### PR DESCRIPTION
Defensive runtime guards on paths that dereference **external/untrusted** data without checking its shape — each can throw `TypeError` on a malformed API response or file. Found via a codebase audit sweep.

| File | Before | Risk |
|------|--------|------|
| `TelegramProvider.ts` (sendMessage) | `data.result.message_id.toString()` | `{ok:true}` with no `result` → throw |
| `TelegramProvider.ts` (owner resolution) | `owner.user.id`, `data.result[0].user.id` | admin entry without nested `user` → throw |
| `llm/llm/generateCompletion.ts` | `data.choices[0].text` | empty/absent `choices` → throw |
| `managers/PersonaManager.ts` | `Object.values(JSON.parse(...))` then `p.id` | file parsing to a non-object (string/array/null) → throw/corrupt |
| `middleware/errorHandler.ts` | `parseInt(header)` (no radix) | octal misparse + `NaN` poisoning the retry comparison |

Each now validates shape and either throws a **clear** error or falls back to a safe default, instead of an opaque `Cannot read properties of undefined`. `tsc` clean; Telegram/Persona suites green.