### PR TITLE
fix(config): redact OpenWebUI password from startup debug log

### DIFF
--- a/src/config/openWebUIConfig.ts
+++ b/src/config/openWebUIConfig.ts
@@ -53,6 +53,12 @@ try {
 
 // Validation must happen outside the generic try-catch to fail fast if config is malformed
 openWebUIConfig.validate({ allowed: 'strict' });
-debug('OpenWebUIConfig initialized:', openWebUIConfig.getProperties());
+// Redact the password before logging — getProperties() returns the resolved
+// plaintext value, which would otherwise leak into the debug stream.
+const _loggedProps = { ...openWebUIConfig.getProperties() } as Record<string, unknown>;
+if (_loggedProps.OPEN_WEBUI_PASSWORD) {
+  _loggedProps.OPEN_WEBUI_PASSWORD = '***redacted***';
+}
+debug('OpenWebUIConfig initialized:', _loggedProps);
 
 export default openWebUIConfig;


### PR DESCRIPTION
`src/config/openWebUIConfig.ts` logged `openWebUIConfig.getProperties()` at startup, and `getProperties()` returns the **resolved plaintext** `OPEN_WEBUI_PASSWORD` (declared `sensitive: true`). With `DEBUG` enabled that credential leaks into the log stream / aggregation.

Redacts the password to `***redacted***` before logging. No behavior change beyond the log content. tsc clean.

(Note: the `OPEN_WEBUI_PASSWORD` *default* of `password123` flagged by the audit is an **outbound** credential the app uses to authenticate to an external OpenWebUI instance — not a password protecting this app — so changing that default is a separate, behavior-affecting decision and is intentionally not touched here.)