### PR TITLE
fix(providers): write messengers.json with 0o600 (it holds bot tokens)

### DIFF
--- a/src/providers/DiscordProvider.ts
+++ b/src/providers/DiscordProvider.ts
@@ -114,7 +114,12 @@ export class DiscordProvider implements IMessageProvider<DiscordConfig> {
 
     try {
       await fs.promises.mkdir(path.dirname(messengersPath), { recursive: true });
-      await fs.promises.writeFile(messengersPath, JSON.stringify(cfg, null, 2), 'utf8');
+      // messengers.json holds bot tokens — restrict to owner read/write (0o600),
+      // matching TelegramProvider, so other OS users can't read the secrets.
+      await fs.promises.writeFile(messengersPath, JSON.stringify(cfg, null, 2), {
+        encoding: 'utf8',
+        mode: 0o600,
+      });
     } catch (e) {
       debug('ERROR:', 'Failed writing messengers.json', e);
     }

--- a/src/providers/MattermostProvider.ts
+++ b/src/providers/MattermostProvider.ts
@@ -123,7 +123,12 @@ export class MattermostProvider implements IMessageProvider<MattermostConfig> {
 
     try {
       await fs.promises.mkdir(path.dirname(messengersPath), { recursive: true });
-      await fs.promises.writeFile(messengersPath, JSON.stringify(cfg, null, 2), 'utf8');
+      // messengers.json holds bot tokens — restrict to owner read/write (0o600),
+      // matching TelegramProvider, so other OS users can't read the secrets.
+      await fs.promises.writeFile(messengersPath, JSON.stringify(cfg, null, 2), {
+        encoding: 'utf8',
+        mode: 0o600,
+      });
     } catch (e: unknown) {
       debug('Failed writing messengers.json', e);
     }

--- a/src/providers/SlackProvider.ts
+++ b/src/providers/SlackProvider.ts
@@ -157,7 +157,12 @@ export class SlackProvider implements IMessageProvider<SlackConfig> {
 
     try {
       await fs.promises.mkdir(path.dirname(messengersPath), { recursive: true });
-      await fs.promises.writeFile(messengersPath, JSON.stringify(cfg, null, 2), 'utf8');
+      // messengers.json holds bot tokens — restrict to owner read/write (0o600),
+      // matching TelegramProvider, so other OS users can't read the secrets.
+      await fs.promises.writeFile(messengersPath, JSON.stringify(cfg, null, 2), {
+        encoding: 'utf8',
+        mode: 0o600,
+      });
     } catch (e: unknown) {
       debug('ERROR:', 'Failed writing messengers.json', e);
     }


### PR DESCRIPTION
`config/providers/messengers.json` stores **bot tokens**. `TelegramProvider` already writes it with `{ encoding: 'utf8', mode: 0o600 }` (owner read/write only), but `SlackProvider`, `DiscordProvider`, and `MattermostProvider` wrote it with just `'utf8'` — i.e. the process umask, often world-readable — so other OS users on the host could read the tokens.

Applies the same `0o600` mode to all three to match Telegram. `tsc` clean; provider suites green.

Found via a codebase audit sweep.