### PR TITLE
🎨 Palette: Add aria-label to refresh button in WelcomeSplash

### DIFF
--- a/src/client/src/components/WelcomeSplash.tsx
+++ b/src/client/src/components/WelcomeSplash.tsx
@@ -177,7 +177,14 @@ const WelcomeSplash: React.FC = () => {
             <Sparkles className="w-5 h-5 text-primary" />
             Setup Progress
           </h3>
-          <Button variant="ghost" size="sm" onClick={handleRefresh} loading={refreshing}>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleRefresh}
+            loading={refreshing}
+            aria-label="Refresh setup progress"
+            title="Refresh setup progress"
+          >
             <RefreshCw className={`w-4 h-4 ${refreshing ? 'animate-spin' : ''}`} />
           </Button>
         </div>


### PR DESCRIPTION
💡 What: Added an `aria-label` and `title` tooltip to the icon-only refresh button in the WelcomeSplash component.
🎯 Why: Without an `aria-label`, the button is completely opaque to screen readers because it only contains an SVG icon. The `title` acts as a helpful native tooltip for mouse users.
📸 Before/After: Visuals will show a native tooltip "Refresh setup progress" when hovering over the button.
♿ Accessibility: Improved screen reader navigation and announced context for the setup progress refresh action.

---
*PR created automatically by Jules for task [7660007645906416803](https://jules.google.com/task/7660007645906416803) started by @matthewhand*