### PR TITLE
docs: add admin health workflow and screenshot to user guide

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -268,6 +268,12 @@ A comprehensive dashboard for tracking ecosystem status, bot status, and real-ti
 ### [System Health](/admin/health)
 Monitor real-time service status and infrastructure health.
 
+**Workflow: Monitoring API Status**
+1. Navigate to **System Health** via the sidebar or Command Palette.
+2. Check the **Service Health** cards to see the status of the Database, Memory Providers, etc.
+3. Review the **Infrastructure Health** list for individual ping statuses to APIs and internal processes.
+4. If a service is marked offline or degraded, hover over its status chip for additional error details.
+
 ![System Health Page](screenshots/admin-health-page.png)
 
 *   **Service Health**: View detailed health status, latency, and details for connected services like Database, LLM Providers, Memory Providers, and Message Providers.


### PR DESCRIPTION
This PR fulfills the Docco persona directive by identifying the System Health page as an area lacking a clear workflow definition. 
- Added a step-by-step workflow for monitoring API status on the System Health page in `docs/USER_GUIDE.md`.
- Verified that the screenshot automation (`screenshot-admin-health.spec.ts`) correctly generates `docs/screenshots/admin-health-page.png`.

---
*PR created automatically by Jules for task [11939911974084721843](https://jules.google.com/task/11939911974084721843) started by @matthewhand*