### PR TITLE
🎨 Palette: [a11y improvement] Add aria-label to send message button in Chat

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-20 - Icon-only Submit Button Accessibility
+**Learning:** Icon-only submit buttons (like the `➤` chat send button) require explicit `aria-label` attributes to ensure screen readers convey their action accurately, avoiding confusion over raw icon interpretations.
+**Action:** Always verify `type="submit"` buttons containing only icons or unreadable characters implement a descriptive `aria-label`.

--- a/src/client/src/components/DaisyUI/Chat.tsx
+++ b/src/client/src/components/DaisyUI/Chat.tsx
@@ -310,6 +310,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({
               type="submit"
               className="btn btn-primary"
               disabled={!inputValue.trim() || isLoading}
+              aria-label="Send message"
             >
               {isLoading ? <span className="loading loading-spinner" aria-hidden="true"></span> : '➤'}
             </button>


### PR DESCRIPTION
💡 What: Added an `aria-label="Send message"` to the send button in `Chat.tsx`.
🎯 Why: The button is an icon-only submit button displaying a `➤` character, which is poorly read by screen readers. Adding a descriptive `aria-label` ensures screen readers can accurately interpret and announce its function.
📸 Before/After: Visuals are unchanged. The underlying DOM now includes `aria-label="Send message"` on the `➤` button.
♿ Accessibility: Improved screen reader announcements for the form submission element, enabling smoother keyboard navigation and comprehension.

---
*PR created automatically by Jules for task [13266158867454526331](https://jules.google.com/task/13266158867454526331) started by @matthewhand*