### PR TITLE
e2e: add visual regression, network resilience, and multi-tab session tests

### DIFF
--- a/tests/e2e/multi-tab-sessions.spec.ts
+++ b/tests/e2e/multi-tab-sessions.spec.ts
@@ -1,0 +1,234 @@
+import { expect, test } from '@playwright/test';
+import { setupAuth, waitForPageReady } from './test-utils';
+
+/**
+ * Multi-Tab Concurrent Session & Data Isolation Tests
+ *
+ * Verifies:
+ * - Two independent sessions don't leak localStorage/auth state
+ * - Mutations in one tab are reflected when the other tab refreshes
+ * - Concurrent writes don't corrupt shared data
+ * - Session expiry in one tab doesn't crash the other
+ */
+
+function createSharedBotStore() {
+  const bots: any[] = [
+    {
+      id: 'shared-1',
+      name: 'Shared Bot Alpha',
+      provider: 'discord',
+      status: 'running',
+      connected: true,
+      messageCount: 5,
+      errorCount: 0,
+    },
+  ];
+  return {
+    get: () => [...bots],
+    add: (bot: any) => {
+      bots.push(bot);
+    },
+  };
+}
+
+function setupCommonMocks(page: import('@playwright/test').Page) {
+  return Promise.all([
+    page.route('**/api/health/detailed', (route) =>
+      route.fulfill({ status: 200, json: { status: 'healthy' } })
+    ),
+    page.route('**/api/config/llm-status', (route) =>
+      route.fulfill({
+        status: 200,
+        json: {
+          defaultConfigured: true,
+          defaultProviders: [],
+          botsMissingLlmProvider: [],
+          hasMissing: false,
+        },
+      })
+    ),
+    page.route('**/api/config/global', (route) => route.fulfill({ status: 200, json: {} })),
+    page.route('**/api/csrf-token', (route) =>
+      route.fulfill({ status: 200, json: { token: 'csrf-multi' } })
+    ),
+    page.route('**/api/health', (route) => route.fulfill({ status: 200, json: { status: 'ok' } })),
+    page.route('**/api/dashboard/api/status', (route) =>
+      route.fulfill({ status: 200, json: { bots: [], uptime: 100 } })
+    ),
+    page.route('**/api/demo/status', (route) =>
+      route.fulfill({ status: 200, json: { active: false } })
+    ),
+    page.route('**/api/personas', (route) => route.fulfill({ status: 200, json: [] })),
+    page.route('**/api/admin/llm-profiles', (route) => route.fulfill({ status: 200, json: [] })),
+  ]);
+}
+
+test.describe('Multi-Tab Concurrent Sessions', () => {
+  test.setTimeout(120000);
+
+  test('two contexts have isolated auth state', async ({ browser }) => {
+    const ctx1 = await browser.newContext();
+    const ctx2 = await browser.newContext();
+    const page1 = await ctx1.newPage();
+    const page2 = await ctx2.newPage();
+
+    await setupAuth(page1);
+    await setupCommonMocks(page1);
+    await setupCommonMocks(page2);
+
+    await page1.route('**/api/config', (route) =>
+      route.fulfill({ status: 200, json: { bots: [] } })
+    );
+
+    await page1.goto('/admin/overview');
+    await waitForPageReady(page1);
+
+    // Context 2 has no auth — should redirect to login or show unauthorized
+    await page2.goto('/admin/overview');
+    await page2.waitForTimeout(3000);
+
+    const page2Url = page2.url();
+    const page2Body = (await page2.locator('body').textContent()) || '';
+    const isIsolated =
+      page2Url.includes('login') ||
+      page2Body.toLowerCase().includes('login') ||
+      page2Body.toLowerCase().includes('sign in') ||
+      page2Body.toLowerCase().includes('unauthorized');
+    expect(isIsolated).toBe(true);
+
+    await ctx1.close();
+    await ctx2.close();
+  });
+
+  test('mutation in tab A is visible in tab B after refresh', async ({ browser }) => {
+    const store = createSharedBotStore();
+
+    const ctx1 = await browser.newContext();
+    const ctx2 = await browser.newContext();
+    const page1 = await ctx1.newPage();
+    const page2 = await ctx2.newPage();
+
+    await setupAuth(page1);
+    await setupAuth(page2);
+    await setupCommonMocks(page1);
+    await setupCommonMocks(page2);
+
+    await page1.route('**/api/config', async (route) => {
+      await route.fulfill({ status: 200, json: { bots: store.get() } });
+    });
+    await page2.route('**/api/config', async (route) => {
+      await route.fulfill({ status: 200, json: { bots: store.get() } });
+    });
+
+    await page1.goto('/admin/bots');
+    await waitForPageReady(page1);
+    await page2.goto('/admin/bots');
+    await waitForPageReady(page2);
+
+    // Simulate mutation from tab A
+    store.add({
+      id: 'tab-a-bot',
+      name: 'Tab A Bot',
+      provider: 'slack',
+      status: 'running',
+      connected: true,
+      messageCount: 0,
+      errorCount: 0,
+    });
+
+    // Tab B refreshes — should see new bot
+    await page2.reload();
+    await waitForPageReady(page2);
+
+    const page2Body = (await page2.locator('body').textContent()) || '';
+    expect(page2Body).toContain('Tab A Bot');
+
+    await ctx1.close();
+    await ctx2.close();
+  });
+
+  test('concurrent navigation does not corrupt page state', async ({ browser }) => {
+    const ctx = await browser.newContext();
+    const page1 = await ctx.newPage();
+    const page2 = await ctx.newPage();
+
+    await setupAuth(page1);
+    await setupAuth(page2);
+    await setupCommonMocks(page1);
+    await setupCommonMocks(page2);
+
+    await page1.route('**/api/config', (route) =>
+      route.fulfill({
+        status: 200,
+        json: { bots: [{ id: 'b1', name: 'Bot One', provider: 'discord', status: 'running' }] },
+      })
+    );
+    await page2.route('**/api/config', (route) =>
+      route.fulfill({
+        status: 200,
+        json: { bots: [{ id: 'b1', name: 'Bot One', provider: 'discord', status: 'running' }] },
+      })
+    );
+    await page1.route('**/api/guards', (route) =>
+      route.fulfill({
+        status: 200,
+        json: { guards: [{ id: 'g1', name: 'Guard One', enabled: true }] },
+      })
+    );
+    await page2.route('**/api/monitoring/**', (route) =>
+      route.fulfill({ status: 200, json: { metrics: [], events: [] } })
+    );
+
+    await Promise.all([page1.goto('/admin/bots'), page2.goto('/admin/guards')]);
+    await Promise.all([waitForPageReady(page1), waitForPageReady(page2)]);
+
+    expect(page1.url()).toContain('/bots');
+    expect(page2.url()).toContain('/guards');
+
+    await ctx.close();
+  });
+
+  test('session expiry in one context does not crash the other', async ({ browser }) => {
+    const ctx1 = await browser.newContext();
+    const ctx2 = await browser.newContext();
+    const page1 = await ctx1.newPage();
+    const page2 = await ctx2.newPage();
+
+    await setupAuth(page1);
+    await setupAuth(page2);
+    await setupCommonMocks(page1);
+    await setupCommonMocks(page2);
+
+    await page1.route('**/api/config', (route) =>
+      route.fulfill({ status: 200, json: { bots: [] } })
+    );
+    await page2.route('**/api/config', (route) =>
+      route.fulfill({ status: 200, json: { bots: [] } })
+    );
+
+    await page1.goto('/admin/overview');
+    await page2.goto('/admin/overview');
+    await Promise.all([waitForPageReady(page1), waitForPageReady(page2)]);
+
+    // Expire session in context 1
+    await page1.evaluate(() => {
+      localStorage.removeItem('auth_tokens');
+      localStorage.removeItem('auth_user');
+    });
+    await page1.route('**/api/config', (route) =>
+      route.fulfill({ status: 401, json: { error: 'Unauthorized' } })
+    );
+    await page1.reload();
+    await page1.waitForTimeout(3000);
+
+    // Context 2 should still work
+    await page2.reload();
+    await waitForPageReady(page2);
+    await expect(page2.locator('body')).toBeVisible();
+    const page2Body = (await page2.locator('body').textContent()) || '';
+    expect(page2Body.length).toBeGreaterThan(10);
+
+    await ctx1.close();
+    await ctx2.close();
+  });
+});

--- a/tests/e2e/network-resilience.spec.ts
+++ b/tests/e2e/network-resilience.spec.ts
@@ -1,0 +1,243 @@
+import { expect, test } from '@playwright/test';
+import { setupAuth, waitForPageReady } from './test-utils';
+
+/**
+ * Network Resilience E2E Tests
+ *
+ * Verifies the UI degrades gracefully under adverse network conditions:
+ * - Slow API responses (simulated latency)
+ * - Request timeouts / hung connections
+ * - Offline/disconnected state
+ * - Intermittent failures (flaky APIs)
+ * - Server error responses (500, 502, 503)
+ */
+
+test.describe('Network Resilience', () => {
+  test.setTimeout(120000);
+
+  test.beforeEach(async ({ page }) => {
+    await setupAuth(page);
+  });
+
+  test.describe('Slow Responses', () => {
+    test('shows loading state during slow API response', async ({ page }) => {
+      await page.route('**/api/config', async (route) => {
+        await new Promise((r) => setTimeout(r, 3000));
+        await route.fulfill({
+          status: 200,
+          json: { bots: [{ id: 'b1', name: 'Slow Bot', provider: 'discord', status: 'running' }] },
+        });
+      });
+
+      await page.goto('/admin/bots');
+      const loading = page.locator('[class*="loading"], [class*="spinner"], .skeleton');
+      await expect(loading.first()).toBeVisible({ timeout: 2000 });
+      await expect(page.locator('text=/Slow Bot|bot/i').first()).toBeVisible({ timeout: 10000 });
+    });
+
+    test('dashboard remains interactive during slow health check', async ({ page }) => {
+      await page.route('**/api/health/detailed', async (route) => {
+        await new Promise((r) => setTimeout(r, 5000));
+        await route.fulfill({ status: 200, json: { status: 'healthy' } });
+      });
+      await page.route('**/api/config', (route) =>
+        route.fulfill({ status: 200, json: { bots: [] } })
+      );
+      await page.route('**/api/config/llm-status', (route) =>
+        route.fulfill({
+          status: 200,
+          json: {
+            defaultConfigured: true,
+            defaultProviders: [],
+            botsMissingLlmProvider: [],
+            hasMissing: false,
+          },
+        })
+      );
+      await page.route('**/api/config/global', (route) => route.fulfill({ status: 200, json: {} }));
+      await page.route('**/api/csrf-token', (route) =>
+        route.fulfill({ status: 200, json: { token: 'tok' } })
+      );
+      await page.route('**/api/health', (route) =>
+        route.fulfill({ status: 200, json: { status: 'ok' } })
+      );
+      await page.route('**/api/dashboard/api/status', (route) =>
+        route.fulfill({ status: 200, json: { bots: [], uptime: 100 } })
+      );
+      await page.route('**/api/demo/status', (route) =>
+        route.fulfill({ status: 200, json: { active: false } })
+      );
+
+      await page.goto('/admin/overview');
+      await waitForPageReady(page);
+
+      const nav = page.locator('nav a, [data-testid="sidebar"] a, .sidebar a').first();
+      await expect(nav).toBeEnabled();
+    });
+  });
+
+  test.describe('Timeouts & Aborts', () => {
+    test('handles hung connection without crashing', async ({ page }) => {
+      await page.route('**/api/config', () => {
+        // Never respond — simulates a hung connection
+      });
+
+      await page.goto('/admin/bots');
+      await page.waitForTimeout(5000);
+
+      await expect(page.locator('body')).toBeVisible();
+      const bodyText = await page.locator('body').textContent();
+      expect(bodyText?.length).toBeGreaterThan(0);
+    });
+
+    test('retries or shows error on aborted fetch', async ({ page }) => {
+      let callCount = 0;
+      await page.route('**/api/config', async (route) => {
+        callCount++;
+        if (callCount <= 2) {
+          await route.abort('connectionfailed');
+        } else {
+          await route.fulfill({
+            status: 200,
+            json: {
+              bots: [{ id: 'b1', name: 'Recovered Bot', provider: 'discord', status: 'running' }],
+            },
+          });
+        }
+      });
+
+      await page.goto('/admin/bots');
+      await page.waitForTimeout(6000);
+
+      const hasContent = await page
+        .locator('text=/Recovered Bot|error|retry|failed/i')
+        .first()
+        .isVisible();
+      expect(hasContent).toBe(true);
+    });
+  });
+
+  test.describe('Offline Mode', () => {
+    test('handles network drop without crash', async ({ page }) => {
+      await page.route('**/api/**', (route) => route.fulfill({ status: 200, json: {} }));
+      await page.goto('/admin/overview');
+      await waitForPageReady(page);
+
+      await page.context().setOffline(true);
+      await page.goto('/admin/bots').catch(() => {});
+      await page.waitForTimeout(2000);
+
+      await expect(page.locator('body')).toBeVisible();
+    });
+
+    test('recovers when network is restored', async ({ page }) => {
+      await page.route('**/api/config', (route) =>
+        route.fulfill({
+          status: 200,
+          json: {
+            bots: [{ id: 'b1', name: 'Online Bot', provider: 'discord', status: 'running' }],
+          },
+        })
+      );
+      await page.route('**/api/health', (route) =>
+        route.fulfill({ status: 200, json: { status: 'ok' } })
+      );
+      await page.route('**/api/csrf-token', (route) =>
+        route.fulfill({ status: 200, json: { token: 'tok' } })
+      );
+      await page.route('**/api/config/llm-status', (route) =>
+        route.fulfill({
+          status: 200,
+          json: {
+            defaultConfigured: true,
+            defaultProviders: [],
+            botsMissingLlmProvider: [],
+            hasMissing: false,
+          },
+        })
+      );
+      await page.route('**/api/config/global', (route) => route.fulfill({ status: 200, json: {} }));
+      await page.route('**/api/dashboard/api/status', (route) =>
+        route.fulfill({ status: 200, json: { bots: [], uptime: 100 } })
+      );
+      await page.route('**/api/demo/status', (route) =>
+        route.fulfill({ status: 200, json: { active: false } })
+      );
+      await page.route('**/api/health/detailed', (route) =>
+        route.fulfill({ status: 200, json: { status: 'healthy' } })
+      );
+
+      await page.goto('/admin/overview');
+      await waitForPageReady(page);
+
+      await page.context().setOffline(true);
+      await page.waitForTimeout(1000);
+      await page.context().setOffline(false);
+
+      await page.reload();
+      await waitForPageReady(page);
+      await expect(page.locator('body')).toBeVisible();
+      const bodyText = await page.locator('body').textContent();
+      expect(bodyText!.length).toBeGreaterThan(10);
+    });
+  });
+
+  test.describe('Server Errors', () => {
+    test('displays error state on 500 response', async ({ page }) => {
+      await page.route('**/api/config', (route) =>
+        route.fulfill({ status: 500, json: { error: 'Internal Server Error' } })
+      );
+      await page.route('**/api/csrf-token', (route) =>
+        route.fulfill({ status: 200, json: { token: 'tok' } })
+      );
+
+      await page.goto('/admin/bots');
+      await page.waitForTimeout(3000);
+
+      await expect(page.locator('body')).toBeVisible();
+      const bodyText = (await page.locator('body').textContent()) || '';
+      expect(bodyText.length).toBeGreaterThan(10);
+    });
+
+    test('handles 503 Service Unavailable gracefully', async ({ page }) => {
+      await page.route('**/api/**', (route) =>
+        route.fulfill({ status: 503, json: { error: 'Service Unavailable' } })
+      );
+
+      await page.goto('/admin/overview');
+      await page.waitForTimeout(3000);
+
+      await expect(page.locator('body')).toBeVisible();
+      const bodyText = (await page.locator('body').textContent()) || '';
+      expect(bodyText.length).toBeGreaterThan(10);
+    });
+
+    test('intermittent 502 does not permanently break the page', async ({ page }) => {
+      let callCount = 0;
+      await page.route('**/api/config', async (route) => {
+        callCount++;
+        if (callCount === 1) {
+          await route.fulfill({ status: 502, json: { error: 'Bad Gateway' } });
+        } else {
+          await route.fulfill({
+            status: 200,
+            json: {
+              bots: [{ id: 'b1', name: 'Resilient Bot', provider: 'discord', status: 'running' }],
+            },
+          });
+        }
+      });
+      await page.route('**/api/csrf-token', (route) =>
+        route.fulfill({ status: 200, json: { token: 'tok' } })
+      );
+
+      await page.goto('/admin/bots');
+      await page.waitForTimeout(4000);
+
+      await page.reload();
+      await page.waitForTimeout(3000);
+
+      await expect(page.locator('body')).toBeVisible();
+    });
+  });
+});

--- a/tests/e2e/visual-regression.spec.ts
+++ b/tests/e2e/visual-regression.spec.ts
@@ -1,0 +1,159 @@
+import { expect, test } from '@playwright/test';
+import { setupAuth, waitForPageReady } from './test-utils';
+
+/**
+ * Visual Regression Tests
+ *
+ * Uses Playwright's built-in toHaveScreenshot() to detect unintended UI changes.
+ * On first run, baseline screenshots are generated in tests/e2e/visual-regression.spec.ts-snapshots/.
+ * Subsequent runs compare against baselines and fail on pixel drift beyond threshold.
+ *
+ * Update baselines: npx playwright test visual-regression --update-snapshots
+ */
+
+const CRITICAL_PAGES = [
+  { path: '/admin/overview', name: 'dashboard' },
+  { path: '/admin/bots', name: 'bots-list' },
+  { path: '/admin/providers/llm', name: 'llm-providers' },
+  { path: '/admin/providers/message', name: 'message-providers' },
+  { path: '/admin/guards', name: 'guards' },
+  { path: '/admin/settings', name: 'settings' },
+  { path: '/admin/monitoring', name: 'monitoring' },
+  { path: '/admin/personas', name: 'personas' },
+];
+
+test.describe('Visual Regression', () => {
+  test.setTimeout(120000);
+
+  test.beforeEach(async ({ page }) => {
+    await setupAuth(page);
+
+    await page.route('**/api/health/detailed', (route) =>
+      route.fulfill({ status: 200, json: { status: 'healthy', uptime: 86400 } })
+    );
+    await page.route('**/api/config', (route) =>
+      route.fulfill({
+        status: 200,
+        json: {
+          bots: [
+            {
+              id: 'vr-bot-1',
+              name: 'Visual Bot',
+              provider: 'discord',
+              status: 'running',
+              connected: true,
+              messageCount: 10,
+              errorCount: 0,
+            },
+          ],
+        },
+      })
+    );
+    await page.route('**/api/personas', (route) =>
+      route.fulfill({
+        status: 200,
+        json: [{ id: 'p1', name: 'Default Persona', description: 'A test persona' }],
+      })
+    );
+    await page.route('**/api/guards', (route) =>
+      route.fulfill({
+        status: 200,
+        json: { guards: [{ id: 'g1', name: 'Rate Limiter', enabled: true }] },
+      })
+    );
+    await page.route('**/api/admin/llm-profiles', (route) =>
+      route.fulfill({
+        status: 200,
+        json: [{ id: 'llm1', name: 'OpenAI', provider: 'openai', model: 'gpt-4' }],
+      })
+    );
+    await page.route('**/api/config/llm-status', (route) =>
+      route.fulfill({
+        status: 200,
+        json: {
+          defaultConfigured: true,
+          defaultProviders: [],
+          botsMissingLlmProvider: [],
+          hasMissing: false,
+        },
+      })
+    );
+    await page.route('**/api/config/global', (route) => route.fulfill({ status: 200, json: {} }));
+    await page.route('**/api/csrf-token', (route) =>
+      route.fulfill({ status: 200, json: { token: 'vr-csrf' } })
+    );
+    await page.route('**/api/health', (route) =>
+      route.fulfill({ status: 200, json: { status: 'ok' } })
+    );
+    await page.route('**/api/dashboard/api/status', (route) =>
+      route.fulfill({ status: 200, json: { bots: [], uptime: 100 } })
+    );
+    await page.route('**/api/demo/status', (route) =>
+      route.fulfill({ status: 200, json: { active: false } })
+    );
+    await page.route('**/api/monitoring/**', (route) =>
+      route.fulfill({ status: 200, json: { metrics: [], events: [] } })
+    );
+    await page.route('**/api/message-providers', (route) =>
+      route.fulfill({
+        status: 200,
+        json: [{ id: 'mp1', name: 'Discord', type: 'discord', status: 'connected' }],
+      })
+    );
+  });
+
+  for (const { path, name } of CRITICAL_PAGES) {
+    test(`${name} page has no visual regression`, async ({ page }) => {
+      await page.goto(path);
+      await waitForPageReady(page);
+
+      // Mask dynamic content to reduce flakiness
+      await page.evaluate(() => {
+        document
+          .querySelectorAll('time, [data-testid*="timestamp"], [class*="uptime"]')
+          .forEach((el) => {
+            (el as HTMLElement).style.visibility = 'hidden';
+          });
+      });
+
+      await expect(page).toHaveScreenshot(`${name}.png`, {
+        maxDiffPixelRatio: 0.01,
+        animations: 'disabled',
+        mask: [page.locator('[class*="spinner"], [class*="loading"]')],
+      });
+    });
+  }
+
+  test('responsive layout - mobile viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('/admin/overview');
+    await waitForPageReady(page);
+
+    await expect(page).toHaveScreenshot('dashboard-mobile.png', {
+      maxDiffPixelRatio: 0.01,
+      animations: 'disabled',
+    });
+  });
+
+  test('responsive layout - tablet viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 768, height: 1024 });
+    await page.goto('/admin/overview');
+    await waitForPageReady(page);
+
+    await expect(page).toHaveScreenshot('dashboard-tablet.png', {
+      maxDiffPixelRatio: 0.01,
+      animations: 'disabled',
+    });
+  });
+
+  test('dark mode toggle visual consistency', async ({ page }) => {
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await page.goto('/admin/overview');
+    await waitForPageReady(page);
+
+    await expect(page).toHaveScreenshot('dashboard-dark.png', {
+      maxDiffPixelRatio: 0.01,
+      animations: 'disabled',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds three new E2E test suites that verify UI runtime behavior and resilience across network conditions, visual consistency, and multi-tab scenarios.

### Visual Regression
- Screenshot-based testing for all critical pages using Playwright's `toHaveScreenshot()`
- 1% pixel diff threshold to catch unintended UI changes
- Covers: dashboard, bots, providers, guards, settings, monitoring, personas
- Includes responsive layouts (mobile 375x812, tablet 768x1024) and dark mode

### Network Resilience  
- Verifies graceful degradation under adverse network conditions:
  - **Slow responses**: 3-5s latency with loading states
  - **Timeouts/aborts**: hung connections and connection failures
  - **Offline mode**: network drop and recovery
  - **Server errors**: 500, 502, 503 responses
- Ensures UI remains interactive and doesn't crash

### Multi-Tab Concurrent Sessions
- Tests session isolation across browser contexts:
  - Independent auth state between contexts
  - Mutations in one tab visible after refresh in another
  - Concurrent navigation without state corruption
  - Session expiry in one context doesn't break the other

## Test Infrastructure Only
- No production code changes
- All tests use mocked API endpoints for deterministic behavior
- ~630 lines of new test coverage

## Test Plan
```bash
# Run all three suites
npx playwright test visual-regression network-resilience multi-tab-sessions

# Update visual baselines (if needed)
npx playwright test visual-regression --update-snapshots
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)