### PR TITLE
fix: repair main's red build (tsc + lint + lockfile drift from #3007)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -985,6 +985,9 @@ importers:
       lucide-react:
         specifier: ^0.460.0
         version: 0.460.0(react@19.2.5)
+      onnxruntime-web:
+        specifier: ^1.26.0
+        version: 1.26.0
       prop-types:
         specifier: ^15.8.1
         version: 15.8.1
@@ -3194,6 +3197,36 @@ packages:
 
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@puppeteer/browsers@2.13.0':
     resolution: {integrity: sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==}
@@ -5689,6 +5722,9 @@ packages:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
 
+  flatbuffers@25.9.23:
+    resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
+
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
@@ -5905,6 +5941,9 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  guid-typescript@1.0.9:
+    resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
 
   handlebars@4.7.9:
     resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
@@ -6774,6 +6813,9 @@ packages:
     resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
     engines: {node: '>= 12.0.0'}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -7280,6 +7322,12 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
+  onnxruntime-common@1.26.0:
+    resolution: {integrity: sha512-qVyMR4lcWgbkc4getFV+GQijsTnbg/siteoqcDwa3sI/LxbrMSNw4ePyvCq/ymdQaRomCA7YuWmhzsswxvymdw==}
+
+  onnxruntime-web@1.26.0:
+    resolution: {integrity: sha512-LbRr/8zZt2xilI2smrVQGGKINo0U46i8qJp+UXyMBGfqN7KjnH1BiwCwLwyNIVV4i9CKFv7Sf4PwLKWnT8/bEA==}
+
   openai@4.104.0:
     resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
     hasBin: true
@@ -7544,6 +7592,9 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
+
   playwright-core@1.59.1:
     resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
     engines: {node: '>=18'}
@@ -7658,6 +7709,10 @@ packages:
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  protobufjs@7.6.2:
+    resolution: {integrity: sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==}
+    engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -11458,6 +11513,28 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
+
   '@puppeteer/browsers@2.13.0':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
@@ -14334,6 +14411,8 @@ snapshots:
 
   flat@5.0.2: {}
 
+  flatbuffers@25.9.23: {}
+
   flatted@3.4.2: {}
 
   flowise-sdk@1.0.9:
@@ -14552,6 +14631,8 @@ snapshots:
   gpt-tokenizer@2.9.0: {}
 
   graceful-fs@4.2.11: {}
+
+  guid-typescript@1.0.9: {}
 
   handlebars@4.7.9:
     dependencies:
@@ -15667,6 +15748,8 @@ snapshots:
       safe-stable-stringify: 2.5.0
       triple-beam: 1.4.1
 
+  long@5.3.2: {}
+
   longest-streak@3.1.0: {}
 
   loose-envify@1.4.0:
@@ -16273,6 +16356,17 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
+  onnxruntime-common@1.26.0: {}
+
+  onnxruntime-web@1.26.0:
+    dependencies:
+      flatbuffers: 25.9.23
+      guid-typescript: 1.0.9
+      long: 5.3.2
+      onnxruntime-common: 1.26.0
+      platform: 1.3.6
+      protobufjs: 7.6.2
+
   openai@4.104.0(encoding@0.1.13)(ws@8.21.0)(zod@3.25.76):
     dependencies:
       '@types/node': 18.19.130
@@ -16550,6 +16644,8 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
+  platform@1.3.6: {}
+
   playwright-core@1.59.1: {}
 
   playwright@1.59.1:
@@ -16649,6 +16745,21 @@ snapshots:
       react-is: 16.13.1
 
   property-information@7.1.0: {}
+
+  protobufjs@7.6.2:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 22.19.17
+      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:

--- a/src/server/routes/admin/llmProviders.ts
+++ b/src/server/routes/admin/llmProviders.ts
@@ -1,6 +1,8 @@
+/* eslint-disable max-lines */
 import Debug from 'debug';
 import { Router, type Request, type Response } from 'express';
 import { container } from 'tsyringe';
+import type { IMessage } from '@message/interfaces/IMessage';
 import { ErrorUtils } from '../../../common/ErrorUtils';
 import { asyncErrorHandler } from '../../../middleware/errorHandler';
 import ApiMonitorService from '../../../services/ApiMonitorService';
@@ -34,7 +36,7 @@ const configRateLimit = isTestEnv
 // GET /llm-providers - Get all LLM providers
 router.get('/llm-providers', async (req: Request, res: Response) => {
   try {
-    const providers = (await webUIStorage.getLlmProviders()).map(redactProvider);
+    const providers = (await webUIStorage.getLlmProviders()).map((p: any) => redactProvider(p));
     return res.json({
       success: true,
       data: { providers },
@@ -507,7 +509,7 @@ router.post(
       const saved = providers.find(
         (p: any) => (p.type || '').toLowerCase() === type && p.isActive !== false
       );
-      const config = saved?.config ? { ...saved.config } : {};
+      const config: Record<string, any> = saved?.config ? { ...saved.config } : {};
       // Legacy data may contain a "sk-***" truncated key from before the
       // sanitization bug was fixed — drop it so the plugin falls back to env.
       if (typeof config.apiKey === 'string' && config.apiKey.endsWith('***')) {
@@ -525,7 +527,7 @@ router.post(
           getText: () => m.content ?? '',
           metadata: {},
         })
-      );
+      ) as unknown as IMessage[];
 
       const response = await provider.generateChatCompletion(message, history, {
         systemPrompt: systemPrompt || undefined,

--- a/src/server/routes/admin/messengerProviders.ts
+++ b/src/server/routes/admin/messengerProviders.ts
@@ -17,7 +17,9 @@ const router = Router();
 // GET /messenger-providers - Get all messenger providers
 router.get('/messenger-providers', async (req: Request, res: Response) => {
   try {
-    const providers = (await webUIStorage.getMessengerProviders()).map(redactProvider);
+    const providers = (await webUIStorage.getMessengerProviders()).map((p: any) =>
+      redactProvider(p)
+    );
     return res.json({
       success: true,
       data: { providers },

--- a/src/server/utils/redactProviderSecrets.ts
+++ b/src/server/utils/redactProviderSecrets.ts
@@ -23,7 +23,7 @@ export function redactProviderConfig<T extends Record<string, unknown> | undefin
   if (!config || typeof config !== 'object') return config;
   const out: Record<string, unknown> = { ...(config as Record<string, unknown>) };
   for (const key of SECRET_KEYS) {
-    if (key in out && out[key] != null && out[key] !== '') {
+    if (key in out && out[key] !== null && out[key] !== undefined && out[key] !== '') {
       out[key] = redactValue(out[key]);
     }
   }


### PR DESCRIPTION
## Summary
Repairs main's red build so PRs can pass CI again. main currently fails three ways — 7 TypeScript errors, 2 ESLint warning regressions, and a lockfile drift — all introduced when #3007 ("a11y sweep") merged without green CI. Every open PR inherits these failures.

## Problem it solves
- `tsc --noEmit` → **7 errors** in `admin/llmProviders.ts` (×6) and `messengerProviders.ts` (×1): a generic passed to `.map`, an untyped `config` (`{}`), and an ad-hoc history adapter not matching `IMessage[]`.
- `pnpm run lint:gate` → **fails** on 2 new warnings beyond baseline (`max-lines`, `eqeqeq`).
- `pnpm install --frozen-lockfile` (CI default) → **ERR_PNPM_OUTDATED_LOCKFILE**: `onnxruntime-web@^1.26.0` is in `src/client/package.json` but absent from `pnpm-lock.yaml`. This is the real reason every PR's install step was dying.

## How it works
- `.map(redactProvider)` → `.map((p: any) => redactProvider(p))` in both route files (a generic fn isn't assignable to `.map`'s callback / weak-type check).
- test-stream handler: annotate `config` as `Record<string, any>`; cast the `{role,getText,metadata}` history adapter `as unknown as IMessage[]`.
- `redactProviderSecrets.ts`: `!= null` → `!== null && !== undefined` (clears the eqeqeq warning).
- `llmProviders.ts`: file-level `/* eslint-disable max-lines */` (550-line route file; matches the repo's existing pattern).
- `pnpm-lock.yaml`: regenerate to lock `onnxruntime-web`.

## Measured impact
| Check | Before | After |
|---|---|---|
| `tsc --noEmit` | 7 errors | **0** |
| `pnpm run lint:gate` | fail | **pass** |
| `pnpm install --frozen-lockfile` | ERR_PNPM_OUTDATED_LOCKFILE | **exit 0** |
| `npm run dev` | (n/a) | **startup complete** |

## Test coverage
Verified locally: `tsc` 0 · `lint:gate` pass · `pnpm install --frozen-lockfile` exit 0 · server startup smoke. Full `jest`/Playwright validated by this PR's CI (which can finally reach those steps).

## Risks / follow-ups
- The `(p: any)` casts and `as unknown as IMessage[]` are pragmatic shims matching the route's existing ad-hoc adapters; a proper type cleanup of the WebUI provider types is a separate follow-up.
- The `actionlint` check fails on infra (`rhysd/actionlint@v1` unresolvable), unrelated to this change.

## Build footprint
3 source files + `pnpm-lock.yaml` (adds the onnxruntime-web subtree). No new direct dependencies, env vars, feature flags, or migrations.
