### PR TITLE
fix(client): restore xssSanitizer helpers dropped by #3010 (fixes unit-tests-frontend)

### DIFF
--- a/src/client/src/utils/xssSanitizer.ts
+++ b/src/client/src/utils/xssSanitizer.ts
@@ -1,7 +1,87 @@
-export {
+/**
+ * @fileoverview Client-side XSS sanitization helpers.
+ * The core sanitizers (sanitizeHTML / sanitizeText / sanitizeURL / sanitizeObject)
+ * live in @hivemind/shared-types and are re-exported here; the client-specific
+ * helpers below (stripHTML, ContextSanitizers, useSanitizedInput, safeHTMLTemplate)
+ * build on them. (Restored after #3010's consolidation dropped them.)
+ */
+import DOMPurify from 'dompurify';
+import {
   sanitizeHTML,
   sanitizeText,
   sanitizeURL,
   sanitizeObject,
-  SANITIZE_CONFIG
+  SANITIZE_CONFIG,
 } from '@hivemind/shared-types';
+
+export { sanitizeHTML, sanitizeText, sanitizeURL, sanitizeObject, SANITIZE_CONFIG };
+
+// Initialize DOMPurify for both browser and Node/JSDOM environments
+const sanitizer = typeof DOMPurify === 'function' ? (DOMPurify as any)(window) : DOMPurify;
+
+/**
+ * Strip all HTML tags from a string, returning plain text.
+ */
+export function stripHTML(html: string): string {
+  if (!html || typeof html !== 'string') {
+    return '';
+  }
+  return sanitizer.sanitize(html, { ALLOWED_TAGS: [] });
+}
+
+/**
+ * Context-specific sanitizers for embedding untrusted input safely.
+ */
+export const ContextSanitizers = {
+  attribute: (value: string): string => sanitizeText(value).replace(/"/g, '&quot;'),
+  javascript: (value: string): string =>
+    value
+      .replace(/\\/g, '\\\\')
+      .replace(/'/g, "\\'")
+      .replace(/"/g, '\\"')
+      .replace(/</g, '\\x3C')
+      .replace(/>/g, '\\x3E')
+      .replace(/&/g, '\\x26')
+      .replace(/\n/g, '\\n')
+      .replace(/\r/g, '\\r'),
+  css: (value: string): string => value.replace(/[^a-zA-Z0-9\-_]/g, ''),
+  urlParam: (value: string): string => encodeURIComponent(value),
+  json: (value: string): string => JSON.stringify(value).slice(1, -1),
+};
+
+/**
+ * Sanitize user input for a given context (html | text | url).
+ */
+export function useSanitizedInput(input: string, type: 'html' | 'text' | 'url' = 'text'): string {
+  switch (type) {
+    case 'html':
+      return sanitizeHTML(input);
+    case 'url':
+      return sanitizeURL(input);
+    case 'text':
+    default:
+      return sanitizeText(input);
+  }
+}
+
+/**
+ * Tagged-template helper that escapes all interpolations.
+ */
+export function safeHTMLTemplate(strings: TemplateStringsArray, ...values: any[]): string {
+  return strings.reduce((result, string, i) => {
+    const value = values[i] !== undefined ? values[i] : '';
+    const sanitizedValue = typeof value === 'string' ? sanitizeText(value) : JSON.stringify(value);
+    return result + string + sanitizedValue;
+  }, '');
+}
+
+export default {
+  sanitizeHTML,
+  sanitizeText,
+  sanitizeURL,
+  sanitizeObject,
+  stripHTML,
+  ContextSanitizers,
+  useSanitizedInput,
+  safeHTMLTemplate,
+};

--- a/src/client/vite.config.ts
+++ b/src/client/vite.config.ts
@@ -35,6 +35,8 @@ export default defineConfig({
       '@src': './src',
       '@config': '../config',
       '@webui': './webui/src',
+      // shared-types has no built dist; resolve it to source for vite/frontend
+      '@hivemind/shared-types': '../../packages/shared-types/src/index.ts',
     },
   },
   build: {

--- a/src/client/vitest.config.ts
+++ b/src/client/vitest.config.ts
@@ -1,8 +1,15 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      // shared-types has no built dist; resolve it to source so vitest can load it
+      '@hivemind/shared-types': path.resolve(__dirname, '../../packages/shared-types/src/index.ts'),
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
Restores 4 client XSS-sanitizer helpers that #3010's consolidation dropped, fixing the red `unit-tests-frontend` check (11 broken tests + a vite module-resolution failure).

## Problem it solves
#3010 replaced `src/client/src/utils/xssSanitizer.ts` with a 5-function re-export from `@hivemind/shared-types`. That (a) broke vite/vitest resolution — shared-types ships **no `dist`**, so the bare import is unresolvable in the frontend (the backend only works via tsx's src fallback); and (b) **dropped 4 client-only helpers** (`stripHTML`, `ContextSanitizers`, `useSanitizedInput`, `safeHTMLTemplate`), failing 11 tests.

## How it works
- Add a vite + vitest `resolve.alias`: `@hivemind/shared-types` → `packages/shared-types/src/index.ts`.
- Re-export the 5 core sanitizers from shared-types **and** restore the 4 client helpers (they build on the core sanitizers; `stripHTML` uses DOMPurify directly).

## Measured impact
`unit-tests-frontend`: **11 failed / 519 passed → 0 failed / 530 passed** (4 pre-existing skips). tsc 0, lint:gate pass.

## Test coverage
Client vitest suite 530 passed / 4 skipped (`xssSanitizer` 27/27); `tsc --noEmit` 0; `lint:gate` pass. The helpers are only consumed by tests today (no app-code usage), so no runtime behavior change.

## Risks / follow-ups
Low — security-relevant code restored to its original test-passing form. Follow-up: these helpers have no app-code consumers, so a future cleanup could instead delete them + their tests if intentionally dead.

## Build footprint
3 files (`xssSanitizer.ts`, `vite.config.ts`, `vitest.config.ts`). No new deps (dompurify already present), no env vars or migrations.
