### PR TITLE
fix(client): add missing PageHeader import in PersonasPage

### DIFF
--- a/src/client/src/pages/PersonasPage/index.tsx
+++ b/src/client/src/pages/PersonasPage/index.tsx
@@ -2,6 +2,7 @@ import { Copy, Edit2, Settings, Trash2, Users } from 'lucide-react';
 import React, { useCallback, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Alert } from '../../components/DaisyUI/Alert';
+import PageHeader from '../../components/DaisyUI/PageHeader';
 import { Badge } from '../../components/DaisyUI/Badge';
 import { SkeletonPage } from '../../components/DaisyUI/Skeleton';
 import { useSuccessToast, useErrorToast, useInfoToast } from '../../components/DaisyUI/ToastNotification';


### PR DESCRIPTION
## Summary
Fixes the one failing WebUI page found in the comprehensive fan-out check.

## Problem it solves
`/admin/personas` crashed with `ReferenceError: PageHeader is not defined` and rendered the React error boundary. PR #3010 deleted `MCPToolsPage/components/PageHeader.tsx` (a duplicate) but `PersonasPage` referenced it without importing it — leaving a dangling undefined runtime reference.

## How it works
Add `import PageHeader from '../../components/DaisyUI/PageHeader';` — the canonical `PageHeader` component that already exists in the DaisyUI library.

## Measured impact
| Page | Before | After |
|---|---|---|
| /admin/personas | ❌ React error boundary | ✅ h1='Personas', 0 errors |
| All other 34 routes | ✅ | ✅ |

**35/35 WebUI pages now pass.**

## Test coverage
Playwright-verified locally: server starts, auth injected, /admin/personas renders with h1='Personas' and zero console errors. tsc 0, lint:gate pass.

## Risks / follow-ups
None — single import line, no logic change.

## Build footprint
1 file. No deps, env vars, or migrations.