### PR TITLE
💎 Hone: UX Engineering Refactor (Accessibility, Semantics, and Focus Integrity)

### DIFF
--- a/src/client/src/components/DaisyUI/Button.tsx
+++ b/src/client/src/components/DaisyUI/Button.tsx
@@ -69,7 +69,7 @@ export const Button = memo(({
     }
   };
 
-  const baseClasses = 'btn';
+  const baseClasses = 'btn focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none';
   const variantClass = getVariantClass();
   const sizeClass = getSizeClass();
   const disabledClass = disabled || loading ? 'btn-disabled' : '';

--- a/src/client/src/components/DaisyUI/Input.tsx
+++ b/src/client/src/components/DaisyUI/Input.tsx
@@ -67,7 +67,7 @@ export const Input = memo(forwardRef<HTMLInputElement, InputProps>(
     const appliedVariant = error ? 'error' : variant;
 
     const inputClasses = twMerge(
-      'input w-full',
+      'input w-full focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:outline-none',
       bordered && 'input-bordered',
       ghost && 'input-ghost',
       appliedVariant && variantClasses[appliedVariant],

--- a/src/client/src/components/DaisyUI/List.tsx
+++ b/src/client/src/components/DaisyUI/List.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
-export interface ListRowProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface ListRowProps extends React.HTMLAttributes<HTMLLIElement> {
   /** Additional CSS classes */
   className?: string;
   children?: React.ReactNode;
@@ -15,9 +15,9 @@ export const ListRow: React.FC<ListRowProps> = React.memo(({
   const classes = classNames('list-row', className);
 
   return (
-    <div className={classes} {...props}>
+    <li className={classes} role="listitem" {...props}>
       {children}
-    </div>
+    </li>
   );
 });
 
@@ -65,7 +65,7 @@ export const ListColWrap: React.FC<ListColWrapProps> = React.memo(({
 
 ListColWrap.displayName = 'ListColWrap';
 
-export interface ListProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface ListProps extends React.HTMLAttributes<HTMLUListElement> {
   /** Additional CSS classes */
   className?: string;
   children?: React.ReactNode;
@@ -79,9 +79,9 @@ const List: React.FC<ListProps> = React.memo(({
   const classes = classNames('list', className);
 
   return (
-    <div className={classes} {...props}>
+    <ul className={classes} role="list" {...props}>
       {children}
-    </div>
+    </ul>
   );
 });
 

--- a/src/client/src/components/DaisyUI/Modal.tsx
+++ b/src/client/src/components/DaisyUI/Modal.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { LoadingSpinner } from './Loading';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 
 export interface ModalAction {
   label: string;
@@ -48,6 +49,9 @@ const Modal: React.FC<ModalProps> = ({
   className = '',
 }) => {
   const modalRef = useRef<HTMLDialogElement>(null);
+  const closeBtnRef = useRef<HTMLButtonElement>(null);
+
+  useFocusTrap(isOpen, modalRef, closeBtnRef);
 
   useEffect(() => {
     const modal = modalRef.current;
@@ -125,6 +129,7 @@ const Modal: React.FC<ModalProps> = ({
             {title && <h3 id="modal-dialog-title" className="font-bold text-lg">{title}</h3>}
             {showCloseButton && closable && (
               <button
+                ref={closeBtnRef}
                 className="btn btn-sm btn-circle btn-ghost"
                 onClick={onClose}
                 aria-label="Close modal"
@@ -371,9 +376,6 @@ export interface DetailDrawerProps {
   width?: string;
 }
 
-const FOCUSABLE_SELECTOR =
-  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
-
 export const DetailDrawer: React.FC<DetailDrawerProps> = ({
   isOpen,
   onClose,
@@ -383,20 +385,10 @@ export const DetailDrawer: React.FC<DetailDrawerProps> = ({
 }) => {
   const drawerRef = React.useRef<HTMLDivElement | null>(null);
   const closeButtonRef = React.useRef<HTMLButtonElement | null>(null);
-  const previousFocusRef = React.useRef<HTMLElement | null>(null);
 
-  // Capture the element that had focus before opening; restore on close.
-  React.useEffect(() => {
-    if (isOpen) {
-      previousFocusRef.current = document.activeElement as HTMLElement | null;
-      requestAnimationFrame(() => closeButtonRef.current?.focus());
-    } else if (previousFocusRef.current) {
-      previousFocusRef.current.focus();
-      previousFocusRef.current = null;
-    }
-  }, [isOpen]);
+  useFocusTrap(isOpen, drawerRef, closeButtonRef);
 
-  // ESC closes; Tab/Shift+Tab cycles within the drawer (focus trap).
+  // ESC closes drawer.
   React.useEffect(() => {
     if (!isOpen) return;
 
@@ -405,24 +397,6 @@ export const DetailDrawer: React.FC<DetailDrawerProps> = ({
         e.preventDefault();
         onClose();
         return;
-      }
-      if (e.key !== 'Tab' || !drawerRef.current) return;
-
-      const focusable = Array.from(
-        drawerRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
-      ).filter((el) => !el.hasAttribute('disabled') && el.offsetParent !== null);
-      if (focusable.length === 0) return;
-
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      const active = document.activeElement as HTMLElement | null;
-
-      if (e.shiftKey && active === first) {
-        e.preventDefault();
-        last.focus();
-      } else if (!e.shiftKey && active === last) {
-        e.preventDefault();
-        first.focus();
       }
     };
 

--- a/src/client/src/components/IntegrationsPanel.tsx
+++ b/src/client/src/components/IntegrationsPanel.tsx
@@ -467,13 +467,13 @@ const IntegrationsPanel: React.FC = () => {
                 if (isAdvanced && !advancedMode) return null;
 
                 return (
-                  <div
+                  <dl
                     key={key}
-                    className="flex justify-between items-center p-2.5 bg-base-100 rounded-lg border border-base-200 shadow-sm"
+                    className="flex justify-between items-center p-2.5 bg-base-100 rounded-lg border border-base-200 shadow-sm m-0"
                   >
-                    <span className="text-[10px] font-mono opacity-60 uppercase truncate mr-2" title={key}>{key}</span>
-                    <span className="font-bold text-xs">{String(value)}</span>
-                  </div>
+                    <dt className="text-[10px] font-mono opacity-60 uppercase truncate mr-2" title={key}>{key}</dt>
+                    <dd className="font-bold text-xs m-0">{String(value)}</dd>
+                  </dl>
                 );
               })}
 

--- a/src/client/src/hooks/useFocusTrap.ts
+++ b/src/client/src/hooks/useFocusTrap.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from 'react';
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export function useFocusTrap(isOpen: boolean, containerRef: React.RefObject<HTMLElement | null>, closeButtonRef?: React.RefObject<HTMLElement | null>) {
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      previousFocusRef.current = document.activeElement as HTMLElement | null;
+      if (closeButtonRef?.current) {
+        requestAnimationFrame(() => closeButtonRef.current?.focus());
+      } else if (containerRef.current) {
+         // Focus first element if no close button provided
+         const focusable = Array.from(
+            containerRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+         ).filter((el) => !el.hasAttribute('disabled') && (el.offsetParent !== null || el.tagName === 'DIALOG'));
+
+         if (focusable.length > 0) {
+            requestAnimationFrame(() => focusable[0].focus());
+         }
+      }
+    } else if (previousFocusRef.current) {
+      previousFocusRef.current.focus();
+      previousFocusRef.current = null;
+    }
+  }, [isOpen, containerRef, closeButtonRef]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab' || !containerRef.current) return;
+
+      const focusable = Array.from(
+        containerRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      ).filter((el) => !el.hasAttribute('disabled') && (el.offsetParent !== null || el.tagName === 'DIALOG'));
+
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [isOpen, containerRef]);
+}


### PR DESCRIPTION
This PR addresses 3 significant UX and accessibility refactors according to the "Hone" protocol:

1. **Standardized Focus Trapping**: Created a reusable `useFocusTrap` hook and implemented it within `Modal.tsx` (`Modal` and `DetailDrawer` components). This resolves an issue with ad-hoc modal and drawer focus traps and ensures all elements inside these components are accessible and correctly cycle focus natively.
2. **Standardized Keyboard Visibility**: Enhanced `Button.tsx` and `Input.tsx` primitives to include robust keyboard visibility out-of-the-box by integrating Tailwind's `focus-visible:ring-2 focus-visible:ring-primary...` utility classes directly into `baseClasses` and `inputClasses`.
3. **Semantic Data Views**: Replaced non-semantic div-soup with correct, accessible semantic HTML5 tags:
   - Within `List.tsx`, `List` now correctly uses `<ul role="list">` and `ListRow` uses `<li role="listitem">`.
   - Within `IntegrationsPanel.tsx`, the LLM global configurations mapped grid was updated to utilize a description list structure (`<dl>`, `<dt>`, `<dd>`) for configuration pair rendering.

### Verification:
* Verified that formatting and linting succeeded (`pnpm run lint` and `pnpm run format` rules).
* Executed the entire frontend test suite locally with `pnpm -w run test:only:frontend`, passing all **534 tests**.
* Documented findings inside `.jules/hone.md`.

---
*PR created automatically by Jules for task [6207818754549174803](https://jules.google.com/task/6207818754549174803) started by @matthewhand*