### PR TITLE
feat(llm-openwebui): preserve history roles and honor per-bot config in create()

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,7 +51,7 @@ Small, verified gaps where the surrounding feature is otherwise done.
   - [x] Mattermost: hot `addBot` into the running service (currently requires re-init)
   - [ ] Channel routing: extend `pickBestChannel` beyond Discord; decide default for `MESSAGE_CHANNEL_ROUTER_ENABLED`
 - [ ] **LLM provider depth**
-  - [ ] OpenWebUI: preserve assistant roles in history (all turns sent as `user` today); honor per-bot config in `create()`
+  - [x] OpenWebUI: preserve assistant roles in history (all turns sent as `user` today); honor per-bot config in `create()`
   - [ ] OpenWebUI knowledge-file RAG: per-bot/runtime knowledge upload (single startup file today)
   - [ ] Streaming for providers beyond OpenAI (only `llm-openai` implements `generateStreamingChatCompletion`)
 - [ ] **Memory depth**

--- a/packages/llm-openwebui/src/index.ts
+++ b/packages/llm-openwebui/src/index.ts
@@ -1,13 +1,36 @@
 import type { PluginManifest } from '../../../src/plugins/PluginLoader';
-import { openWebUIProvider } from './openWebUIProvider';
+import { OpenWebUIProvider, type OpenWebUIProviderConfig } from './openWebUIProvider';
 
-export { openWebUIProvider } from './openWebUIProvider';
+export {
+  openWebUIProvider,
+  OpenWebUIProvider,
+  type OpenWebUIProviderConfig,
+} from './openWebUIProvider';
 export { generateChatCompletion } from './runInference';
 export { schema } from './schema';
 
-/** Standard factory — preferred entry point for PluginLoader */
-export function create(_config?: any): typeof openWebUIProvider {
-  return openWebUIProvider; // stateless singleton
+/**
+ * Standard factory — preferred entry point for PluginLoader.
+ * Returns a fresh provider per call so each bot keeps its own config
+ * (apiUrl / authHeader / apiKey / model) isolated from the process-wide
+ * `OPEN_WEBUI_*` defaults.
+ *
+ * The PluginLoader passes config in two shapes: the plain provider keys
+ * (`apiUrl`/`apiKey`/`model`) and the raw env-var names from the schema
+ * (`OPEN_WEBUI_API_URL`, `OPEN_WEBUI_API_KEY`, `OPEN_WEBUI_MODEL`). Both
+ * are honored.
+ */
+export function create(
+  config?: (OpenWebUIProviderConfig & Record<string, unknown>) | null
+): OpenWebUIProvider {
+  const c = (config ?? {}) as Record<string, unknown>;
+  return new OpenWebUIProvider({
+    apiUrl: (c.apiUrl as string) ?? (c.OPEN_WEBUI_API_URL as string),
+    authHeader: c.authHeader as string,
+    apiKey: (c.apiKey as string) ?? (c.OPEN_WEBUI_API_KEY as string),
+    model: (c.model as string) ?? (c.OPEN_WEBUI_MODEL as string),
+    embeddingModel: (c.embeddingModel as string) ?? (c.OPEN_WEBUI_EMBEDDING_MODEL as string),
+  });
 }
 
 export const manifest: PluginManifest = {

--- a/packages/llm-openwebui/src/openWebUIProvider.test.ts
+++ b/packages/llm-openwebui/src/openWebUIProvider.test.ts
@@ -1,5 +1,6 @@
-import { manifest } from './index';
-import { openWebUIProvider } from './openWebUIProvider';
+import type { IMessage } from '@hivemind/shared-types';
+import { create, manifest } from './index';
+import { mapHistoryRole, openWebUIProvider } from './openWebUIProvider';
 
 // Mock DNS so isSafeUrl always resolves to a public IP in tests
 jest.mock('dns', () => ({
@@ -41,6 +42,21 @@ function mockFetch(body: unknown, status = 200) {
       headers: { 'content-type': 'application/json' },
     })
   );
+}
+
+function makeMsg(text: string, role: string, fromBot = false): IMessage {
+  return {
+    role,
+    content: text,
+    getText: () => text,
+    isFromBot: () => fromBot,
+  } as unknown as IMessage;
+}
+
+function lastFetchCall() {
+  const calls = (global.fetch as jest.Mock).mock.calls;
+  const [url, init] = calls[calls.length - 1];
+  return { url: url as string, init: init as RequestInit, body: JSON.parse(init.body as string) };
 }
 
 beforeEach(() => jest.clearAllMocks());
@@ -106,5 +122,131 @@ describe('openWebUIProvider', () => {
     await expect(openWebUIProvider.generateEmbedding!('embed me')).rejects.toThrow(
       'Embedding generation failed'
     );
+  });
+});
+
+describe('history role mapping', () => {
+  it('mapHistoryRole preserves assistant and system roles', () => {
+    expect(mapHistoryRole(makeMsg('hi', 'assistant'))).toBe('assistant');
+    expect(mapHistoryRole(makeMsg('rules', 'system'))).toBe('system');
+  });
+
+  it('mapHistoryRole maps bot-authored messages to assistant even when role is user', () => {
+    expect(mapHistoryRole(makeMsg('bot said this', 'user', true))).toBe('assistant');
+  });
+
+  it('mapHistoryRole defaults human and unknown roles to user', () => {
+    expect(mapHistoryRole(makeMsg('hello', 'user'))).toBe('user');
+    expect(mapHistoryRole(makeMsg('tool output', 'tool'))).toBe('user');
+    expect(mapHistoryRole(makeMsg('weird', ''))).toBe('user');
+  });
+
+  it('mapHistoryRole falls back to user when isFromBot throws', () => {
+    const msg = {
+      role: 'user',
+      getText: () => 'x',
+      isFromBot: () => {
+        throw new Error('boom');
+      },
+    } as unknown as IMessage;
+    expect(mapHistoryRole(msg)).toBe('user');
+  });
+
+  it('generateChatCompletion sends mixed history with correct roles', async () => {
+    mockFetch({ choices: [{ message: { content: 'ok' } }] });
+    const history = [
+      makeMsg('you are helpful', 'system'),
+      makeMsg('hello bot', 'user'),
+      makeMsg('hello human', 'assistant'),
+      makeMsg('platform bot turn', 'user', true),
+    ];
+    await openWebUIProvider.generateChatCompletion('latest question', history);
+
+    const { body } = lastFetchCall();
+    expect(body.messages).toEqual([
+      { role: 'system', content: 'you are helpful' },
+      { role: 'user', content: 'hello bot' },
+      { role: 'assistant', content: 'hello human' },
+      { role: 'assistant', content: 'platform bot turn' },
+      { role: 'user', content: 'latest question' },
+    ]);
+  });
+});
+
+describe('per-bot config via create()', () => {
+  it('uses per-bot apiUrl, apiKey and model when provided', async () => {
+    mockFetch({ choices: [{ message: { content: 'bot reply' } }] });
+    const provider = create({
+      apiUrl: 'https://bot.example.com/api',
+      apiKey: 'bot-key',
+      model: 'bot-model',
+    });
+
+    expect(await provider.generateChatCompletion('hi', [])).toBe('bot reply');
+
+    const { url, init, body } = lastFetchCall();
+    expect(url).toBe('https://bot.example.com/api/chat/completions');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer bot-key');
+    expect(body.model).toBe('bot-model');
+  });
+
+  it('accepts raw schema key names (OPEN_WEBUI_*)', async () => {
+    mockFetch({ choices: [{ message: { content: 'raw reply' } }] });
+    const provider = create({
+      OPEN_WEBUI_API_URL: 'https://raw.example.com/api',
+      OPEN_WEBUI_API_KEY: 'raw-key',
+      OPEN_WEBUI_MODEL: 'raw-model',
+    });
+
+    expect(await provider.generateChatCompletion('hi', [])).toBe('raw reply');
+
+    const { url, init, body } = lastFetchCall();
+    expect(url).toBe('https://raw.example.com/api/chat/completions');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer raw-key');
+    expect(body.model).toBe('raw-model');
+  });
+
+  it('authHeader wins over apiKey', async () => {
+    mockFetch({ choices: [{ message: { content: 'ok' } }] });
+    const provider = create({
+      apiUrl: 'https://bot.example.com/api',
+      authHeader: 'Bearer custom-token',
+      apiKey: 'ignored-key',
+    });
+
+    await provider.generateChatCompletion('hi', []);
+
+    const { init } = lastFetchCall();
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer custom-token');
+  });
+
+  it('falls back to global config when no per-bot overrides are given', async () => {
+    mockFetch({ choices: [{ message: { content: 'global reply' } }] });
+    const provider = create({});
+
+    expect(await provider.generateChatCompletion('hi', [])).toBe('global reply');
+
+    const { url, body } = lastFetchCall();
+    expect(url).toBe('https://openwebui.example.com/chat/completions');
+    expect(body.model).toBe('test-model');
+  });
+
+  it('uses per-bot model for non-chat completions', async () => {
+    mockFetch({ choices: [{ text: 'completion' }] });
+    const provider = create({
+      apiUrl: 'https://bot.example.com/api',
+      apiKey: 'bot-key',
+      model: 'bot-model',
+    });
+
+    expect(await provider.generateCompletion('prompt')).toBe('completion');
+
+    const { url, body } = lastFetchCall();
+    expect(url).toBe('https://bot.example.com/api/completions');
+    expect(body.model).toBe('bot-model');
+  });
+
+  it('returns a fresh provider instance per call', () => {
+    expect(create({ model: 'a' })).not.toBe(create({ model: 'a' }));
   });
 });

--- a/packages/llm-openwebui/src/openWebUIProvider.ts
+++ b/packages/llm-openwebui/src/openWebUIProvider.ts
@@ -5,74 +5,143 @@ import { getSessionKey } from './sessionManager';
 
 const debug = Debug('app:openWebUIProvider');
 
-const model = openWebUIConfig.get('model');
+/**
+ * Per-bot configuration for the OpenWebUI provider.
+ *
+ * Every field is optional; unset fields fall back to the process-wide
+ * convict config (`OPEN_WEBUI_*` env vars).
+ */
+export interface OpenWebUIProviderConfig {
+  /** Per-bot API base URL; falls back to OPEN_WEBUI_API_URL. */
+  apiUrl?: string;
+  /** Full Authorization header value (e.g. "Bearer xyz"); wins over apiKey. */
+  authHeader?: string;
+  /** Per-bot API key (sent as a Bearer token); falls back to OPEN_WEBUI_API_KEY. */
+  apiKey?: string;
+  /** Per-bot chat model; falls back to OPEN_WEBUI_MODEL. */
+  model?: string;
+  /** Per-bot embedding model; falls back to OPEN_WEBUI_EMBEDDING_MODEL. */
+  embeddingModel?: string;
+}
 
 /**
- * Creates an HTTP client with proper authorization headers based on auth method.
- * @returns An http client configured for OpenWebUI API.
+ * Maps an IMessage history entry to an OpenAI-compatible chat role.
+ *
+ * The bot's own messages (role "assistant" or `isFromBot()`) are preserved
+ * as `assistant` turns and system turns pass through, so the model sees a
+ * faithful conversation instead of every turn flattened to `user`.
  */
-async function createOpenWebUIClient() {
-  const apiUrl = openWebUIConfig.get('apiUrl');
-  const authMethod = openWebUIConfig.get('authMethod');
-  const apiKey = openWebUIConfig.get('apiKey');
-
-  // For API key auth, we can create the client directly with the key
-  if (authMethod === 'apiKey' && apiKey) {
-    return http.create(apiUrl, {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${apiKey}`,
-    });
+export function mapHistoryRole(msg: IMessage): 'user' | 'assistant' | 'system' {
+  if (msg.role === 'assistant' || msg.role === 'system') {
+    return msg.role;
   }
-
-  // For password auth, we need to get the session key first
-  const sessionKey = await getSessionKey();
-  return http.create(apiUrl, {
-    'Content-Type': 'application/json',
-    Authorization: `Bearer ${sessionKey}`,
-  });
+  try {
+    if (typeof msg.isFromBot === 'function' && msg.isFromBot()) {
+      return 'assistant';
+    }
+  } catch (error) {
+    debug('isFromBot() threw while mapping history role; defaulting to "user":', error);
+  }
+  return 'user';
 }
 
 /**
  * Provides chat and non-chat completion functionality for OpenWebUI.
- * Supports both password-based and API key authentication.
+ * Supports both password-based and API key authentication, with optional
+ * per-bot overrides for apiUrl / auth / model.
  */
-export const openWebUIProvider: ILlmProvider = {
-  name: 'openwebui',
-  supportsChatCompletion: (): boolean => true,
-  supportsCompletion: (): boolean => true,
+export class OpenWebUIProvider implements ILlmProvider {
+  name = 'openwebui';
+  private config: OpenWebUIProviderConfig;
+
+  constructor(config?: OpenWebUIProviderConfig) {
+    this.config = config || {};
+  }
+
+  supportsChatCompletion(): boolean {
+    return true;
+  }
+
+  supportsCompletion(): boolean {
+    return true;
+  }
+
+  /**
+   * Creates an HTTP client with proper authorization headers.
+   *
+   * Resolution order: per-bot authHeader → per-bot apiKey → global apiKey
+   * (when authMethod is "apiKey") → password session key.
+   */
+  private async createClient() {
+    const apiUrl = this.config.apiUrl || openWebUIConfig.get('apiUrl');
+
+    if (this.config.authHeader) {
+      return http.create(apiUrl, {
+        'Content-Type': 'application/json',
+        Authorization: this.config.authHeader,
+      });
+    }
+
+    const authMethod = openWebUIConfig.get('authMethod');
+    const apiKey =
+      this.config.apiKey || (authMethod === 'apiKey' ? openWebUIConfig.get('apiKey') : '');
+    if (apiKey) {
+      return http.create(apiUrl, {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      });
+    }
+
+    // For password auth, we need to get the session key first
+    const sessionKey = await getSessionKey();
+    return http.create(apiUrl, {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${sessionKey}`,
+    });
+  }
+
+  private resolveModel(metadata?: Record<string, any>): string {
+    return (
+      metadata?.modelOverride ||
+      metadata?.model ||
+      this.config.model ||
+      openWebUIConfig.get('model')
+    );
+  }
 
   async generateChatCompletion(
     userMessage: string,
-    historyMessages: IMessage[] = []
+    historyMessages: IMessage[] = [],
+    metadata?: Record<string, any>
   ): Promise<string> {
     debug('Generating chat completion with OpenWebUI:', { userMessage, historyMessages });
 
-    const client = await createOpenWebUIClient();
+    const client = await this.createClient();
     const messages = [
-      ...historyMessages.map((msg) => ({ role: 'user', content: msg.getText() })),
-      { role: 'user', content: userMessage },
+      ...historyMessages.map((msg) => ({ role: mapHistoryRole(msg), content: msg.getText() })),
+      { role: 'user' as const, content: userMessage },
     ];
 
     try {
       const data = await client.post<{ choices: Array<{ message: { content: string } }> }>(
         '/chat/completions',
-        { model, messages }
+        { model: this.resolveModel(metadata), messages }
       );
       return data.choices[0].message.content;
     } catch (error) {
       debug('Error generating chat completion:', formatError(error));
       throw new Error(`Chat completion failed: ${getErrorMessage(error)}`);
     }
-  },
+  }
 
   async generateCompletion(prompt: string): Promise<string> {
     debug('Generating non-chat completion with OpenWebUI:', { prompt });
 
-    const client = await createOpenWebUIClient();
+    const client = await this.createClient();
 
     try {
       const data = await client.post<{ choices: Array<{ text: string }> }>('/completions', {
-        model,
+        model: this.resolveModel(),
         prompt,
         max_tokens: 100,
       });
@@ -81,7 +150,7 @@ export const openWebUIProvider: ILlmProvider = {
       debug('Error generating non-chat completion:', formatError(error));
       throw new Error(`Non-chat completion failed: ${getErrorMessage(error)}`);
     }
-  },
+  }
 
   /**
    * Generates an embedding vector for the given text using the OpenAI-compatible
@@ -92,8 +161,8 @@ export const openWebUIProvider: ILlmProvider = {
   async generateEmbedding(text: string): Promise<number[]> {
     debug('Generating embedding with OpenWebUI:', { text });
 
-    const client = await createOpenWebUIClient();
-    const embeddingModel = openWebUIConfig.get('embeddingModel');
+    const client = await this.createClient();
+    const embeddingModel = this.config.embeddingModel || openWebUIConfig.get('embeddingModel');
 
     try {
       const data = await client.post<{ data: Array<{ embedding: number[] }> }>('/embeddings', {
@@ -109,8 +178,14 @@ export const openWebUIProvider: ILlmProvider = {
       debug('Error generating embedding:', formatError(error));
       throw new Error(`Embedding generation failed: ${getErrorMessage(error)}`);
     }
-  },
-};
+  }
+}
+
+/**
+ * Default provider instance backed entirely by the process-wide config.
+ * Per-bot instances are created via the package `create()` factory.
+ */
+export const openWebUIProvider = new OpenWebUIProvider();
 
 /**
  * Safely extracts the error message.


### PR DESCRIPTION
## Summary

Implements the ROADMAP "LLM provider depth" item for OpenWebUI:

- **Preserve assistant roles in conversation history.** Previously every history turn was sent to `/chat/completions` as role `user`, so the model never saw its own prior replies as assistant turns. History is now mapped via a new exported `mapHistoryRole()` helper: `assistant`/`system` roles pass through, bot-authored messages (`isFromBot()`) become `assistant`, and everything else (including unknown/`tool` roles) defaults to `user`.
- **Honor per-bot config in the package `create()` factory.** The factory previously ignored its config argument and always returned the env-backed singleton, dropping per-bot `apiUrl`/auth/`model` overrides. The provider is now an `OpenWebUIProvider` class (mirroring the `llm-openai` per-bot config pattern and the `llm-letta` factory): instances resolve `apiUrl`/`authHeader`/`apiKey`/`model`/`embeddingModel` from per-bot config first, falling back to the process-wide `OPEN_WEBUI_*` convict config. `create()` returns a fresh instance per call and accepts both plain keys (`apiUrl`/`apiKey`/`model`) and raw schema env-var names (`OPEN_WEBUI_API_URL`/`OPEN_WEBUI_API_KEY`/`OPEN_WEBUI_MODEL`).

Auth resolution order per request: per-bot `authHeader` → per-bot `apiKey` (Bearer) → global `apiKey` (when `authMethod=apiKey`) → password session key.

The env-backed `openWebUIProvider` singleton export is kept so existing imports (e.g. `taskLlmRouter`) are unaffected. Also ticks the corresponding ROADMAP line.

## Test plan

- `npm test -- openwebui` — 3 suites, **36 tests passed**, including new coverage for:
  - role mapping (assistant/system passthrough, `isFromBot()` → assistant, unknown/tool → user, `isFromBot()` throwing)
  - mixed history sent with correct roles in the request body
  - per-bot `apiUrl`/`apiKey`/`model` override (plain and raw `OPEN_WEBUI_*` key shapes), `authHeader` precedence over `apiKey`, global-config fallback when no overrides are given, per-bot model on `/completions`, fresh instance per `create()` call
- `npm run check-types` — clean
- `npm run lint:json && node scripts/ci/eslint-warning-gate.js` — baseline check passed, no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)