### PR TITLE
feat(mcp): auto-connect bot-assigned servers at startup + HTTP/SSE transports

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -58,8 +58,8 @@ Small, verified gaps where the surrounding feature is otherwise done.
   - [ ] MemVault durable store (in-memory only; Postgres/pgvector store deferred)
   - [ ] Wire `ConversationSummaryService` into the pipeline (zero callers today)
 - [ ] **MCP**
-  - [ ] Auto-connect bot-assigned MCP servers at startup (only admin routes connect today)
-  - [ ] Support non-stdio MCP server URLs in `/api/mcp/servers` connect path (stdio:// only)
+  - [x] Auto-connect bot-assigned MCP servers at startup (only admin routes connect today)
+  - [x] Support non-stdio MCP server URLs in `/api/mcp/servers` connect path (stdio:// only)
 - [ ] **Monitoring truth**
   - [x] Replace `mockSpans` + `Math.random()` bot stats in MonitoringDashboard with real data
   - [x] Implement `/api/activity/messages` and `/llm-usage` (return `[]` today) and real `/chart-data` (random series today)

--- a/src/mcp/MCPService.ts
+++ b/src/mcp/MCPService.ts
@@ -252,6 +252,69 @@ export class MCPService {
   }
 
   /**
+   * Connects every MCP server assigned to an enabled bot via its
+   * `mcpServers` configuration.
+   *
+   * Intended as a startup hook (see src/server/initServices.ts): historically
+   * only the admin WebUI routes ever connected MCP servers, so bot-assigned
+   * servers were silently unavailable until an admin clicked "connect".
+   *
+   * Failure-tolerant by design — a server that cannot be reached is recorded
+   * in `failed` and logged, but never throws, so boot is not blocked by an
+   * offline tool server. Servers are deduplicated by name across bots, and
+   * servers (or bots) explicitly disabled via `enabled: false` are skipped.
+   *
+   * @returns The names of servers that connected and those that failed.
+   */
+  public async autoConnectConfiguredServers(): Promise<{
+    connected: string[];
+    failed: { name: string; error: string }[];
+  }> {
+    const connected: string[] = [];
+    const failed: { name: string; error: string }[] = [];
+
+    const pending = new Map<string, MCPConfig>();
+    try {
+      const bots = BotConfigurationManager.getInstance().getAllBots();
+      for (const bot of bots) {
+        if (bot.enabled === false) {
+          continue;
+        }
+        for (const server of bot.mcpServers ?? []) {
+          if (!server?.name || !server.serverUrl || server.enabled === false) {
+            continue;
+          }
+          if (this.clients.has(server.name) || pending.has(server.name)) {
+            continue; // already connected, or another bot already queued it
+          }
+          pending.set(server.name, {
+            name: server.name,
+            serverUrl: server.serverUrl,
+            apiKey: server.credentials?.apiKey,
+          });
+        }
+      }
+    } catch (error) {
+      // Config lookup failure must not block boot either.
+      debug('Auto-connect: unable to read bot configurations:', error);
+      return { connected, failed };
+    }
+
+    for (const config of pending.values()) {
+      try {
+        await this.connectToServer(config);
+        connected.push(config.name);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        failed.push({ name: config.name, error: message });
+        debug(`Auto-connect: failed to connect MCP server ${config.name}: ${message}`);
+      }
+    }
+
+    return { connected, failed };
+  }
+
+  /**
    * Disconnect from an MCP server
    */
   public async disconnectFromServer(serverName: string): Promise<void> {

--- a/src/mcp/MCPService.ts
+++ b/src/mcp/MCPService.ts
@@ -1,8 +1,12 @@
 import Debug from 'debug';
 import { SlackMessageProvider } from '@hivemind/message-slack';
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import type { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import type { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import type { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { BotConfigurationManager } from '@config/BotConfigurationManager';
 import { MCPGuard, type MCPGuardConfig } from './MCPGuard';
+import { resolveMcpTransport } from './transportSelection';
 
 // The MCP SDK is published as ESM-only with subpath exports (no CJS root
 // export), so it MUST be loaded via a dynamic `import()` of the real entry
@@ -40,9 +44,12 @@ export class MCPService {
    *
    * Loads the SDK via dynamic `import()` of its real subpath entry points
    * (the package has no working CJS root export, so `require()` throws), then
-   * selects the correct transport from the server URL scheme:
+   * selects the correct transport from the server URL scheme (see
+   * ./transportSelection):
    *  - `http(s)://` -> StreamableHTTPClientTransport (remote servers); the
    *    optional apiKey is sent as a Bearer Authorization header.
+   *  - `sse://` / `sse+http(s)://` -> SSEClientTransport (legacy remote
+   *    servers); apiKey handled the same way.
    *  - `stdio://`   -> StdioClientTransport (local command servers).
    *
    * @param config - The MCP server configuration.
@@ -57,40 +64,50 @@ export class MCPService {
    * imports unreliable in jest); tests spy on this method instead.
    */
   protected async loadSdk(): Promise<{
-    Client: typeof import('@modelcontextprotocol/sdk/client/index.js').Client;
-    StreamableHTTPClientTransport: typeof import('@modelcontextprotocol/sdk/client/streamableHttp.js').StreamableHTTPClientTransport;
-    StdioClientTransport: typeof import('@modelcontextprotocol/sdk/client/stdio.js').StdioClientTransport;
+    Client: typeof Client;
+    StreamableHTTPClientTransport: typeof StreamableHTTPClientTransport;
+    SSEClientTransport: typeof SSEClientTransport;
+    StdioClientTransport: typeof StdioClientTransport;
   }> {
-    const [{ Client }, { StreamableHTTPClientTransport }, { StdioClientTransport }] =
-      await Promise.all([
-        import('@modelcontextprotocol/sdk/client/index.js'),
-        import('@modelcontextprotocol/sdk/client/streamableHttp.js'),
-        import('@modelcontextprotocol/sdk/client/stdio.js'),
-      ]);
-    return { Client, StreamableHTTPClientTransport, StdioClientTransport };
+    const [
+      { Client },
+      { StreamableHTTPClientTransport },
+      { SSEClientTransport },
+      { StdioClientTransport },
+    ] = await Promise.all([
+      import('@modelcontextprotocol/sdk/client/index.js'),
+      import('@modelcontextprotocol/sdk/client/streamableHttp.js'),
+      import('@modelcontextprotocol/sdk/client/sse.js'),
+      import('@modelcontextprotocol/sdk/client/stdio.js'),
+    ]);
+    return { Client, StreamableHTTPClientTransport, SSEClientTransport, StdioClientTransport };
   }
 
   private async createConnectedClient(config: MCPConfig, clientName: string): Promise<Client> {
-    const { Client, StreamableHTTPClientTransport, StdioClientTransport } = await this.loadSdk();
+    const { Client, StreamableHTTPClientTransport, SSEClientTransport, StdioClientTransport } =
+      await this.loadSdk();
 
     const client = new Client(
       { name: clientName, version: '1.0.0' },
       { capabilities: { experimental: {} } }
     );
 
-    const url = config.serverUrl;
-    if (url.startsWith('stdio://')) {
-      const command = url.replace('stdio://', '');
-      const transport = new StdioClientTransport({ command, args: [] });
+    const resolved = resolveMcpTransport(config.serverUrl);
+
+    if (resolved.kind === 'stdio') {
+      const transport = new StdioClientTransport({ command: resolved.target, args: [] });
       await client.connect(transport);
       return client;
     }
 
-    const transport = new StreamableHTTPClientTransport(new URL(url), {
-      requestInit: config.apiKey
-        ? { headers: { Authorization: `Bearer ${config.apiKey}` } }
-        : undefined,
-    });
+    const requestInit = config.apiKey
+      ? { headers: { Authorization: `Bearer ${config.apiKey}` } }
+      : undefined;
+
+    const transport =
+      resolved.kind === 'sse'
+        ? new SSEClientTransport(new URL(resolved.target), { requestInit })
+        : new StreamableHTTPClientTransport(new URL(resolved.target), { requestInit });
     await client.connect(transport);
     return client;
   }

--- a/src/mcp/transportSelection.ts
+++ b/src/mcp/transportSelection.ts
@@ -1,0 +1,70 @@
+/**
+ * URL-scheme-based MCP transport selection.
+ *
+ * A single MCP server "URL" field is used across the codebase (bot
+ * `mcpServers[].serverUrl`, the admin `/api/mcp/servers` store, …). The scheme
+ * of that URL decides which MCP SDK client transport is used:
+ *
+ * | Scheme                      | Transport                       | Target                       |
+ * |-----------------------------|---------------------------------|------------------------------|
+ * | `stdio://<command>`         | StdioClientTransport            | the local command to spawn   |
+ * | `http://` / `https://`      | StreamableHTTPClientTransport   | the URL as-is                |
+ * | `sse+http://` / `sse+https://` | SSEClientTransport (legacy)  | rewritten to http(s)://      |
+ * | `sse://`                    | SSEClientTransport (legacy)     | rewritten to https:// (TLS by default) |
+ *
+ * Streamable HTTP is the modern MCP remote transport; SSE is the deprecated
+ * legacy transport that some servers still speak, hence the explicit `sse`
+ * scheme prefixes for opting into it.
+ *
+ * This module is intentionally pure (no SDK imports) so transport selection
+ * can be unit-tested without loading the ESM-only MCP SDK.
+ */
+
+export type McpTransportKind = 'stdio' | 'sse' | 'streamable-http';
+
+export interface ResolvedMcpTransport {
+  /** Which SDK client transport to instantiate. */
+  kind: McpTransportKind;
+  /**
+   * Transport target: the command to spawn for `stdio`, or the normalized
+   * `http(s)://` URL for the network transports.
+   */
+  target: string;
+}
+
+/**
+ * Resolves an MCP server URL to a transport kind + target.
+ *
+ * @throws {Error} if the URL uses an unsupported scheme.
+ */
+export function resolveMcpTransport(serverUrl: string): ResolvedMcpTransport {
+  const url = (serverUrl ?? '').trim();
+
+  if (url.startsWith('stdio://')) {
+    const command = url.slice('stdio://'.length);
+    if (!command) {
+      throw new Error(`Invalid stdio MCP server URL (no command): ${serverUrl}`);
+    }
+    return { kind: 'stdio', target: command };
+  }
+
+  if (url.startsWith('sse+http://')) {
+    return { kind: 'sse', target: `http://${url.slice('sse+http://'.length)}` };
+  }
+  if (url.startsWith('sse+https://')) {
+    return { kind: 'sse', target: `https://${url.slice('sse+https://'.length)}` };
+  }
+  if (url.startsWith('sse://')) {
+    // Bare sse:// defaults to TLS; use sse+http:// to opt into plaintext.
+    return { kind: 'sse', target: `https://${url.slice('sse://'.length)}` };
+  }
+
+  if (url.startsWith('http://') || url.startsWith('https://')) {
+    return { kind: 'streamable-http', target: url };
+  }
+
+  throw new Error(
+    `Unsupported MCP server URL scheme: ${serverUrl}. ` +
+      'Supported schemes: stdio://, http://, https://, sse://, sse+http://, sse+https://'
+  );
+}

--- a/src/server/initServices.ts
+++ b/src/server/initServices.ts
@@ -405,6 +405,36 @@ export async function initServices(
     appLogger.info('\ud83d\udd0d Integration Anomaly Detector started');
   }
 
+  // Auto-connect MCP servers assigned to enabled bots (bot config `mcpServers`).
+  // Historically only the admin WebUI routes ever connected MCP servers, so
+  // bot-assigned servers were unavailable until an admin connected them by
+  // hand. Fire-and-forget: a slow or unreachable tool server must never block
+  // boot \u2014 failures are logged as warnings and the bot runs without that
+  // server's tools. Disconnect on shutdown is handled by ShutdownCoordinator
+  // (MCPService.disconnectAll). Skipped in test runs (same convention as the
+  // detectors above).
+  if (process.env.NODE_ENV !== 'test') {
+    void (async () => {
+      try {
+        const { MCPService } = await import('@src/mcp/MCPService');
+        const { connected, failed } = await MCPService.getInstance().autoConnectConfiguredServers();
+        if (connected.length > 0) {
+          appLogger.info('\ud83d\udd0c MCP auto-connect: servers connected', { connected });
+        }
+        for (const failure of failed) {
+          appLogger.warn('\ud83d\udd0c MCP auto-connect: server connection failed', failure);
+        }
+        if (connected.length === 0 && failed.length === 0) {
+          indexLog('MCP auto-connect: no bot-assigned MCP servers configured');
+        }
+      } catch (error) {
+        appLogger.warn('MCP auto-connect failed', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    })();
+  }
+
   // Prepare messenger services collection for optional webhook registration later
 
   let messengerServices: any[] = [];

--- a/src/server/routes/mcp/shared.ts
+++ b/src/server/routes/mcp/shared.ts
@@ -2,7 +2,8 @@ import { promises as fs } from 'fs';
 import { join } from 'path';
 import Debug from 'debug';
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import type { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { resolveMcpTransport } from '@src/mcp/transportSelection';
 import { ErrorUtils } from '@src/types/errors';
 import { BotConfigurationManager } from '@config/BotConfigurationManager';
 
@@ -24,7 +25,7 @@ export interface MCPServer {
 
 export interface MCPClient {
   client: Client;
-  transport: StdioClientTransport;
+  transport: Transport;
   server: MCPServer;
 }
 
@@ -70,62 +71,104 @@ export const saveMCPServers = async (servers: MCPServer[]): Promise<void> => {
   await fs.writeFile(MCP_SERVERS_CONFIG_FILE, JSON.stringify(serversToSave, null, 2), 'utf8');
 };
 
+/**
+ * Loads the MCP SDK entry points via dynamic `import()`.
+ *
+ * The SDK is ESM-only with subpath exports (no usable CJS root export), so it
+ * must be loaded via dynamic import. Exposed as a mutable seam object so unit
+ * tests can stub the SDK (module-level mocking of dynamic ESM imports is
+ * unreliable in jest) — same pattern as MCPService.loadSdk.
+ */
+export const mcpSdk = {
+  load: async () => {
+    const [
+      { Client },
+      { StreamableHTTPClientTransport },
+      { SSEClientTransport },
+      { StdioClientTransport },
+    ] = await Promise.all([
+      import('@modelcontextprotocol/sdk/client/index.js'),
+      import('@modelcontextprotocol/sdk/client/streamableHttp.js'),
+      import('@modelcontextprotocol/sdk/client/sse.js'),
+      import('@modelcontextprotocol/sdk/client/stdio.js'),
+    ]);
+    return { Client, StreamableHTTPClientTransport, SSEClientTransport, StdioClientTransport };
+  },
+};
+
+/**
+ * Builds the right SDK client transport for a server URL.
+ *
+ * Scheme-based selection (see src/mcp/transportSelection.ts):
+ * `stdio://` -> stdio, `http(s)://` -> Streamable HTTP,
+ * `sse://`/`sse+http(s)://` -> legacy SSE. An optional apiKey is sent as a
+ * Bearer Authorization header on the network transports.
+ */
+export const createTransportForServer = async (server: MCPServer): Promise<Transport> => {
+  const { StreamableHTTPClientTransport, SSEClientTransport, StdioClientTransport } =
+    await mcpSdk.load();
+
+  const resolved = resolveMcpTransport(server.url);
+
+  if (resolved.kind === 'stdio') {
+    return new StdioClientTransport({ command: resolved.target, args: [] });
+  }
+
+  const requestInit = server.apiKey
+    ? { headers: { Authorization: `Bearer ${server.apiKey}` } }
+    : undefined;
+
+  return resolved.kind === 'sse'
+    ? new SSEClientTransport(new URL(resolved.target), { requestInit })
+    : new StreamableHTTPClientTransport(new URL(resolved.target), { requestInit });
+};
+
 // Connect to MCP server
 export const connectToMCPServer = async (server: MCPServer): Promise<MCPClient> => {
   try {
     debug(`Connecting to MCP server: ${server.name} at ${server.url}`);
 
-    // For stdio transport (local MCP servers)
-    if (server.url.startsWith('stdio://')) {
-      const command = server.url.replace('stdio://', '');
-      const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
-      const transport = new StdioClientTransport({
-        command: command,
-        args: [],
-      });
+    const transport = await createTransportForServer(server);
 
-      const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
-      const client = new Client(
-        {
-          name: `hivemind-${server.name}`,
-          version: '1.0.0',
+    const { Client } = await mcpSdk.load();
+    const client = new Client(
+      {
+        name: `hivemind-${server.name}`,
+        version: '1.0.0',
+      },
+      {
+        capabilities: {
+          experimental: {},
         },
-        {
-          capabilities: {
-            experimental: {},
-          },
-        }
-      );
+      }
+    );
 
-      await client.connect(transport);
+    await client.connect(transport);
 
-      // Get available tools
-      const toolsResponse = await client.listTools();
-      const tools = toolsResponse.tools.map((tool) => ({
-        name: tool.name,
-        description: tool.description || '',
-        inputSchema: tool.inputSchema,
-      }));
+    // Get available tools
+    const toolsResponse = await client.listTools();
+    const tools = toolsResponse.tools.map((tool) => ({
+      name: tool.name,
+      description: tool.description || '',
+      inputSchema: tool.inputSchema,
+    }));
 
-      const mcpClient: MCPClient = {
-        client,
-        transport,
-        server: {
-          ...server,
-          connected: true,
-          tools,
-          lastConnected: new Date().toISOString(),
-          error: undefined,
-        },
-      };
+    const mcpClient: MCPClient = {
+      client,
+      transport,
+      server: {
+        ...server,
+        connected: true,
+        tools,
+        lastConnected: new Date().toISOString(),
+        error: undefined,
+      },
+    };
 
-      connectedClients.set(server.name, mcpClient);
-      debug(`Successfully connected to MCP server: ${server.name}`);
+    connectedClients.set(server.name, mcpClient);
+    debug(`Successfully connected to MCP server: ${server.name}`);
 
-      return mcpClient;
-    } else {
-      throw new Error(`Unsupported MCP server URL scheme: ${server.url}`);
-    }
+    return mcpClient;
   } catch (error: unknown) {
     const hivemindError = ErrorUtils.toHivemindError(error);
     debug(`Failed to connect to MCP server ${server.name}:`, ErrorUtils.getMessage(hivemindError));

--- a/tests/unit/mcp/MCPService.test.ts
+++ b/tests/unit/mcp/MCPService.test.ts
@@ -1,3 +1,5 @@
+import { MCPService } from '../../../src/mcp/MCPService';
+
 /**
  * Regression test for the MCP SDK import bug (audit #5/#6/#9).
  *
@@ -24,9 +26,8 @@ const ClientCtor = jest.fn().mockImplementation(() => ({
 }));
 
 const StreamableHTTPCtor = jest.fn().mockImplementation((url: URL) => ({ __kind: 'http', url }));
+const SSECtor = jest.fn().mockImplementation((url: URL) => ({ __kind: 'sse', url }));
 const StdioCtor = jest.fn().mockImplementation((opts: unknown) => ({ __kind: 'stdio', opts }));
-
-import { MCPService } from '../../../src/mcp/MCPService';
 
 describe('MCPService SDK client construction', () => {
   let service: MCPService;
@@ -43,6 +44,7 @@ describe('MCPService SDK client construction', () => {
       .mockResolvedValue({
         Client: ClientCtor,
         StreamableHTTPClientTransport: StreamableHTTPCtor,
+        SSEClientTransport: SSECtor,
         StdioClientTransport: StdioCtor,
       });
     // Fresh singleton each test so connect/disconnect state does not leak.
@@ -65,9 +67,7 @@ describe('MCPService SDK client construction', () => {
     expect(ClientCtor).toHaveBeenCalledTimes(1);
     // A real transport instance was passed to connect() (not a {url,apiKey}
     // object, which the old code wrongly used).
-    expect(mockConnect).toHaveBeenCalledWith(
-      expect.objectContaining({ __kind: 'http' })
-    );
+    expect(mockConnect).toHaveBeenCalledWith(expect.objectContaining({ __kind: 'http' }));
     expect(service.getConnectedServers()).toContain('remote');
   });
 
@@ -94,9 +94,31 @@ describe('MCPService SDK client construction', () => {
     });
 
     expect(StdioCtor).toHaveBeenCalledWith({ command: 'my-mcp-binary', args: [] });
-    expect(mockConnect).toHaveBeenCalledWith(
-      expect.objectContaining({ __kind: 'stdio' })
-    );
+    expect(mockConnect).toHaveBeenCalledWith(expect.objectContaining({ __kind: 'stdio' }));
+  });
+
+  it('uses the SSE transport for sse:// URLs (rewritten to https)', async () => {
+    await service.connectToServer({
+      name: 'legacy',
+      serverUrl: 'sse://example.com/sse',
+      apiKey: 'secret',
+    });
+
+    expect(SSECtor).toHaveBeenCalledTimes(1);
+    const [urlArg, optsArg] = SSECtor.mock.calls[0];
+    expect((urlArg as URL).href).toBe('https://example.com/sse');
+    expect(optsArg).toEqual({
+      requestInit: { headers: { Authorization: 'Bearer secret' } },
+    });
+    expect(StreamableHTTPCtor).not.toHaveBeenCalled();
+    expect(mockConnect).toHaveBeenCalledWith(expect.objectContaining({ __kind: 'sse' }));
+  });
+
+  it('rejects unsupported URL schemes', async () => {
+    await expect(
+      service.connectToServer({ name: 'bad', serverUrl: 'ftp://example.com' })
+    ).rejects.toThrow(/Unsupported MCP server URL scheme/);
+    expect(service.getConnectedServers()).not.toContain('bad');
   });
 
   it('testConnection builds a client and returns discovered tools', async () => {

--- a/tests/unit/mcp/MCPService.test.ts
+++ b/tests/unit/mcp/MCPService.test.ts
@@ -1,3 +1,4 @@
+import { BotConfigurationManager } from '@config/BotConfigurationManager';
 import { MCPService } from '../../../src/mcp/MCPService';
 
 /**
@@ -131,5 +132,129 @@ describe('MCPService SDK client construction', () => {
     expect(tools).toEqual([{ name: 'echo', serverName: 'remote' }]);
     // testConnection must NOT store the client.
     expect(service.getConnectedServers()).not.toContain('remote');
+  });
+
+  describe('autoConnectConfiguredServers (startup hook)', () => {
+    const stubBots = (bots: unknown[]) => {
+      jest
+        .spyOn(BotConfigurationManager, 'getInstance')
+        .mockReturnValue({ getAllBots: () => bots } as unknown as BotConfigurationManager);
+    };
+
+    it('connects every MCP server assigned to enabled bots, deduplicated by name', async () => {
+      stubBots([
+        {
+          name: 'bot-a',
+          mcpServers: [
+            { name: 'srv-http', serverUrl: 'https://example.com/mcp' },
+            { name: 'srv-stdio', serverUrl: 'stdio://my-mcp-binary' },
+          ],
+        },
+        {
+          name: 'bot-b',
+          // Same server assigned to a second bot must only connect once.
+          mcpServers: [{ name: 'srv-http', serverUrl: 'https://example.com/mcp' }],
+        },
+      ]);
+
+      const result = await service.autoConnectConfiguredServers();
+
+      expect(result.connected.sort()).toEqual(['srv-http', 'srv-stdio']);
+      expect(result.failed).toEqual([]);
+      expect(ClientCtor).toHaveBeenCalledTimes(2);
+      expect(service.getConnectedServers().sort()).toEqual(['srv-http', 'srv-stdio']);
+    });
+
+    it('skips disabled bots, disabled servers, and incomplete server entries', async () => {
+      stubBots([
+        {
+          name: 'disabled-bot',
+          enabled: false,
+          mcpServers: [{ name: 'should-not-connect', serverUrl: 'https://x.example/mcp' }],
+        },
+        {
+          name: 'bot',
+          mcpServers: [
+            { name: 'disabled-server', serverUrl: 'https://y.example/mcp', enabled: false },
+            { name: 'no-url' }, // missing serverUrl
+            { name: 'ok', serverUrl: 'https://ok.example/mcp' },
+          ],
+        },
+        { name: 'bot-without-servers' },
+      ]);
+
+      const result = await service.autoConnectConfiguredServers();
+
+      expect(result.connected).toEqual(['ok']);
+      expect(result.failed).toEqual([]);
+      expect(service.getConnectedServers()).toEqual(['ok']);
+    });
+
+    it('tolerates individual connection failures and keeps connecting the rest', async () => {
+      stubBots([
+        {
+          name: 'bot',
+          mcpServers: [
+            { name: 'down', serverUrl: 'https://down.example/mcp' },
+            { name: 'up', serverUrl: 'https://up.example/mcp' },
+          ],
+        },
+      ]);
+      mockConnect.mockRejectedValueOnce(new Error('ECONNREFUSED')).mockResolvedValueOnce(undefined);
+
+      const result = await service.autoConnectConfiguredServers();
+
+      expect(result.connected).toEqual(['up']);
+      expect(result.failed).toHaveLength(1);
+      expect(result.failed[0].name).toBe('down');
+      expect(result.failed[0].error).toContain('ECONNREFUSED');
+      expect(service.getConnectedServers()).toEqual(['up']);
+    });
+
+    it('passes server credentials.apiKey through as a Bearer header', async () => {
+      stubBots([
+        {
+          name: 'bot',
+          mcpServers: [
+            {
+              name: 'secured',
+              serverUrl: 'https://secure.example/mcp',
+              credentials: { apiKey: 'tok-123' },
+            },
+          ],
+        },
+      ]);
+
+      await service.autoConnectConfiguredServers();
+
+      expect(StreamableHTTPCtor).toHaveBeenCalledWith(expect.any(URL), {
+        requestInit: { headers: { Authorization: 'Bearer tok-123' } },
+      });
+    });
+
+    it('returns empty results instead of throwing when bot config lookup fails', async () => {
+      jest.spyOn(BotConfigurationManager, 'getInstance').mockImplementation(() => {
+        throw new Error('config store unavailable');
+      });
+
+      await expect(service.autoConnectConfiguredServers()).resolves.toEqual({
+        connected: [],
+        failed: [],
+      });
+    });
+
+    it('does not reconnect servers that are already connected', async () => {
+      stubBots([
+        { name: 'bot', mcpServers: [{ name: 'srv', serverUrl: 'https://example.com/mcp' }] },
+      ]);
+      await service.connectToServer({ name: 'srv', serverUrl: 'https://example.com/mcp' });
+      ClientCtor.mockClear();
+
+      const result = await service.autoConnectConfiguredServers();
+
+      expect(result.connected).toEqual([]);
+      expect(result.failed).toEqual([]);
+      expect(ClientCtor).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/unit/mcp/transportSelection.test.ts
+++ b/tests/unit/mcp/transportSelection.test.ts
@@ -1,0 +1,67 @@
+/**
+ * URL-scheme -> MCP transport selection (src/mcp/transportSelection.ts).
+ *
+ * This pure helper is the single source of truth for which SDK client
+ * transport a server URL maps to; it is shared by MCPService and the admin
+ * /api/mcp/servers connect path (src/server/routes/mcp/shared.ts). The
+ * `/api/mcp/servers` path used to be stdio:// only — these tests pin the
+ * http/https (Streamable HTTP) and sse:// (legacy SSE) support.
+ */
+
+import { resolveMcpTransport } from '@src/mcp/transportSelection';
+
+describe('resolveMcpTransport', () => {
+  it('maps stdio:// to the stdio transport with the command as target', () => {
+    expect(resolveMcpTransport('stdio:///usr/local/bin/my-mcp')).toEqual({
+      kind: 'stdio',
+      target: '/usr/local/bin/my-mcp',
+    });
+  });
+
+  it('maps http:// and https:// to the streamable-http transport, URL unchanged', () => {
+    expect(resolveMcpTransport('http://localhost:3001/mcp')).toEqual({
+      kind: 'streamable-http',
+      target: 'http://localhost:3001/mcp',
+    });
+    expect(resolveMcpTransport('https://api.example.com/mcp')).toEqual({
+      kind: 'streamable-http',
+      target: 'https://api.example.com/mcp',
+    });
+  });
+
+  it('maps sse:// to the SSE transport over https (TLS by default)', () => {
+    expect(resolveMcpTransport('sse://api.example.com/sse')).toEqual({
+      kind: 'sse',
+      target: 'https://api.example.com/sse',
+    });
+  });
+
+  it('maps sse+http:// and sse+https:// to the SSE transport over the given scheme', () => {
+    expect(resolveMcpTransport('sse+http://localhost:3001/sse')).toEqual({
+      kind: 'sse',
+      target: 'http://localhost:3001/sse',
+    });
+    expect(resolveMcpTransport('sse+https://api.example.com/sse')).toEqual({
+      kind: 'sse',
+      target: 'https://api.example.com/sse',
+    });
+  });
+
+  it('trims surrounding whitespace before matching', () => {
+    expect(resolveMcpTransport('  https://api.example.com/mcp ')).toEqual({
+      kind: 'streamable-http',
+      target: 'https://api.example.com/mcp',
+    });
+  });
+
+  it('rejects unsupported schemes with an actionable error', () => {
+    expect(() => resolveMcpTransport('ftp://example.com')).toThrow(
+      /Unsupported MCP server URL scheme: ftp:\/\/example\.com/
+    );
+    expect(() => resolveMcpTransport('not-a-url')).toThrow(/Unsupported MCP server URL scheme/);
+  });
+
+  it('rejects a stdio:// URL with no command', () => {
+    expect(() => resolveMcpTransport('stdio://')).toThrow(/no command/);
+  });
+});

--- a/tests/unit/server/routes/mcp/shared.test.ts
+++ b/tests/unit/server/routes/mcp/shared.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Transport selection in the admin /api/mcp/servers connect path
+ * (src/server/routes/mcp/shared.ts connectToMCPServer).
+ *
+ * This path was stdio:// only — any http(s) or SSE URL was rejected with
+ * "Unsupported MCP server URL scheme". These tests pin the new scheme-based
+ * selection: stdio:// -> StdioClientTransport, http(s):// ->
+ * StreamableHTTPClientTransport, sse:// / sse+http(s):// -> SSEClientTransport.
+ *
+ * The MCP SDK is ESM-only (dynamic import()), so the tests stub the exported
+ * `mcpSdk.load` seam rather than mocking the SDK modules — same pattern as the
+ * MCPService.loadSdk seam in tests/unit/mcp/MCPService.test.ts.
+ */
+
+import {
+  connectedClients,
+  connectToMCPServer,
+  mcpSdk,
+  type MCPServer,
+} from '@src/server/routes/mcp/shared';
+
+const mockConnect = jest.fn().mockResolvedValue(undefined);
+const mockListTools = jest.fn().mockResolvedValue({
+  tools: [{ name: 'echo', description: 'Echoes', inputSchema: {} }],
+});
+const ClientCtor = jest.fn().mockImplementation(() => ({
+  connect: mockConnect,
+  listTools: mockListTools,
+}));
+const StreamableHTTPCtor = jest.fn().mockImplementation((url: URL) => ({ __kind: 'http', url }));
+const SSECtor = jest.fn().mockImplementation((url: URL) => ({ __kind: 'sse', url }));
+const StdioCtor = jest.fn().mockImplementation((opts: unknown) => ({ __kind: 'stdio', opts }));
+
+const server = (overrides: Partial<MCPServer>): MCPServer => ({
+  name: 'test-server',
+  url: 'stdio://noop',
+  connected: false,
+  ...overrides,
+});
+
+describe('connectToMCPServer transport selection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    connectedClients.clear();
+    jest.spyOn(mcpSdk, 'load').mockResolvedValue({
+      Client: ClientCtor,
+      StreamableHTTPClientTransport: StreamableHTTPCtor,
+      SSEClientTransport: SSECtor,
+      StdioClientTransport: StdioCtor,
+    } as unknown as Awaited<ReturnType<typeof mcpSdk.load>>);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    connectedClients.clear();
+  });
+
+  it('uses the stdio transport for stdio:// URLs', async () => {
+    const result = await connectToMCPServer(server({ url: 'stdio://my-mcp-binary' }));
+
+    expect(StdioCtor).toHaveBeenCalledWith({ command: 'my-mcp-binary', args: [] });
+    expect(mockConnect).toHaveBeenCalledWith(expect.objectContaining({ __kind: 'stdio' }));
+    expect(result.server.connected).toBe(true);
+    expect(result.server.tools).toEqual([{ name: 'echo', description: 'Echoes', inputSchema: {} }]);
+    expect(connectedClients.has('test-server')).toBe(true);
+  });
+
+  it('uses the Streamable HTTP transport for http(s):// URLs (no longer stdio-only)', async () => {
+    await connectToMCPServer(server({ url: 'https://api.example.com/mcp', apiKey: 'secret' }));
+
+    expect(StreamableHTTPCtor).toHaveBeenCalledTimes(1);
+    const [urlArg, optsArg] = StreamableHTTPCtor.mock.calls[0];
+    expect((urlArg as URL).href).toBe('https://api.example.com/mcp');
+    expect(optsArg).toEqual({ requestInit: { headers: { Authorization: 'Bearer secret' } } });
+    expect(mockConnect).toHaveBeenCalledWith(expect.objectContaining({ __kind: 'http' }));
+    expect(connectedClients.has('test-server')).toBe(true);
+  });
+
+  it('omits the Authorization header when no apiKey is configured', async () => {
+    await connectToMCPServer(server({ url: 'http://localhost:3001/mcp' }));
+
+    const [, optsArg] = StreamableHTTPCtor.mock.calls[0];
+    expect(optsArg).toEqual({ requestInit: undefined });
+  });
+
+  it('uses the SSE transport for sse:// URLs (https by default)', async () => {
+    await connectToMCPServer(server({ url: 'sse://api.example.com/sse', apiKey: 'tok' }));
+
+    expect(SSECtor).toHaveBeenCalledTimes(1);
+    const [urlArg, optsArg] = SSECtor.mock.calls[0];
+    expect((urlArg as URL).href).toBe('https://api.example.com/sse');
+    expect(optsArg).toEqual({ requestInit: { headers: { Authorization: 'Bearer tok' } } });
+    expect(StreamableHTTPCtor).not.toHaveBeenCalled();
+    expect(mockConnect).toHaveBeenCalledWith(expect.objectContaining({ __kind: 'sse' }));
+  });
+
+  it('uses the SSE transport over plaintext http for sse+http:// URLs', async () => {
+    await connectToMCPServer(server({ url: 'sse+http://localhost:3001/sse' }));
+
+    const [urlArg] = SSECtor.mock.calls[0];
+    expect((urlArg as URL).href).toBe('http://localhost:3001/sse');
+  });
+
+  it('rejects unsupported schemes and does not register a client', async () => {
+    await expect(connectToMCPServer(server({ url: 'ftp://example.com' }))).rejects.toThrow(
+      /Unsupported MCP server URL scheme/
+    );
+    expect(connectedClients.has('test-server')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the two MCP ROADMAP items (ticked in this branch):

### 1. Auto-connect bot-assigned MCP servers at startup
- New `MCPService.autoConnectConfiguredServers()`: collects `mcpServers` entries across enabled bots (deduplicated by server name; bots/servers with `enabled: false` skipped, already-connected servers skipped) and connects each one.
- Wired as a startup hook in `src/server/initServices.ts` (same spot/convention as the AnomalyDetectionService wiring). Fire-and-forget and failure-tolerant: an unreachable server logs a warning and never blocks boot. Skipped when `NODE_ENV=test`.
- Shutdown was already covered: `ShutdownCoordinator` calls `MCPService.disconnectAll()`.

### 2. Non-stdio transports in the `/api/mcp/servers` connect path
Previously `stdio://` only — any other scheme was rejected. New pure helper `src/mcp/transportSelection.ts` (shared by `MCPService` and the admin connect path in `src/server/routes/mcp/shared.ts`) selects the SDK transport by URL scheme:

| Scheme | Transport |
|---|---|
| `stdio://<command>` | `StdioClientTransport` |
| `http://` / `https://` | `StreamableHTTPClientTransport` |
| `sse://` (https by default), `sse+http://`, `sse+https://` | `SSEClientTransport` (legacy servers) |

An optional `apiKey` is sent as a `Bearer` Authorization header on the network transports. `shared.ts` gains an `mcpSdk.load` test seam (ESM-only SDK, same pattern as `MCPService.loadSdk`) and `MCPClient.transport` is widened to `Transport`.

## Verification

- `npm test -- mcp`: 11 suites / 72 tests pass, including new tests for scheme-based transport selection (`tests/unit/mcp/transportSelection.test.ts`, `tests/unit/server/routes/mcp/shared.test.ts`) and startup auto-connect iteration/failure tolerance (`tests/unit/mcp/MCPService.test.ts`).
- `npm run check-types`: no errors in changed files (remaining errors in the run come from unrelated concurrent WIP in the shared working tree, not this branch).
- ESLint on changed files: 0 errors, no new warnings (the pre-existing `max-lines` warning on `initServices.ts` and the 3 pre-existing `import()` type-annotation warnings in `MCPService.ts` were cleared by hoisting type-only imports).
- Boot smoke test (`npm run dev`): startup completes; with `DEBUG=app:index` the hook logs `MCP auto-connect: no bot-assigned MCP servers configured` when nothing is assigned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)