### PR TITLE
docs: guided tour, screenshot index, and user-guide refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ For the full first-session walkthrough with screenshots — onboarding through p
 ## Documentation
 
 *   [User Guide](docs/USER_GUIDE.md): Screenshot-backed Quick Tour of the full user story, plus a detailed explanation of all WebUI features.
+*   [Guided Tour](docs/GUIDED_TOUR.md): A narrative, persona-driven walkthrough — building a two-bot support swarm from onboarding to backup.
 *   [Developer Guide](docs/architecture/development.md): Deep dives into platform specifics and local development.
 *   [Quick Start / Installation Guide](docs/operations/deployment.md): Advanced deployment options and configurations.
 

--- a/docs/GUIDED_TOUR.md
+++ b/docs/GUIDED_TOUR.md
@@ -1,0 +1,147 @@
+# Guided Tour — Sam Sets Up a Support Swarm
+
+This is a narrative walkthrough of Open-Hivemind, one sitting from first launch to a working multi-bot deployment. It follows **Sam**, who runs a busy open-source community on Discord, and goes deeper than the [User Guide Quick Tour](USER_GUIDE.md#quick-tour--your-first-session): the *why* behind each step, the decisions Sam makes along the way, and the pages where each decision lives.
+
+Sam's goal: **a support swarm** — two bots with different personalities sharing one channel. One answers technical questions patiently; the other keeps the mood light and welcomes newcomers. Both need guardrails, memory, and a way for Sam to see what they're doing.
+
+> Screenshots are the same auto-captured journey set used by the Quick Tour (`npm run test:journey:guide`, demo-mode data). Steps without a screenshot yet are listed under [Screenshots wanted](#screenshots-wanted).
+
+## Contents
+
+1. [First launch and onboarding](#1-first-launch-and-onboarding)
+2. [Connecting the providers](#2-connecting-the-providers)
+3. [Two bots, two personas](#3-two-bots-two-personas)
+4. [Guardrails before going live](#4-guardrails-before-going-live)
+5. [Test drive](#5-test-drive)
+6. [Going live in a real channel](#6-going-live-in-a-real-channel)
+7. [Watching the swarm work](#7-watching-the-swarm-work)
+8. [Giving the bots memory](#8-giving-the-bots-memory)
+9. [Extending with an MCP tool (with approval)](#9-extending-with-an-mcp-tool-with-approval)
+10. [Backing it all up](#10-backing-it-all-up)
+11. [Screenshots wanted](#screenshots-wanted)
+
+---
+
+## 1. First launch and onboarding
+
+Sam starts the server (`npm run dev`) and opens `http://localhost:3028`. Running on a trusted home network, Sam uses the localhost admin bypass (`ALLOW_LOCALHOST_ADMIN=true`) to land straight on the admin dashboard — in production this would be a password login instead.
+
+With nothing configured yet, the app is in **Demo Mode**: every page is seeded with simulated bots and conversations so Sam can click around and see what a running deployment looks like before committing to anything. The onboarding wizard offers the fastest path out — it asks for exactly the three things a live bot needs: a message platform, an LLM provider, and a name.
+
+![Admin dashboard on first sign-in](screenshots/journey-01-onboarding.png)
+
+Sam skips the wizard's bot step for now — the plan is two bots, not one, so Sam will set up providers first and create the bots deliberately on the Bots page.
+
+## 2. Connecting the providers
+
+### The message platform
+
+Under **Configuration → Message Platforms**, Sam adds a Discord connection with the bot token from the Discord Developer Portal. The connection is validated immediately and shows up in the provider list. One important property for the swarm plan: a single platform connection can back **several** bot personas, though Sam will actually register a second Discord application later so each bot has its own avatar and name in the member list.
+
+(Slack, Mattermost, and Telegram work the same way — Telegram receives messages via long-polling, so it needs no public webhook URL.)
+
+![Message Providers page after adding Discord](screenshots/journey-02-discord-add.png)
+
+### The LLM provider
+
+Under **Configuration → LLM Providers**, Sam adds an OpenAI profile with an API key and picks a default model. Profiles are reusable connection templates: both bots will share this one, but nothing stops Sam from later giving the fun bot a cheaper model and the support bot a stronger one — that's a per-bot choice at creation time. Any OpenAI-compatible endpoint (local Ollama, vLLM) works through the same provider type via the base-URL field.
+
+![LLM Providers page after adding OpenAI](screenshots/journey-03-openai-add.png)
+
+## 3. Two bots, two personas
+
+Before creating the bots, Sam visits **Personas** and prepares two personalities:
+
+- **Patient Mentor** — system prompt focused on step-by-step troubleshooting, asking clarifying questions, never condescending.
+- **Community Greeter** — short, upbeat replies, welcomes new members, deflects technical questions to its sibling.
+
+Personas are reusable presets (system prompt + traits) that live independently of any bot: edit the prompt once and every assigned bot updates immediately. Built-in personas are read-only but cloneable, which is how Sam starts the Mentor.
+
+![Persona library](screenshots/journey-07-personas.png)
+
+Now to **Bots → Create Bot**. The 4-step wizard (Basics → Persona → Guardrails → Review) walks through name, message provider, LLM profile, and persona. Sam runs it twice — once for **HelpfulHive** (Patient Mentor) and once for **BuzzBee** (Community Greeter) — and both appear in the fleet list.
+
+![Bots page after creating a bot](screenshots/journey-04-bot-create.png)
+
+To keep the two from talking over each other in one channel, Sam tunes each bot's **Response Profile**: BuzzBee gets a high base response probability but a "social anxiety" modifier so it goes quiet when the channel is busy; HelpfulHive responds mostly when mentioned or when a question is detected. Swarm mode is set so one bot claims a conversation rather than both piling on.
+
+## 4. Guardrails before going live
+
+A bot with an LLM behind it is a liability without limits, so Sam opens **Guards** before either bot says a word in public. A guard profile bundles:
+
+- **Rate limits** — caps per-bot message volume so a prompt loop can't flood the channel.
+- **Content filtering** — strictness level for what the bots will repeat or engage with.
+- **Tool permissions** — which MCP tools the bot may invoke, and whether invocations need a human approval first (this matters in step 9).
+
+Sam creates one profile, "Community Safe", and assigns it to both bots. Profiles are shared, so tightening a limit later fixes both bots at once.
+
+![Guard profiles](screenshots/journey-08-guards.png)
+
+## 5. Test drive
+
+Rather than finding out in public that the API key is wrong, Sam opens HelpfulHive's detail drawer on the Bots page and uses the **Test Drive** tab — a direct chat against the bot's configured LLM, persona prompt included, with no platform round-trip. Token usage and estimated cost are tracked per exchange, which gives Sam an early feel for what a chatty support bot will cost per day.
+
+![Test Drive tab in the bot detail drawer](screenshots/journey-05-bot-chat.png)
+
+A few exchanges confirm the Mentor persona is coming through. Sam repeats the check with BuzzBee, then flips both bots' **Active** toggles on.
+
+## 6. Going live in a real channel
+
+Sam invites both Discord applications to the community server and watches `#support`. The bots don't answer everything — that's by design. Open-Hivemind bots respond *probabilistically*: a direct mention nearly always gets a reply, an open question usually draws HelpfulHive, and ambient chatter mostly gets ignored unless BuzzBee's engagement roll succeeds. Once a bot engages in a thread it tends to stay engaged, so conversations feel continuous rather than summoned.
+
+The first real exchange: a member asks "how do I fix a node version mismatch?", HelpfulHive replies with a step-by-step, and BuzzBee stays quiet — exactly the division of labor Sam configured in the response profiles.
+
+*(No screenshot for this step yet — see [Screenshots wanted](#screenshots-wanted).)*
+
+## 7. Watching the swarm work
+
+Back in the admin UI, the **Activity** page is the flight recorder: every inbound message, which bot replied (or chose not to), which provider served the reply, and how long it took. Filters narrow it to a bot, platform, provider, or date range, and the log exports to CSV. This is also where Sam will start when someone says "the bot ignored me" — if the inbound message never arrived, it's a platform problem; if it arrived and got no reply, it's usually the response-probability dice.
+
+![Live activity feed](screenshots/journey-06-activity.png)
+
+The **Monitoring** dashboard covers the system half of the story: per-bot health scores, message rates, CPU/memory. Prometheus-compatible metrics and trace export are available when Sam later wants this in the community's existing Grafana.
+
+![Monitoring dashboard](screenshots/journey-10-monitoring.png)
+
+## 8. Giving the bots memory
+
+A support bot that forgets the user's setup between messages is barely better than a search box. Under **Memory**, Sam configures **MemVault**, the built-in backend — it persists to the app's SQLite database, so memories survive restarts (Mem0, Mem4AI, and PostgreSQL are the alternatives for bigger deployments). Retention and eviction controls cap how much history accumulates, and long conversations are summarized automatically in the message pipeline so context stays affordable.
+
+![Memory provider configuration](screenshots/journey-09-memory.png)
+
+From now on, HelpfulHive can recall that the user it's helping was on Node 18 yesterday.
+
+## 9. Extending with an MCP tool (with approval)
+
+The community's most common request is "what's the status of issue #N?" — answerable only by an external tool. Sam adds the project's MCP server under **MCP Servers** (HTTP, SSE, and stdio transports are supported); its tools are discovered automatically, and any MCP server already listed in a bot's configuration auto-connects at startup, so this is a one-time setup.
+
+On **MCP Tools**, Sam inspects the `lookup_issue` tool's schema and test-runs it in Form mode before any bot can touch it. Then comes the safety decision: in the "Community Safe" guard profile, Sam enables `lookup_issue` for HelpfulHive only and turns on **human-in-the-loop approval** — when the bot wants to invoke the tool, the request is held until Sam approves it. After a week of sensible invocations, Sam can relax this to auto-approve.
+
+The first approved invocation shows up in the Activity feed like any other event, tool call and all.
+
+*(No screenshot for this step yet — see [Screenshots wanted](#screenshots-wanted).)*
+
+## 10. Backing it all up
+
+Everything Sam built — providers, two bots, personas, the guard profile, memory config — is now worth protecting. The **Export** page snapshots the entire configuration as JSON, YAML, or CSV (optionally compressed or encrypted), and the same page imports a snapshot back, so this doubles as a migration path to a bigger host later. The server also takes automatic daily configuration backups with a 7-backup retention window, visible under System Management.
+
+![Configuration export](screenshots/journey-11-export.png)
+
+Sam downloads a JSON export, commits it to the community's private ops repo, and closes the laptop. Total elapsed time: one evening. The swarm is live.
+
+---
+
+## Where to next
+
+- The **[User Guide](USER_GUIDE.md)** covers every page in depth, plus ten common workflows (headless `.env` setup, debugging "my bot didn't reply", locking down a public deployment, …).
+- **[SCREENSHOTS.md](SCREENSHOTS.md)** indexes every screenshot used here and elsewhere.
+
+## Screenshots wanted
+
+Steps in this tour that don't yet have a matching screenshot in the journey set (`tests/e2e/journey-user-guide.spec.ts`, regenerated via `npm run test:journey:guide`):
+
+| Step | Wanted screenshot |
+|---|---|
+| [6. Going live in a real channel](#6-going-live-in-a-real-channel) | A real platform channel (Discord) showing a member's question and a bot's reply — or the Live Chat Monitor rendering that exchange. |
+| [9. Extending with an MCP tool (with approval)](#9-extending-with-an-mcp-tool-with-approval) | The human-in-the-loop approval prompt for a pending MCP tool invocation, and/or the guard profile's tool-permission editor with approval enabled. |
+| [3. Two bots, two personas](#3-two-bots-two-personas) | The Bots page showing **two** bots with different personas side by side (journey-04 shows a single created bot). |

--- a/docs/SCREENSHOTS.md
+++ b/docs/SCREENSHOTS.md
@@ -1,0 +1,239 @@
+# Screenshot Index
+
+A single tracking index of **every screenshot in the repository** — both the current set in
+[`docs/screenshots/`](screenshots/) and the previous versions in [`archive/screenshots/`](../archive/screenshots/).
+
+- **Regeneration:** the `journey-01…11` set is regenerated with `npm run test:journey:guide`
+  (demo-mode data, Playwright); other screenshots come from `tests/e2e/screenshot-*.spec.ts`
+  via `npm run generate-docs`.
+- **Convention:** naming and archival rules (plain kebab-case, current vs. archived directories,
+  no suffixes) are documented in [CLAUDE.md](../CLAUDE.md).
+- **"Used by"** is determined by grepping these docs for each filename:
+  [USER_GUIDE.md](USER_GUIDE.md), [GUIDED_TOUR.md](GUIDED_TOUR.md),
+  [docs/screenshots/README.md](screenshots/README.md),
+  [archive/screenshots/README.md](../archive/screenshots/README.md), and the root
+  [README.md](../README.md).
+
+Non-image files in `docs/screenshots/` not tracked below: `index.html`, `mcp-tools-testing.txt`, `README.md`.
+
+## Current screenshots (`docs/screenshots/`)
+
+| Filename | Location | Used by | Description |
+|---|---|---|---|
+| `activity-monitor.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Real-time activity monitor showing live system events |
+| `activity-page-filters.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Activity page with filter controls applied |
+| `activity-page.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | Activity page overview with event timeline |
+| `admin-health-page.png` | current | USER_GUIDE.md, docs/screenshots/README.md | System health page with service status overview |
+| `ai-assist-button.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | AI assist button component |
+| `ai-button-hover-full.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | AI button hover state (full context) |
+| `ai-button-hover.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | AI button hover state |
+| `ai-button-loading.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | AI button loading/spinner state |
+| `analytics-dashboard.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Analytics dashboard with bot performance metrics |
+| `api-docs-page.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Interactive API documentation page |
+| `api-rate-limit.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | API rate limiting configuration |
+| `audit-governance-filtered.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Audit and governance page with filters applied |
+| `audit-governance-initial.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Audit and governance page in initial state |
+| `backup-retention-baseline.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | Backup retention settings in baseline state |
+| `backup-retention-enforced.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | Backup retention with enforcement policy active |
+| `bot-create-page.png` | current | USER_GUIDE.md, docs/screenshots/README.md, archive/screenshots/README.md | Bot creation page |
+| `bot-create-validation.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | Bot creation form showing validation errors |
+| `bot-details-modal.png` | current | USER_GUIDE.md, docs/screenshots/README.md, archive/screenshots/README.md | Bot details modal with configuration summary |
+| `bot-search-filtered.png` | current | docs/screenshots/README.md | Bots page with search filter applied |
+| `bot-templates-page.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Bot templates page for quick bot creation |
+| `bot-wizard-validation.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | Bot creation wizard showing validation state |
+| `bots-page.png` | current | USER_GUIDE.md, docs/screenshots/README.md, archive/screenshots/README.md | Main bots listing page |
+| `button-loading-after-light.png` | current | none | Button loading state after fix, light theme variant |
+| `button-loading-real-app.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | Button loading state in production context |
+| `button-loading.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | Generic button loading state |
+| `chat-monitor.png` | current | USER_GUIDE.md, docs/screenshots/README.md, README.md (root) | Chat monitoring view for live message tracking |
+| `chatpage-latency.png` | current | docs/screenshots/README.md | Chat page showing latency indicators |
+| `chatpage-offline.png` | current | docs/screenshots/README.md | Chat page in offline/disconnected state |
+| `chatpage-optimistic.png` | current | docs/screenshots/README.md | Chat page with optimistic message sending |
+| `chatpage-rollback.png` | current | docs/screenshots/README.md | Chat page showing message rollback after failure |
+| `clone-bot-modal.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Modal dialog for cloning an existing bot |
+| `command-palette-search.png` | current | USER_GUIDE.md | Command palette with a search query filtering results |
+| `command-palette.png` | current | USER_GUIDE.md | Command palette overlay (Ctrl+K) with navigation results |
+| `config-rollback-available.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | Configuration rollback with available restore points |
+| `config-rollback-empty.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | Configuration rollback page with no restore points |
+| `config-rollback-modal.png` | current | docs/screenshots/README.md | Configuration rollback confirmation modal |
+| `config-rollback-success.png` | current | docs/screenshots/README.md | Configuration rollback success state |
+| `config-test-helper.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | Configuration test helper utility |
+| `configuration.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Main configuration page |
+| `create-backup-modal.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Modal for creating a configuration backup |
+| `create-bot-modal.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | Modal dialog for creating a new bot |
+| `demo-mode-banner.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Demo mode banner indicating the app is running in demonstration mode |
+| `demo-mode-dashboard.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Dashboard view while running in demo mode |
+| `distributed-trace-waterfall.png` | current | docs/screenshots/README.md | Distributed tracing waterfall view for request debugging |
+| `env-sample-completeness.png` | current | docs/screenshots/README.md | Environment sample file completeness check |
+| `export-page.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Data export page |
+| `guard-profiles-coverage.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | Guard profiles coverage report |
+| `guards-concurrent-test.png` | current | none | Guards page state during a concurrent guard test |
+| `guards-modal-enhanced.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | Enhanced guards modal with additional options |
+| `guards-modal.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Guards configuration modal |
+| `guards-page.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Guards page with guardrail profiles |
+| `health-dashboard.png` | current | none | Health dashboard view with service status |
+| `help-page-expanded.png` | current | USER_GUIDE.md | Help & FAQ page with a section expanded |
+| `help-page.png` | current | USER_GUIDE.md | Help & FAQ main page |
+| `integrations-llm.png` | current | USER_GUIDE.md, docs/screenshots/README.md | LLM integrations overview panel |
+| `journey-01-onboarding.png` | current | USER_GUIDE.md, GUIDED_TOUR.md, docs/screenshots/README.md, archive/screenshots/README.md | The admin dashboard after first sign-in. |
+| `journey-02-discord-add.png` | current | USER_GUIDE.md, GUIDED_TOUR.md, docs/screenshots/README.md, archive/screenshots/README.md | The Message Providers page after creating a Discord profile. |
+| `journey-03-openai-add.png` | current | USER_GUIDE.md, GUIDED_TOUR.md, docs/screenshots/README.md, archive/screenshots/README.md | The LLM Providers page after creating an OpenAI profile. |
+| `journey-04-bot-create.png` | current | USER_GUIDE.md, GUIDED_TOUR.md, docs/screenshots/README.md, archive/screenshots/README.md | The Bots page after wiring a bot to Discord + OpenAI. |
+| `journey-05-bot-chat.png` | current | USER_GUIDE.md, GUIDED_TOUR.md, docs/screenshots/README.md, archive/screenshots/README.md | The bot detail drawer open on the Test Drive tab after exchanging a message. |
+| `journey-06-activity.png` | current | USER_GUIDE.md, GUIDED_TOUR.md, docs/screenshots/README.md, archive/screenshots/README.md | The Activity page rendering after the exchange. |
+| `journey-07-personas.png` | current | USER_GUIDE.md, GUIDED_TOUR.md, docs/screenshots/README.md | The Personas library with the demo persona presets. |
+| `journey-08-guards.png` | current | USER_GUIDE.md, GUIDED_TOUR.md, docs/screenshots/README.md | The Guards page with guard profiles (rate limit, content filter, tool access). |
+| `journey-09-memory.png` | current | USER_GUIDE.md, GUIDED_TOUR.md, docs/screenshots/README.md | The Memory Providers configuration page. |
+| `journey-10-monitoring.png` | current | USER_GUIDE.md, GUIDED_TOUR.md, docs/screenshots/README.md | The monitoring view with demo-mode metrics. |
+| `journey-11-export.png` | current | USER_GUIDE.md, GUIDED_TOUR.md, docs/screenshots/README.md | The configuration Export page. |
+| `letta-cloud-config.png` | current | none | Letta cloud provider configuration form |
+| `letta-localhost-health.png` | current | none | Letta localhost provider health check result |
+| `letta-provider-list.png` | current | docs/screenshots/README.md | Letta provider instances list |
+| `letta-provider-selection.png` | current | docs/screenshots/README.md | Letta provider selection interface |
+| `llm-add-profile-modal.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Modal for adding a new LLM profile |
+| `llm-add-profile-ollama-modal.png` | current | docs/screenshots/README.md | Modal for adding an Ollama LLM profile |
+| `llm-providers-list.png` | current | USER_GUIDE.md, docs/screenshots/README.md | LLM providers list page |
+| `marketplace-install-modal.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Plugin installation modal |
+| `marketplace-page.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Plugin marketplace page |
+| `mcp-add-server-modal.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Modal for adding a new MCP server |
+| `mcp-guard-ux.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | MCP guard UX for tool usage controls |
+| `mcp-servers-list.png` | current | USER_GUIDE.md, docs/screenshots/README.md | MCP servers list page |
+| `mcp-tool-run-modal.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Modal for running an MCP tool |
+| `mcp-tools-list.png` | current | USER_GUIDE.md, docs/screenshots/README.md | MCP tools list view |
+| `mcp-tools-modal.png` | current | docs/screenshots/README.md | MCP tools detail modal |
+| `memory-providers-list.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Memory providers list page (Redis, Pinecone, etc.) |
+| `message-add-provider-modal.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Modal for adding a new message provider |
+| `message-providers-list.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Message providers list page |
+| `monitoring-dashboard.png` | current | USER_GUIDE.md, docs/screenshots/README.md | System monitoring dashboard with health metrics |
+| `onboarding-page.png` | current | USER_GUIDE.md, docs/screenshots/README.md | First-run onboarding flow for new users |
+| `openwebui.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | OpenWebUI provider configuration |
+| `pagination-accessible.png` | current | docs/screenshots/README.md | Pagination with accessibility enhancements |
+| `pagination-after-accessible.png` | current | none | Reworked pagination with accessibility enhancements |
+| `pagination-after.png` | current | none | Pagination component after rework |
+| `pagination.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | Pagination component |
+| `personas-page.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Personas management page |
+| `plugin-security-dashboard.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Plugin security dashboard |
+| `plugin-security-filtered.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Plugin security dashboard with filters applied |
+| `providers-api-memory.png` | current | none | Memory providers page backed by live providers API |
+| `providers-api-tool.png` | current | none | Tool providers page backed by live providers API |
+| `response-profile-add-modal.png` | current | USER_GUIDE.md | Modal for adding a response profile |
+| `response-profile-edit-modal.png` | current | none | Modal for editing an existing response profile |
+| `response-profiles-list.png` | current | USER_GUIDE.md | Response profiles list page |
+| `settings-general-loading.png` | current | USER_GUIDE.md, docs/screenshots/README.md | General settings page in loading state |
+| `settings-general.png` | current | USER_GUIDE.md, docs/screenshots/README.md | General settings page |
+| `settings-messaging-debug.png` | current | docs/screenshots/README.md | Messaging settings with debug mode |
+| `settings-messaging.png` | current | docs/screenshots/README.md | Messaging settings page |
+| `settings-security.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | Security settings page |
+| `showcase-page.png` | current | docs/screenshots/README.md | DaisyUI component showcase page |
+| `sitemap-page.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Initial loading splash shown before the sitemap renders — filename is misleading; image needs re-shooting (see docs/screenshots/README.md) |
+| `specs-action-clicked.png` | current | none | Specifications page after clicking an action |
+| `specs-baseline.png` | current | none | Specifications page baseline state |
+| `specs-detail-page.png` | current | USER_GUIDE.md | Specification detail view rendered in Markdown |
+| `specs-page.png` | current | USER_GUIDE.md, docs/screenshots/README.md | OpenAPI/spec catalog page |
+| `static-pages.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Static pages overview |
+| `system-management-config-tab.png` | current | docs/screenshots/README.md | System management configuration tab |
+| `system-management-page.png` | current | USER_GUIDE.md, docs/screenshots/README.md | System management full page |
+| `system-management.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | System management overview |
+| `template-version-diff-viewer.png` | current | docs/screenshots/README.md | Template version diff viewer for comparing configs |
+| `tool-providers-list.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Tool providers list page (GitHub, Jira, Google Search, etc.) |
+| `tts-supertonic-ready.png` | current | docs/screenshots/README.md | The Voice [Experimental] settings tab with the Supertonic engine loaded and ready (WASM backend shown). |
+| `verification-bots-search.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | Bot search verification view |
+| `verification-personas-copy.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | Persona copy verification |
+| `verification-personas.png` | current | docs/screenshots/README.md, archive/screenshots/README.md | Persona verification view |
+| `webhook-integration.png` | current | USER_GUIDE.md, docs/screenshots/README.md | Webhook integration configuration |
+| `widget-after-removal.png` | current | none | Widget dashboard after removing a widget |
+| `widget-after-reset.png` | current | none | Widget dashboard after layout reset |
+| `widget-dashboard.png` | current | docs/screenshots/README.md | Widget-driven dashboard layout with rearrangeable tiles |
+| `widget-edit-mode.png` | current | none | Widget dashboard in edit mode |
+| `widget-empty-state.png` | current | none | Widget dashboard empty state |
+| `widget-palette.png` | current | none | Widget palette for adding dashboard tiles |
+| `widget-three-added.png` | current | none | Widget dashboard with three widgets added |
+
+## Archived screenshots (`archive/screenshots/`)
+
+> Note: "Used by" matches are by filename. For archived files, a match in USER_GUIDE.md / GUIDED_TOUR.md / docs/screenshots/README.md actually refers to the **current** counterpart in `docs/screenshots/` (those docs embed `screenshots/<name>` paths); the only doc that indexes the archive copies themselves is `archive/screenshots/README.md`.
+
+| Filename | Location | Used by | Description |
+|---|---|---|---|
+| `activity-page.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | Activity page (previous version) |
+| `ai-assist-button.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | AI assist button (previous version) |
+| `ai-button-hover-full.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | AI button hover full context (previous version) |
+| `ai-button-hover.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | AI button hover state (previous version) |
+| `ai-button-loading.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | AI button loading state (previous version) |
+| `analytics-dashboard.png` | archived | USER_GUIDE.md, docs/screenshots/README.md | Analytics dashboard with bot performance metrics |
+| `api-rate-limit.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | API rate limiting (previous version) |
+| `backup-retention-baseline.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | Backup retention baseline (previous version) |
+| `backup-retention-enforced.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | Backup retention enforced (previous version) |
+| `bot-create-page.png` | archived | USER_GUIDE.md, docs/screenshots/README.md, archive/screenshots/README.md | Bot creation page (previous version) |
+| `bot-create-validation.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | Bot creation validation (previous version) |
+| `bot-details-modal.png` | archived | USER_GUIDE.md, docs/screenshots/README.md, archive/screenshots/README.md | Bot details modal (previous version) |
+| `bot-wizard-validation.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | Bot wizard validation (previous version) |
+| `bots-page.png` | archived | USER_GUIDE.md, docs/screenshots/README.md, archive/screenshots/README.md | Bots page (previous version) |
+| `button-loading-real-app.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | Button loading in production (previous version) |
+| `button-loading.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | Button loading state (previous version) |
+| `config-rollback-available.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | Config rollback available (previous version) |
+| `config-rollback-empty.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | Config rollback empty (previous version) |
+| `config-test-helper.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | Config test helper (previous version) |
+| `create-bot-modal.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | Create bot modal (previous version) |
+| `guard-profiles-coverage.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | Guard profiles coverage (previous version) |
+| `guards-modal-enhanced.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | Enhanced guards modal (previous version) |
+| `journey-01-onboarding.png` | archived | USER_GUIDE.md, GUIDED_TOUR.md, docs/screenshots/README.md, archive/screenshots/README.md | Golden-journey onboarding step (previous version) |
+| `journey-02-discord-add.png` | archived | USER_GUIDE.md, GUIDED_TOUR.md, docs/screenshots/README.md, archive/screenshots/README.md | Golden-journey Discord-add step (previous version) |
+| `journey-03-openai-add.png` | archived | USER_GUIDE.md, GUIDED_TOUR.md, docs/screenshots/README.md, archive/screenshots/README.md | Golden-journey OpenAI-add step (previous version) |
+| `journey-04-bot-create.png` | archived | USER_GUIDE.md, GUIDED_TOUR.md, docs/screenshots/README.md, archive/screenshots/README.md | Golden-journey bot-create step (previous version) |
+| `journey-05-bot-chat.png` | archived | USER_GUIDE.md, GUIDED_TOUR.md, docs/screenshots/README.md, archive/screenshots/README.md | Golden-journey bot-chat step (previous version) |
+| `journey-06-activity.png` | archived | USER_GUIDE.md, GUIDED_TOUR.md, docs/screenshots/README.md, archive/screenshots/README.md | Golden-journey activity step (previous version) |
+| `mcp-guard-ux.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | MCP guard UX (previous version) |
+| `openwebui.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | OpenWebUI configuration (previous version) |
+| `pagination-expanded-scope.png` | archived | archive/screenshots/README.md | Pagination expanded scope (previous version) |
+| `pagination.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | Pagination component (previous version) |
+| `settings-security.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | Security settings (previous version) |
+| `system-management.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | System management (previous version) |
+| `verification-bots-search.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | Bot search verification (previous version) |
+| `verification-personas-copy.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | Persona copy verification (previous version) |
+| `verification-personas.png` | archived | docs/screenshots/README.md, archive/screenshots/README.md | Persona verification (previous version) |
+| `widget-overlap-bug.png` | archived | none | Widget dashboard overlap rendering bug (archived bug evidence) |
+
+## Findings
+
+### Orphans (referenced by no checked doc)
+
+Current set (18):
+
+- `docs/screenshots/button-loading-after-light.png`
+- `docs/screenshots/guards-concurrent-test.png`
+- `docs/screenshots/health-dashboard.png`
+- `docs/screenshots/letta-cloud-config.png`
+- `docs/screenshots/letta-localhost-health.png`
+- `docs/screenshots/pagination-after-accessible.png`
+- `docs/screenshots/pagination-after.png`
+- `docs/screenshots/providers-api-memory.png`
+- `docs/screenshots/providers-api-tool.png`
+- `docs/screenshots/response-profile-edit-modal.png`
+- `docs/screenshots/specs-action-clicked.png`
+- `docs/screenshots/specs-baseline.png`
+- `docs/screenshots/widget-after-removal.png`
+- `docs/screenshots/widget-after-reset.png`
+- `docs/screenshots/widget-edit-mode.png`
+- `docs/screenshots/widget-empty-state.png`
+- `docs/screenshots/widget-palette.png`
+- `docs/screenshots/widget-three-added.png`
+
+Archived set (1):
+
+- `archive/screenshots/widget-overlap-bug.png`
+
+Orphans are candidates for either (a) adding to `docs/screenshots/README.md` with a description,
+or (b) archiving/deleting if the feature state they captured is no longer worth tracking.
+
+### Missing references (doc points at a file that does not exist)
+
+None — every screenshot reference in the checked docs resolves to an existing file.
+
+### Convention notes
+
+- `archive/screenshots/analytics-dashboard.png` is listed in this index but **missing from `archive/screenshots/README.md`**.
+- `archive/screenshots/widget-overlap-bug.png` is listed in this index but **missing from `archive/screenshots/README.md`**.
+- `archive/screenshots/pagination-expanded-scope.png` has **no counterpart in `docs/screenshots/`** — per the convention an archive entry should be the previous version of a current screenshot.
+- `archive/screenshots/widget-overlap-bug.png` has **no counterpart in `docs/screenshots/`** — per the convention an archive entry should be the previous version of a current screenshot.
+- `docs/screenshots/` contains `*-after*` filenames (`pagination-after.png`, `pagination-after-accessible.png`, `button-loading-after-light.png`) — the convention forbids `-after` suffixes; these should be renamed or archived.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -2,7 +2,9 @@
 
 Welcome to the Open-Hivemind User Guide. It starts with a **Quick Tour** — the complete first-run user story with screenshots — followed by a detailed reference for every page, organized by the application's menu structure.
 
-> All screenshots show **demo-mode data** (simulated bots and conversations) and are captured automatically by Playwright (`npm run test:journey:guide`), so they stay in sync with the real UI.
+> All screenshots show **demo-mode data** (simulated bots and conversations) and are captured automatically by Playwright (`npm run test:journey:guide`), so they stay in sync with the real UI. A full index of every screenshot in the repo lives in [SCREENSHOTS.md](SCREENSHOTS.md).
+
+> Prefer a story? The **[Guided Tour](GUIDED_TOUR.md)** follows Sam, a community manager, through building a complete support swarm — onboarding, two persona-driven bots, guardrails, memory, MCP tools, and backup — at a deeper level than the Quick Tour below.
 
 ## Quick Tour — your first session
 
@@ -12,7 +14,7 @@ Start the server (`npm run dev`) and open `http://localhost:3028`. On a fresh in
 ![Onboarding wizard](screenshots/journey-01-onboarding.png)
 
 ### 2. Connect a message platform
-Add your Discord (or Slack/Mattermost) bot token under **Messaging**. The connection is validated immediately, and one token can back several bot personas.
+Add your Discord (or Slack/Mattermost/Telegram) bot token under **Messaging**. The connection is validated immediately, and one token can back several bot personas.
 
 ![Adding a Discord connection](screenshots/journey-02-discord-add.png)
 
@@ -47,7 +49,7 @@ Open the bot's detail drawer and use **Test Drive** to exchange a message with t
 ![Guard profiles](screenshots/journey-08-guards.png)
 
 ### 9. Add memory
-**Memory** configures a backend (Mem0, Mem4AI, MemVault, or PostgreSQL) so bots remember context across conversations, with retention and eviction controls.
+**Memory** configures a backend (Mem0, Mem4AI, MemVault, or PostgreSQL) so bots remember context across conversations, with retention and eviction controls. The built-in MemVault store persists to the app's SQLite database, so memories survive restarts.
 
 ![Memory provider configuration](screenshots/journey-09-memory.png)
 
@@ -134,7 +136,7 @@ reference sections below for screenshots and per-page detail.
 > *As an operator, I want one bot answering in my Discord/Slack/Mattermost channel.*
 
 1. Open the [Setup Wizard](#onboarding-wizard) — it launches automatically on first start, from the Demo Mode banner's **Get Started** button, or any time from **Settings → Rerun Setup Wizard**.
-2. **Message Provider**: pick Discord, Slack, or Mattermost and paste the credentials (bot token for Discord; bot + app token and signing secret for Slack; URL + token for Mattermost). See [Message Platforms](#message-platforms).
+2. **Message Provider**: pick Discord, Slack, Mattermost, or Telegram and paste the credentials (bot token for Discord; bot + app token and signing secret for Slack; URL + token for Mattermost; @BotFather bot token for Telegram). See [Message Platforms](#message-platforms).
 3. **LLM Provider**: pick OpenAI, Flowise, or OpenWebUI and enter the API key. Any OpenAI-compatible endpoint (e.g. a local Ollama or vLLM server) works via the OpenAI provider's base-URL field. See [LLM Providers](#llm-providers).
 4. **Create a Bot**: name it and link it to the providers from steps 2–3.
 5. **Review** and launch. The wizard summary shows a green check next to each configured provider.
@@ -201,7 +203,7 @@ reference sections below for screenshots and per-page detail.
 
 > *As a builder, I want my bot to call external tools (search, tickets, databases) via Model Context Protocol.*
 
-1. Add the server under [MCP Servers](#mcp-servers) (by URL) and wait for the connection check to pass; its tools are discovered automatically.
+1. Add the server under [MCP Servers](#mcp-servers) (by URL — `stdio://`, `http(s)://`, and `sse://` transports are all supported) and wait for the connection check to pass; its tools are discovered automatically. Servers already assigned to a bot's configuration connect automatically at startup.
 2. Inspect them on [MCP Tools](#mcp-tools) — view each tool's input/output schema and test it directly in Form or JSON mode before any bot touches it.
 3. Enable the tools you want and scope access per bot via [Guards](#guards) tool permissions.
 4. Verify in conversation that the bot invokes the tool, and audit usage on the [Activity Feed](#activity-feed).
@@ -213,18 +215,18 @@ reference sections below for screenshots and per-page detail.
 1. Automatic: the server takes a daily configuration backup with a 7-backup retention window — view the history under [System Management](#system-management).
 2. Manual: create a backup before risky changes from [System Backups & Export](#system-backups--export), or download the full config as JSON/YAML/CSV.
 3. Restore by importing the file on the same page, or roll back individual config sections via [Global Defaults](#global-defaults) hot-reload snapshots.
-4. Note: scheduled bot tasks (recurring prompts via the `/api/bots/:id/tasks` API) are currently held in memory only and are **not** included in backups — they are lost on restart. See [docs/ROADMAP.md](ROADMAP.md).
+4. Note: scheduled bot tasks (recurring prompts via the `/api/bots/:id/tasks` API) are currently held in memory only and are **not** included in backups — they are lost on restart. See [ROADMAP.md](../ROADMAP.md).
 
 ### Workflow 10: Lock down a public-facing deployment
 
 > *As an admin, I'm exposing the WebUI beyond localhost and need it secured.*
 
-1. Set `NODE_ENV=production` — this enforces strict validation; the app refuses to start without a proper `SESSION_SECRET` (≥ 32 chars).
+1. Set `NODE_ENV=production` — this enforces strict validation; the app refuses to start without a proper `SESSION_SECRET` (≥ 32 chars). All protected API routes share a single authentication middleware (session or JWT bearer) that verifies the token's user still exists and returns uniform JSON 401/403 bodies; the E2E test bypass (`ALLOW_TEST_BYPASS`) is hard-refused in production.
 2. Set strong `ADMIN_PASSWORD`, `SESSION_SECRET`, `JWT_SECRET`, and `JWT_REFRESH_SECRET`; disable `ALLOW_LOCALHOST_ADMIN`/`ALLOW_LOCAL_NETWORK_ACCESS`.
 3. Restrict access: `ADMIN_IP_WHITELIST` for the admin UI, `CORS_ORIGIN`, `TRUST_PROXY` behind a reverse proxy, and rate limits (`RATE_LIMIT_API_MAX`). Webhook endpoints are deny-by-default — allow specific callers via `WEBHOOK_IP_WHITELIST` (exact IPs, no CIDR).
 4. Configure [Guards](#guards) for content filtering and tool permissions, and review [Plugin Security](#plugin-security) trust levels for any community packages.
 5. Confirm [Audit & Governance](#audit--governance) is recording admin actions, then re-run the daily health check (Workflow 6).
-6. Note: two-factor authentication and account lockout are **not yet available** (under security review — see [docs/ROADMAP.md](ROADMAP.md)); compensate with IP restrictions and a strong password.
+6. Note: two-factor authentication and account lockout are **not yet available** (under security review — see [ROADMAP.md](../ROADMAP.md)); compensate with IP restrictions and a strong password.
 
 ---
 
@@ -309,6 +311,7 @@ Manage connections to Large Language Model providers.
 *   **Add Profile**: Configure reusable connection templates for services like OpenAI, Anthropic, Google Gemini, or local models (via Ollama/vLLM).
 *   **System Default**: Define the fallback provider for bots without a specific profile.
 *   **WebUI Intelligence**: Select a provider to power internal AI features.
+*   **OpenWebUI fidelity**: conversation history keeps assistant/system roles intact (the model sees its own prior replies as assistant turns), and each bot's own API URL/key/model settings are honored, falling back to the global `OPEN_WEBUI_*` configuration.
 
 ![LLM Providers List](screenshots/llm-providers-list.png)
 ![Add LLM Profile](screenshots/llm-add-profile-modal.png)
@@ -320,9 +323,9 @@ Connect your bots to messaging services.
 ![Add Message Provider](screenshots/message-add-provider-modal.png)
 
 *   **Discord**: Add your Discord Bot Token and configure server settings.
-*   **Slack**: Set up your Slack App Token and Bot Token.
+*   **Slack**: Set up your Slack App Token and Bot Token. Interactive components (buttons, modals) are acknowledged immediately and dispatched through a generic `action_id` registry; actions without a registered handler are forwarded into the bot's normal message pipeline so the LLM can respond.
 *   **Mattermost**: Configure your Mattermost URL and Bot Token.
-*   **Telegram**: Add your Telegram Bot Token (obtained from @BotFather).
+*   **Telegram**: Add your Telegram Bot Token (obtained from @BotFather). Messages are received via long-polling, so no public webhook URL is required.
 *   **Status**: Check connection health for each platform.
 
 ### [Memory Providers](/admin/providers/memory)
@@ -331,6 +334,7 @@ Configure memory providers for persistent context and knowledge storage.
 ![Memory Providers List](screenshots/memory-providers-list.png)
 
 *   **Provider Types**: Support for Redis, Pinecone, and other database or vector storage backends.
+*   **Durable MemVault**: the built-in MemVault backend persists memories to the app's SQLite database (write-through cache on top; set `durable: false` to keep it in-memory only), and long conversations are summarized automatically in the message pipeline.
 *   **Configuration Details**: View connection parameters like host and environment.
 *   **Bot Associations**: See which bots are actively utilizing each memory profile.
 *   **System Default**: Define the fallback memory provider for bots without a specific profile.
@@ -371,6 +375,8 @@ Manage Model Context Protocol servers to extend bot capabilities with external t
 
 *   **Server List**: View and manage connected MCP servers.
 *   **Add Server**: Connect to a new MCP server by URL.
+*   **Transports**: `stdio://`, `http://`/`https://` (streamable HTTP), and `sse://` server URLs are supported; an optional API key is sent as a Bearer header on network transports.
+*   **Auto-Connect at Startup**: servers assigned to bots in their configuration connect automatically when the app starts — no manual connect step needed.
 *   **Tool Discovery**: Automatically discover tools provided by connected servers.
 *   **Connection Status**: Monitor server health and retry failed connections.
 
@@ -520,7 +526,7 @@ The Setup Wizard guides you through the minimum configuration required to run a 
 | Step | What you configure |
 |------|-------------------|
 | 1. Welcome | Overview of what's needed |
-| 2. Message Provider | Choose a platform (Discord, Slack, Mattermost) and enter credentials |
+| 2. Message Provider | Choose a platform (Discord, Slack, Mattermost, Telegram) and enter credentials |
 | 3. LLM Provider | Choose an AI provider (OpenAI, Flowise, OpenWebUI) and enter API key |
 | 4. Create a Bot | Name your first bot and link it to the providers from steps 2 & 3 |
 | 5. Review | Confirm configuration and launch |
@@ -682,3 +688,5 @@ You can trigger the **Update Screenshots** workflow manually from the Actions ta
 npm run generate-docs
 ```
 This process runs the End-to-End (E2E) tests located in `tests/e2e/screenshot-*.spec.ts`, captures the UI state natively, and saves the images to `docs/screenshots/`.
+
+A complete tracking index of every screenshot (current and archived), with where each one is used, lives in [SCREENSHOTS.md](SCREENSHOTS.md). The naming/archival convention is documented in [CLAUDE.md](../CLAUDE.md).

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -1,7 +1,8 @@
 # Screenshots — Current State
 This directory contains the canonical (current) screenshots of the Open Hivemind UI.
 When a screenshot is updated, the previous version moves to `archive/screenshots/` under the same filename.
-See [CLAUDE.md](/CLAUDE.md) for the screenshot naming and archival convention.
+See [CLAUDE.md](/CLAUDE.md) for the screenshot naming and archival convention, and
+[docs/SCREENSHOTS.md](../SCREENSHOTS.md) for the full tracking index of every screenshot (current + archived) with where each one is used.
 ## How to Regenerate Screenshots
 Screenshots are generated automatically using Playwright:
 To add a new screenshot:


### PR DESCRIPTION
## Summary

Three documentation deliverables on top of today's feature merges:

### 1. `docs/GUIDED_TOUR.md` (new)
A narrative, persona-driven walkthrough — **"Sam sets up a support swarm"** — that goes deeper than the User Guide's Quick Tour: onboarding → providers → two bots with different personas → guard profile → test drive → real channel chat → activity/monitoring → memory → MCP tool with human-in-the-loop approval → export/backup. Reuses the existing `journey-01..11` screenshots (no recaptures); steps without a matching screenshot are written without one and tracked in a **Screenshots wanted** list at the bottom (real-channel chat, MCP approval prompt, two-bot fleet view). Linked from the top of USER_GUIDE.md and the README documentation list.

### 2. `docs/SCREENSHOTS.md` (new)
A single tracking index of **all 166 screenshots** (128 current in `docs/screenshots/`, 38 archived in `archive/screenshots/`): filename | location | used-by (grep-verified against USER_GUIDE.md, GUIDED_TOUR.md, both screenshot READMEs, and the root README) | one-line description (reused from `docs/screenshots/README.md` where available). Header notes regeneration (`npm run test:journey:guide` / `npm run generate-docs`) and points to the CLAUDE.md convention. Linked from USER_GUIDE.md and `docs/screenshots/README.md`.

**Findings surfaced by the index:**
- **18 orphan current screenshots** (referenced by no doc), e.g. the `widget-*` set, `letta-cloud-config`, `providers-api-*`, `specs-baseline`; **1 orphan archived** (`widget-overlap-bug.png`).
- **0 missing references** — every screenshot referenced by the docs exists on disk.
- Convention notes: `analytics-dashboard.png` + `widget-overlap-bug.png` absent from the archive README; `pagination-expanded-scope.png` / `widget-overlap-bug.png` have no `docs/` counterpart; three `*-after*` filenames violate the no-suffix rule.

### 3. `docs/USER_GUIDE.md` staleness refresh
Brief updates for the six features merged today:
- **Telegram is real** (#3030): added to Quick Tour, Workflow 2, the wizard table, and Message Platforms (long-polling, no public webhook URL).
- **Slack generic actions** (#3027): `action_id` registry dispatch, unmatched actions forwarded to the message pipeline.
- **MCP auto-connect + transports** (#3028): bot-assigned servers connect at startup; `stdio://` / `http(s)://` / `sse://` documented in Workflow 8 and MCP Servers.
- **Durable MemVault + summarization** (#3032): SQLite-backed persistence noted in Quick Tour step 9 and Memory Providers.
- **OpenWebUI role fidelity** (#3026): history roles preserved, per-bot config honored.
- **Auth consolidation** (#3029): single middleware, uniform JSON 401/403, production refusal of the test bypass — noted in Workflow 10.

Also fixed two pre-existing broken `ROADMAP.md` relative links in USER_GUIDE.md (pointed at `docs/ROADMAP.md`, which doesn't exist).

## Verification
- All relative image/file links in the five touched docs resolve (scripted check; the only non-resolving links are intentional in-app `/admin/...` routes, pre-existing).
- Markdown-only change — no code-adjacent files, lint gate unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)