### PR TITLE
feat(mattermost): implement setModelActivity via custom status API

### DIFF
--- a/packages/message-mattermost/src/MattermostService.ts
+++ b/packages/message-mattermost/src/MattermostService.ts
@@ -34,6 +34,7 @@ export class MattermostService extends EventEmitter implements IMessengerService
     botConfig: any
   ) => Promise<string | null>;
   private subscribedBots = new Set<string>();
+  private lastModelActivity = new Map<string, string>();
 
   public supportsChannelPrioritization: boolean = true;
 
@@ -727,10 +728,49 @@ export class MattermostService extends EventEmitter implements IMessengerService
     }
   }
 
+  /**
+   * Surfaces the active LLM model as the bot's Mattermost custom status
+   * (the short text + emoji shown next to the user).
+   *
+   * Opt-in: set `MATTERMOST_ENABLE_STATUS_UPDATES=true` to enable. This is
+   * gated because updating a bot's custom status requires the token to be a
+   * full user/bot account with status scope, which not every deployment has;
+   * leaving it off keeps the previous no-op behavior.
+   *
+   * Best-effort and self-deduplicating: repeated calls with the same modelId
+   * for the same bot make no API call, and any API failure is swallowed (the
+   * underlying client logs it at debug level) so model selection never breaks
+   * message handling.
+   */
   public async setModelActivity(modelId: string, senderKey?: string): Promise<void> {
-    void modelId;
-    void senderKey;
-    return;
+    if (process.env.MATTERMOST_ENABLE_STATUS_UPDATES !== 'true') {
+      return;
+    }
+    if (!modelId) {
+      return;
+    }
+
+    const botName = senderKey || Array.from(this.clients.keys())[0];
+    if (!botName) {
+      return;
+    }
+
+    if (this.lastModelActivity.get(botName) === modelId) {
+      return;
+    }
+
+    const client = this.clients.get(botName);
+    if (!client || typeof client.setCustomStatus !== 'function') {
+      return;
+    }
+
+    try {
+      await client.setCustomStatus(`Model: ${modelId}`);
+      this.lastModelActivity.set(botName, modelId);
+      debug(`[${botName}] Set Mattermost custom status: Model: ${modelId}`);
+    } catch (error) {
+      debug(`Mattermost setModelActivity failed for ${botName}:`, error);
+    }
   }
 
   public async shutdown(): Promise<void> {
@@ -743,6 +783,7 @@ export class MattermostService extends EventEmitter implements IMessengerService
       }
     }
     this.subscribedBots.clear();
+    this.lastModelActivity.clear();
     this.messageHandler = undefined;
     MattermostService.instance = undefined;
   }

--- a/packages/message-mattermost/src/mattermostClient.ts
+++ b/packages/message-mattermost/src/mattermostClient.ts
@@ -419,6 +419,33 @@ export default class MattermostClient {
   }
 
   /**
+   * Sets the bot's custom status (the short text + emoji shown next to the
+   * user in Mattermost). Used to surface the active LLM model.
+   *
+   * Maps to `PUT /api/v4/users/me/status/custom`. Best-effort: any failure
+   * (unsupported server version, missing scope, network error) is swallowed
+   * and logged at debug level so it can never disrupt message handling.
+   *
+   * @param text  Status text (truncated to 100 chars to match Mattermost limits).
+   * @param emoji Emoji name without colons (defaults to "robot_face").
+   */
+  async setCustomStatus(text: string, emoji = 'robot_face'): Promise<void> {
+    if (!this.connected) {
+      return;
+    }
+    try {
+      await this.api.put('/users/me/status/custom', {
+        emoji,
+        text: text.slice(0, 100),
+      });
+    } catch (error: unknown) {
+      logger.debug('Mattermost custom status update failed', {
+        error: isHttpError(error) ? error.message : error,
+      });
+    }
+  }
+
+  /**
    * Best-effort typing indicator.
    *
    * Prefers the realtime WebSocket channel (Mattermost `user_typing` action),

--- a/packages/message-mattermost/src/mattermostClientStatus.test.ts
+++ b/packages/message-mattermost/src/mattermostClientStatus.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests for MattermostClient.setCustomStatus() — the REST call that backs
+ * MattermostService.setModelActivity(). Verifies the correct endpoint/payload,
+ * the 100-char truncation, the not-connected guard, and best-effort error
+ * swallowing.
+ */
+
+import MattermostClient from './mattermostClient';
+
+const getApi = (client: MattermostClient) => (client as unknown as { api: { put: jest.Mock } }).api;
+
+const buildClient = (connected = true): MattermostClient => {
+  const client = new MattermostClient({ serverUrl: 'https://mm.example.com', token: 'tok' });
+  (client as unknown as { connected: boolean }).connected = connected;
+  getApi(client).put = jest.fn().mockResolvedValue({});
+  return client;
+};
+
+describe('MattermostClient.setCustomStatus', () => {
+  it('PUTs to /users/me/status/custom with text and default emoji', async () => {
+    const client = buildClient();
+    await client.setCustomStatus('Model: gpt-4o');
+
+    expect(getApi(client).put).toHaveBeenCalledTimes(1);
+    expect(getApi(client).put).toHaveBeenCalledWith('/users/me/status/custom', {
+      emoji: 'robot_face',
+      text: 'Model: gpt-4o',
+    });
+  });
+
+  it('respects a custom emoji', async () => {
+    const client = buildClient();
+    await client.setCustomStatus('busy', 'gear');
+    expect(getApi(client).put).toHaveBeenCalledWith('/users/me/status/custom', {
+      emoji: 'gear',
+      text: 'busy',
+    });
+  });
+
+  it('truncates status text to 100 characters', async () => {
+    const client = buildClient();
+    const long = 'x'.repeat(150);
+    await client.setCustomStatus(long);
+    const payload = getApi(client).put.mock.calls[0][1];
+    expect(payload.text).toHaveLength(100);
+  });
+
+  it('no-ops when not connected', async () => {
+    const client = buildClient(false);
+    await client.setCustomStatus('Model: gpt-4o');
+    expect(getApi(client).put).not.toHaveBeenCalled();
+  });
+
+  it('swallows API errors (best-effort)', async () => {
+    const client = buildClient();
+    getApi(client).put = jest.fn().mockRejectedValue(new Error('missing scope'));
+    await expect(client.setCustomStatus('Model: gpt-4o')).resolves.toBeUndefined();
+  });
+});

--- a/packages/message-mattermost/src/mattermostModelActivity.test.ts
+++ b/packages/message-mattermost/src/mattermostModelActivity.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Regression test for audit stub (mattermost-model-activity):
+ * MattermostService.setModelActivity() used to be a no-op. It now (opt-in via
+ * MATTERMOST_ENABLE_STATUS_UPDATES=true) sets the bot's Mattermost custom
+ * status to surface the active LLM model, with de-duplication and best-effort
+ * error handling.
+ */
+
+jest.mock('@src/config/BotConfigurationManager', () => ({
+  __esModule: true,
+  default: {
+    getInstance: jest.fn().mockReturnValue({ getAllBots: jest.fn().mockReturnValue([]) }),
+  },
+}));
+
+describe('MattermostService.setModelActivity', () => {
+  const ORIGINAL_ENV = process.env.MATTERMOST_ENABLE_STATUS_UPDATES;
+
+  afterEach(async () => {
+    process.env.MATTERMOST_ENABLE_STATUS_UPDATES = ORIGINAL_ENV;
+    jest.resetModules();
+  });
+
+  /** Builds a service singleton with one injected fake client. */
+  const buildService = async () => {
+    const { MattermostService } = await import('./MattermostService');
+    const service = MattermostService.getInstance();
+    const setCustomStatus = jest.fn().mockResolvedValue(undefined);
+    const fakeClient = { setCustomStatus } as any;
+    (service as any).clients.set('bot1', fakeClient);
+    (service as any).botConfigs.set('bot1', { name: 'bot1' });
+    return { service, setCustomStatus };
+  };
+
+  it('no-ops by default (flag disabled) — graceful, no API call', async () => {
+    delete process.env.MATTERMOST_ENABLE_STATUS_UPDATES;
+    const { service, setCustomStatus } = await buildService();
+
+    await expect(service.setModelActivity('gpt-4o', 'bot1')).resolves.toBeUndefined();
+    expect(setCustomStatus).not.toHaveBeenCalled();
+
+    await service.shutdown();
+  });
+
+  it('sets the custom status when the flag is enabled', async () => {
+    process.env.MATTERMOST_ENABLE_STATUS_UPDATES = 'true';
+    const { service, setCustomStatus } = await buildService();
+
+    await service.setModelActivity('gpt-4o', 'bot1');
+
+    expect(setCustomStatus).toHaveBeenCalledTimes(1);
+    expect(setCustomStatus).toHaveBeenCalledWith('Model: gpt-4o');
+
+    await service.shutdown();
+  });
+
+  it('de-duplicates repeated calls with the same model for a bot', async () => {
+    process.env.MATTERMOST_ENABLE_STATUS_UPDATES = 'true';
+    const { service, setCustomStatus } = await buildService();
+
+    await service.setModelActivity('gpt-4o', 'bot1');
+    await service.setModelActivity('gpt-4o', 'bot1');
+    expect(setCustomStatus).toHaveBeenCalledTimes(1);
+
+    // A different model triggers another update.
+    await service.setModelActivity('claude-opus', 'bot1');
+    expect(setCustomStatus).toHaveBeenCalledTimes(2);
+    expect(setCustomStatus).toHaveBeenLastCalledWith('Model: claude-opus');
+
+    await service.shutdown();
+  });
+
+  it('falls back to the first bot when no senderKey is given', async () => {
+    process.env.MATTERMOST_ENABLE_STATUS_UPDATES = 'true';
+    const { service, setCustomStatus } = await buildService();
+
+    await service.setModelActivity('gpt-4o');
+    expect(setCustomStatus).toHaveBeenCalledWith('Model: gpt-4o');
+
+    await service.shutdown();
+  });
+
+  it('swallows client errors (best-effort)', async () => {
+    process.env.MATTERMOST_ENABLE_STATUS_UPDATES = 'true';
+    const { MattermostService } = await import('./MattermostService');
+    const service = MattermostService.getInstance();
+    const setCustomStatus = jest.fn().mockRejectedValue(new Error('boom'));
+    (service as any).clients.set('bot1', { setCustomStatus } as any);
+    (service as any).botConfigs.set('bot1', { name: 'bot1' });
+
+    await expect(service.setModelActivity('gpt-4o', 'bot1')).resolves.toBeUndefined();
+    expect(setCustomStatus).toHaveBeenCalledTimes(1);
+
+    await service.shutdown();
+  });
+
+  it('no-ops gracefully when no clients are registered', async () => {
+    process.env.MATTERMOST_ENABLE_STATUS_UPDATES = 'true';
+    const { MattermostService } = await import('./MattermostService');
+    const service = MattermostService.getInstance();
+
+    await expect(service.setModelActivity('gpt-4o')).resolves.toBeUndefined();
+
+    await service.shutdown();
+  });
+});


### PR DESCRIPTION
Salvaged from the branch cleanup (feat/stub-mattermost-model-activity — the only branch of 333 with genuinely unlanded work), rebased onto current main alongside the WS-typing changes.

Implements the previously-stubbed `MattermostService.setModelActivity` via `PUT /api/v4/users/me/status/custom` (custom status text + robot emoji showing the active LLM model). Opt-in via `MATTERMOST_ENABLE_STATUS_UPDATES`; best-effort (failures logged at debug, never disrupt messaging); deduplicates unchanged statuses.

Verification: tsc clean; 8 mattermost suites / 42 tests pass (incl. the branch's new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)