### PR TITLE
chore(release): v1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-hivemind",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "packageManager": "pnpm@10.25.0",
   "description": "Multi-agent orchestration framework: deploy a coordinated network of LLM-powered bot personas across Discord, Slack, and Mattermost simultaneously",
   "repository": {


### PR DESCRIPTION
Bump package.json 1.0.0 → 1.3.0 (repo tags were already at v1.2.0; the manifest had drifted).

On merge, v1.3.0 will be tagged and a GitHub release published with notes covering: Telegram messenger, durable MemVault memory + conversation summarization, MCP startup auto-connect + HTTP/SSE transports, Slack generic action dispatch, auth middleware consolidation, monitoring/activity truth fixes, UI/UX polish rounds 1-2, Docker production fixes, docs overhaul (User Guide / Guided Tour / SCREENSHOTS index / DEVELOPER.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)