### PR TITLE
fix(config): apply LLM/guardrail/MCP profiles for bots without user-config overrides

### DIFF
--- a/src/config/botConfigFactory.ts
+++ b/src/config/botConfigFactory.ts
@@ -231,6 +231,12 @@ export function createBotConfig(
 
   applyUserOverrides(botName, config, userConfigStore);
 
+  // Profiles must apply even when the bot has no user-config override entry
+  // (applyUserOverrides early-returns in that case).
+  applyLlmProfile(config);
+  applyGuardrailProfile(config);
+  applyMcpServerProfile(config);
+
   return config;
 }
 
@@ -287,8 +293,4 @@ function applyUserOverrides(botName: string, config: BotConfig, userConfigStore:
   if (!config.mcpServers) {
     config.mcpServers = [];
   }
-
-  applyLlmProfile(config);
-  applyGuardrailProfile(config);
-  applyMcpServerProfile(config);
 }


### PR DESCRIPTION
## Summary
- `applyLlmProfile` / `applyGuardrailProfile` / `applyMcpServerProfile` were only invoked inside `applyUserOverrides`, which early-returns when a bot has no WebUI override entry.
- Result: `BOTS_<name>_LLM_PROFILE` (the documented, recommended multi-bot config style) was **silently ignored** for purely env-configured bots — their `openai` block stayed empty (no apiKey/model/baseUrl).
- Fix: move the three profile-application calls into `createBotConfig` so they always run after user overrides.

## Verification
- Repro: 16 env-only bots with `LLM_PROFILE` set → before: all `openai.apiKey` missing; after: all resolve model/baseUrl/key from `config/llm-profiles.json`.
- `npm test -- config`: 11 suites / 125 tests pass.
- Lint warning gate passes; `check-types` errors in `src/provider-configs/**/__tests__` (vitest imports) pre-exist on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)