### PR TITLE
fix(boot): opt-in ALLOW_INSECURE_PRODUCTION to degrade instead of crash

### DIFF
--- a/src/auth/AuthManager.ts
+++ b/src/auth/AuthManager.ts
@@ -93,17 +93,27 @@ export class AuthManager {
       }
     }
 
-    if (process.env.NODE_ENV === 'production') {
+    if (process.env.NODE_ENV === 'production' && process.env.ALLOW_INSECURE_PRODUCTION !== 'true') {
       if (!envJwtSecret && !secureJwtSecret) {
         throw new Error(
-          'CRITICAL: JWT_SECRET environment variable or secure config is required in production.'
+          'CRITICAL: JWT_SECRET environment variable or secure config is required in production. ' +
+            'Set it, or set ALLOW_INSECURE_PRODUCTION=true to auto-generate an ephemeral secret (tokens reset on restart).'
         );
       }
       if (!envJwtRefreshSecret && !secureJwtRefreshSecret) {
         throw new Error(
-          'CRITICAL: JWT_REFRESH_SECRET environment variable or secure config is required in production.'
+          'CRITICAL: JWT_REFRESH_SECRET environment variable or secure config is required in production. ' +
+            'Set it, or set ALLOW_INSECURE_PRODUCTION=true to auto-generate an ephemeral secret (tokens reset on restart).'
         );
       }
+    } else if (
+      process.env.NODE_ENV === 'production' &&
+      ((!envJwtSecret && !secureJwtSecret) || (!envJwtRefreshSecret && !secureJwtRefreshSecret))
+    ) {
+      console.warn(
+        '[SECURITY] ALLOW_INSECURE_PRODUCTION=true — JWT secret(s) missing; auto-generating ephemeral secrets. ' +
+          'All sessions/tokens will be invalidated on every restart. Set JWT_SECRET and JWT_REFRESH_SECRET for stable auth.'
+      );
     }
 
     if (process.env.NODE_ENV === 'test') {
@@ -297,8 +307,14 @@ export class AuthManager {
     let password = process.env.ADMIN_PASSWORD;
 
     if (!password) {
-      if (process.env.NODE_ENV === 'production') {
-        throw new Error('CRITICAL: ADMIN_PASSWORD environment variable is required in production.');
+      if (
+        process.env.NODE_ENV === 'production' &&
+        process.env.ALLOW_INSECURE_PRODUCTION !== 'true'
+      ) {
+        throw new Error(
+          'CRITICAL: ADMIN_PASSWORD environment variable is required in production. ' +
+            'Set it, or set ALLOW_INSECURE_PRODUCTION=true to auto-generate a temporary password (logged at startup).'
+        );
       }
 
       password = crypto.randomBytes(16).toString('hex');

--- a/src/database/EncryptionService.ts
+++ b/src/database/EncryptionService.ts
@@ -38,8 +38,14 @@ export class EncryptionService {
         this.encryptionKey = fs.readFileSync(keyPath);
         debug('Encryption key initialized from .key file');
       } else {
-        if (process.env.NODE_ENV === 'production') {
-          throw new Error('FATAL: DATABASE_ENCRYPTION_KEY is required in production environment.');
+        if (
+          process.env.NODE_ENV === 'production' &&
+          process.env.ALLOW_INSECURE_PRODUCTION !== 'true'
+        ) {
+          throw new Error(
+            'FATAL: DATABASE_ENCRYPTION_KEY is required in production environment. ' +
+              'Set it to enable at-rest encryption, or set ALLOW_INSECURE_PRODUCTION=true to run degraded (plaintext).'
+          );
         }
 
         console.warn(

--- a/src/plugins/PluginManager.ts
+++ b/src/plugins/PluginManager.ts
@@ -434,9 +434,10 @@ export async function listInstalledPlugins(): Promise<PluginInfo[]> {
 let PLUGIN_SIGNING_KEY = process.env.HIVEMIND_PLUGIN_SIGNING_KEY;
 
 if (!PLUGIN_SIGNING_KEY) {
-  if (process.env.NODE_ENV === 'production') {
+  if (process.env.NODE_ENV === 'production' && process.env.ALLOW_INSECURE_PRODUCTION !== 'true') {
     throw new Error(
-      'CRITICAL: HIVEMIND_PLUGIN_SIGNING_KEY environment variable is required in production.'
+      'CRITICAL: HIVEMIND_PLUGIN_SIGNING_KEY environment variable is required in production. ' +
+        'Set it, or set ALLOW_INSECURE_PRODUCTION=true to auto-generate an ephemeral key (existing plugin signatures will fail verification).'
     );
   }
 

--- a/src/utils/envValidation.ts
+++ b/src/utils/envValidation.ts
@@ -19,7 +19,12 @@ const envSchema = z
   })
   .passthrough() // Allow other environment variables
   .superRefine((env, ctx) => {
-    if (env.NODE_ENV === 'production') {
+    // ALLOW_INSECURE_PRODUCTION=true opts out of the production-required checks so
+    // the app boots lean (degraded features) instead of failing closed. Mirrors the
+    // inline guards in EncryptionService / AuthManager / PluginManager. Base-schema
+    // validations (PORT format, non-empty tokens) still apply regardless.
+    const allowInsecure = process.env.ALLOW_INSECURE_PRODUCTION === 'true';
+    if (env.NODE_ENV === 'production' && !allowInsecure) {
       if (!env.OPENAI_API_KEY || env.OPENAI_API_KEY.trim().length === 0) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
@@ -100,6 +105,14 @@ const envSchema = z
  * Throws an error if validation fails, allowing the caller to decide how to handle it.
  */
 export function validateRequiredEnvVars(): void {
+  if (process.env.NODE_ENV === 'production' && process.env.ALLOW_INSECURE_PRODUCTION === 'true') {
+    Logger.warn(
+      '[SECURITY] ALLOW_INSECURE_PRODUCTION=true — skipping production env-var requirements ' +
+        '(OPENAI_API_KEY, SESSION_SECRET, JWT/signing secrets, admin password, messaging token). ' +
+        'The app will boot with degraded/disabled features. Configure these for a secure deployment.'
+    );
+  }
+
   const result = envSchema.safeParse(process.env);
 
   if (!result.success) {


### PR DESCRIPTION
## Problem
The 5 production secret guards (`DATABASE_ENCRYPTION_KEY`, `JWT_SECRET`, `JWT_REFRESH_SECRET`, `ADMIN_PASSWORD`, `HIVEMIND_PLUGIN_SIGNING_KEY`) hard-`throw` when unset in production, exiting the process **before the HTTP server binds**. On Render this surfaces as a `Port scan timeout reached, no open ports detected` → `update_failed` — every deploy fails identically even though the build succeeds and the app boots.

## Fix
Each guard already has a graceful fallback (plaintext encryption, auto-generated ephemeral JWT secrets, temp admin password, ephemeral plugin key) used in non-production. This routes production to those same fallbacks when `ALLOW_INSECURE_PRODUCTION=true`, logging a clear warning instead of crashing.

**Secure-by-default is unchanged:** with the flag unset, production still fails closed exactly as before. One opt-in flag replaces needing all five secrets for users who want to run lean.

## Test
- `tsc --noEmit` clean.
- Service confirmed live after providing the secrets the other way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)