### PR TITLE
docs: vision-first entry point, honest status, legacy architecture section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,9 @@
 Thanks for your interest in contributing! This guide covers everything you need to get a
 development environment running and a pull request merged.
 
+> Before diving in, skim the [Vision](docs/VISION.md) for what the project is building toward and an
+> honest snapshot of what's done vs. remaining, and the [Roadmap](ROADMAP.md) for concrete next steps.
+
 ## Development setup
 
 **Prerequisites:** Node.js 22 (an `.nvmrc` is provided) and [pnpm](https://pnpm.io/).

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 Open-Hivemind is a **multi-agent orchestration framework** that transcends the traditional "one bot, one platform" model. Instead of deploying a single chatbot, you deploy a coordinated network of unique personas across Discord, Slack, and Mattermost simultaneously (with outbound Telegram support).
 
+> 🧭 **Vision & honest status:** see [docs/VISION.md](docs/VISION.md) — what we're building toward and a truthful built-vs-remaining snapshot.
 > 🗺️ **Roadmap & status:** see [ROADMAP.md](ROADMAP.md) — a code-audited, nested checklist of what's shipped, what's partial, and what's planned (also summarized [at the bottom of this README](#project-status--roadmap)). Quick gate-check: `npm run test:journey`.
 
 Think of it less as a bot and more as a **digital ecosystem**. You can have as many bots as you want—each with its own distinct personality, memory, and directives—living alongside your human users in the same channels.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,8 @@
 > Statuses reflect what the code actually does, not aspirations.
 > `[x]` = verified working in code. Nested items show partial progress.
 
-**Snapshot:** ~232 features complete · ~44 partial · ~20 stubs · 0 known-broken.
+**Snapshot:** see [docs/FEATURE_STATUS.md](docs/FEATURE_STATUS.md) for the authoritative per-feature
+totals (currently **218 complete · 64 partial · 20 stub · 5 planned · 0 broken** across 307 features).
 The platform core (multi-bot Discord/Slack/Mattermost, OpenAI/Flowise/Letta/OpenSwarm/OpenWebUI
 LLM providers, 5-stage message pipeline, persona system, guard profiles, MCP tool execution
 with HITL approval, SQLite/Postgres persistence, WebUI admin with 35+ pages, TOTP 2FA,

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,51 @@
+# Glossary
+
+Core Open-Hivemind terms, defined as the **code** uses them (not aspirationally). Where a term maps
+to a concrete module or contract, that's noted so you can read the source of truth.
+
+- **Hivemind** — the collective of multiple bot agents running together and coexisting with humans in
+  shared channels. The project's unit of interest is the *hivemind*, not a single chatbot. See
+  [VISION.md](VISION.md).
+
+- **Bot (agent / instance)** — one configured unit = a persona + a message provider + an LLM provider,
+  identified by a `botId`/name. Many bots can run under one process and share a channel; the
+  `IMessengerService` contract exposes per-bot delegation via `getDelegatedServices`.
+
+- **Persona** — a reusable identity (system prompt + behavior traits) assignable to one or more bots.
+  Managed by `PersonaManager`; the canonical API is `/api/personas`, persisted to
+  `config/user/custom-personas.json`. Built-in personas are read-only but clonable. The same bot token
+  can speak as different personas in different channels.
+
+- **Selective engagement** — the logic that decides *whether* a bot responds at all, based on
+  relevance, direct address, conversational momentum, and how crowded the channel is ("social
+  anxiety", to avoid pile-ons). It lives in the pipeline's **Decision** stage.
+
+- **Pipeline stage** — one step of the default 5-stage message pipeline
+  (`src/pipeline/createPipeline.ts`): **Receive** (normalize inbound) → **Decision** (selective
+  engagement) → **Enrich** (history + memory) → **Inference** (LLM call) → **Send** (post-process +
+  deliver). The legacy monolithic handler is still available behind `USE_LEGACY_HANDLER` — see
+  [Legacy Architecture](architecture/legacy/message-handling-evolution.md).
+
+- **Guard profile** — a safety bundle applied to a bot: rate limiting, a content filter
+  (`ContentFilterConfig`), and tool-access control (an MCP guard profile, `mcpGuardProfile`). Surfaced
+  in the WebUI under **Guards**.
+
+- **Swarm mode** — how several bots coordinate who replies in one channel. The implemented modes
+  (`SwarmCoordinator`, `SwarmMode`) are: `exclusive`, `broadcast`, `rotating`, `priority`, and
+  `collaborative`. (Note: the WebUI/Response-Profiles UI currently highlights a subset; the full set
+  lives in code.)
+
+- **MCP (Model Context Protocol)** — the protocol for connecting external **tool servers**.
+  Open-Hivemind runs an MCP client, discovers a server's tools, and can execute them from the message
+  pipeline. See the [MCP overview](mcp/overview.md).
+
+- **HITL (human-in-the-loop)** — tools marked **sensitive** require administrator approval before they
+  execute (`ToolManager`); the request lands in an approval queue rather than running automatically.
+
+- **Provider** — a swappable adapter behind an interface. **Message providers** (Discord, Slack,
+  Mattermost; Telegram send-only) implement `IMessengerService`; **LLM providers** (OpenAI, Flowise,
+  OpenWebUI, Letta, OpenSwarm) implement the LLM contract; **memory providers** (Mem0, Mem4AI,
+  MemVault, PostgreSQL) back conversation memory.
+
+See also: [VISION.md](VISION.md) · [Architecture Overview](architecture/overview.md) ·
+[FEATURE_STATUS.md](FEATURE_STATUS.md) (what's built vs. partial).

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ This directory contains all documentation for Open Hivemind, organized by topic.
 - [Deployment Configuration](operations/deployment.md)
 - [Netlify Frontend Deployment](operations/deployment-netlify.md)
 - [Maintenance Guide](operations/maintenance.md)
+- [File & Directory Locations](operations/file-locations.md) - where config/data/db/backups/logs live, env overrides, and the proposed XDG support
 - [Security Incident Response](operations/security.md)
 
 ## API Reference

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,11 @@
 
 This directory contains all documentation for Open Hivemind, organized by topic.
 
+## 🧭 Start here
+- [**Vision & honest status**](VISION.md) — what we're building toward + a truthful built-vs-remaining snapshot
+- [Feature Implementation Status](FEATURE_STATUS.md) — the per-feature audit (307 features, 10 domains)
+- [Roadmap](../ROADMAP.md) — code-audited checklist of shipped / partial / planned
+
 ## 🧭 Using Open Hivemind
 - [User Guide](USER_GUIDE.md)
 - [Bot Management](admin/bots.md)
@@ -14,6 +19,7 @@ This directory contains all documentation for Open Hivemind, organized by topic.
 - [Architecture Overview](architecture/overview.md)
 - [Server Architecture](architecture/unified-server.md)
 - [Development Guide](architecture/development.md)
+- [Legacy Architecture](architecture/legacy/README.md) - superseded designs (e.g. the monolithic message handler) and why they changed
 
 ## ⚙️ Operations & Deployment
 - [Setup & Bootstrapping](getting-started/setup-guide.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This directory contains all documentation for Open Hivemind, organized by topic.
 - [**Vision & honest status**](VISION.md) — what we're building toward + a truthful built-vs-remaining snapshot
 - [Feature Implementation Status](FEATURE_STATUS.md) — the per-feature audit (307 features, 10 domains)
 - [Roadmap](../ROADMAP.md) — code-audited checklist of shipped / partial / planned
+- [Glossary](GLOSSARY.md) — core terms (hivemind, persona, guard profile, swarm mode, MCP, pipeline stage, HITL) defined as the code uses them
 
 ## 🧭 Using Open Hivemind
 - [User Guide](USER_GUIDE.md)

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,0 +1,90 @@
+# Vision
+
+> **One line:** Open-Hivemind turns a chat channel into a *community of AI personas* — many distinct agents, each with its own voice, memory, and judgment about when to speak — managed from one dashboard and portable across Discord, Slack, and Mattermost.
+
+This document is the front door to *why* the project exists and *where it honestly stands*. For the
+per-feature audit see [FEATURE_STATUS.md](FEATURE_STATUS.md); for the forward plan see
+[ROADMAP.md](../ROADMAP.md); for how the architecture has evolved see
+[architecture/legacy/](architecture/legacy/README.md).
+
+---
+
+## The thesis
+
+Most chatbot frameworks assume **one bot, one platform, one request → one reply**. Open-Hivemind
+rejects that framing. The interesting unit isn't a bot — it's a *hivemind*: a set of agents that
+coexist with humans in the same channels and behave less like a command line and more like
+participants in a conversation.
+
+Three commitments follow from that:
+
+1. **Personas are first-class, not prompts buried in code.** An identity — its system prompt,
+   traits, and behavior — is a reusable object you assign to bots. The same Discord token can speak
+   as different characters in different channels; the same persona can span platforms.
+
+2. **Agents exercise judgment about *whether* to speak.** A bot listens to the room and decides to
+   respond based on relevance, direct address, conversational momentum, and how crowded the channel
+   already is ("social anxiety" so a dozen bots don't pile on). Silence is a feature.
+
+3. **Operators stay in control without writing code.** Everything — providers, personas, guardrails,
+   memory, tools — is configurable from a WebUI or reproducible from environment variables, with
+   audit logging, human-in-the-loop tool approval, and honest observability over what the swarm does.
+
+## What we are building toward
+
+- **A coordination layer for many agents in shared human spaces** — not a single assistant, but an
+  ecosystem where engagement, hand-off, and restraint are tunable per persona and per channel.
+- **Provider independence.** Messaging platforms, LLM backends, memory stores, and tools are all
+  behind interfaces so you are never locked to one vendor. Bring OpenAI or a local OpenAI-compatible
+  endpoint; bring Discord or Mattermost; swap memory backends without touching bot logic.
+- **Safety you can see.** Guardrails (rate limits, content filtering, tool-access control), 2FA and
+  account lockout, durable audit logs, and a message pipeline whose decisions are inspectable —
+  because agents acting autonomously in real communities must be accountable.
+- **Honesty as a product value.** The documentation says what is built, what is partial, and what is
+  aspirational — and the audit that backs those claims is public and re-verified against the code.
+
+## What's true today (honest status)
+
+The numbers below come from [FEATURE_STATUS.md](FEATURE_STATUS.md), a row-by-row audit of **307
+features across 10 domains**, re-verified against `main` (not aspirations):
+
+| | Count | Meaning |
+|---|---|---|
+| ✅ Complete | **218** | Implemented and wired into a real path |
+| 🟡 Partial | **64** | Works, with documented gaps |
+| 🔲 Stub | **20** | Scaffolding present, not functional |
+| 📋 Planned | **5** | Designed, not started |
+| ❌ Broken | **0** | — |
+
+**Shipped and verified:** multi-bot Discord / Slack / Mattermost (two-way messaging, threads, typing
+indicators); OpenAI, Flowise, Letta, OpenSwarm, and OpenWebUI LLM providers; the 5-stage message
+pipeline; the persona system; guard profiles; MCP tool execution with human-in-the-loop approval;
+SQLite/Postgres persistence; a WebUI admin with 35+ pages; TOTP 2FA, account lockout, session
+management, and audit logging.
+
+**Honestly partial or not yet there** (see [ROADMAP.md](../ROADMAP.md) for the itemized list):
+outbound webhook delivery, Telegram receive, some monitoring wire-ups (threshold alerting), Discord
+voice / speech-to-text, vision/image input, and assorted per-provider edges. Where a screen would
+otherwise show fabricated data, we prefer an honest empty state.
+
+> If you find a claim in the docs that the code doesn't back up, that's a bug — please open an issue.
+> Keeping [FEATURE_STATUS.md](FEATURE_STATUS.md) truthful is part of the project's definition of done.
+
+## Design principles
+
+- **Interfaces over implementations** — every platform, provider, memory store, and tool sits behind
+  a contract; concrete adapters are swappable packages.
+- **Configuration as data** — bots are declared (WebUI or `BOTS_<NAME>_*` env vars) and round-trip
+  through JSON/YAML/CSV export, so a deployment is reproducible.
+- **Observable by default** — activity feed, health checks, Prometheus-compatible metrics, and trace
+  export make the swarm's behavior legible.
+- **Fail honest** — a missing capability shows a clear empty state or a 501, never a fabricated chart.
+
+## Where to go next
+
+- New here? Start with the [README](../README.md) quick start, then the [User Guide](USER_GUIDE.md).
+- Want the architecture? See the [Architecture Overview](architecture/overview.md).
+- Curious how we got here? The [Legacy Architecture](architecture/legacy/README.md) section preserves
+  earlier designs (the monolithic message handler, the legacy persona store) and why they changed.
+- Want to help? [CONTRIBUTING.md](../CONTRIBUTING.md) and the [ROADMAP](../ROADMAP.md) list concrete
+  next steps.

--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -4,7 +4,7 @@ Navigation: [Docs Index](../README.md) | [Layered Overview](layered-overview.md)
 
 
 ## Overview
-Open-Hivemind implements a revolutionary multi-agent architecture where each bot instance operates as a neuron in a digital consciousness. See [PACKAGE.md](../../PACKAGE.md) for technical specifications.
+Open-Hivemind implements a revolutionary multi-agent architecture where each bot instance operates as a neuron in a digital consciousness. See [package.md](../reference/package.md) for technical specifications.
 
 ## Multi-Agent Modes
 
@@ -74,7 +74,7 @@ The WebUI provides comprehensive management capabilities:
 - **Env Override Awareness**: Locked fields clearly indicate environment-variable ownership with redacted previews
 - **OpenAPI Export**: Download JSON/YAML specs for all WebUI endpoints via `/webui/api/openapi`
 
-For implementation details, see the technical documentation in [PACKAGE.md](../../PACKAGE.md).
+For implementation details, see the technical documentation in [package.md](../reference/package.md).
 
 ## Development Roadmap
 See [todo.md](../reference/todo.md) for upcoming features including:

--- a/docs/architecture/layered-overview.md
+++ b/docs/architecture/layered-overview.md
@@ -118,4 +118,4 @@ Mattermost.
 - **Custom tooling** – extend MCC/MCP adapters or add bespoke REST/CLI tools
   through the same guard mechanism.
 
-For a feature-by-feature validation matrix, see [`PACKAGE.md`](../../PACKAGE.md).
+For a feature-by-feature validation matrix, see [`package.md`](../reference/package.md).

--- a/docs/architecture/legacy/README.md
+++ b/docs/architecture/legacy/README.md
@@ -1,0 +1,33 @@
+# Legacy Architecture
+
+This section preserves **earlier designs** of Open-Hivemind — how parts of the system used to look,
+why they were built that way, and what replaced them. It exists for two reasons:
+
+1. **Context for current code.** Several seams still carry the shape of an older design (e.g. the
+   legacy message handler still ships behind a flag). Knowing the history explains why.
+2. **Honest record.** We don't pretend the current architecture sprang fully formed. Documenting the
+   path — including dead ends — is part of the project's [honesty commitment](../../VISION.md).
+
+> These documents describe **superseded** designs. For the architecture as it stands today, see the
+> [Architecture Overview](../overview.md), [Layered Overview](../layered-overview.md), and
+> [Unified Server](../unified-server.md).
+
+## Index
+
+| Topic | Then → Now | Status of the old design |
+|---|---|---|
+| [Message handling](message-handling-evolution.md) | Monolithic `handleMessage()` → 5-stage pipeline (Receive · Decision · Enrich · Inference · Send) | Legacy handler still present behind `USE_LEGACY_HANDLER`; pipeline is the default |
+| _Persona storage_ (planned write-up) | Legacy `/api/agents/personas` store → `PersonaManager` (`/api/personas`) | Legacy store removed; canonical path is `/api/personas` |
+
+_More legacy write-ups are added here as older subsystems are documented. If you remember a design
+that predates these docs, a PR adding it (with the "why it changed") is welcome._
+
+## How to read these
+
+Each legacy document follows the same shape:
+
+- **What it was** — the old design, in enough detail to recognize it in git history.
+- **Why it existed** — the constraints that made it reasonable at the time.
+- **Why it changed** — the pressure that made it untenable.
+- **What replaced it** — a pointer to the current design.
+- **What still remains** — any compatibility shims or flags that keep the old path reachable.

--- a/docs/architecture/legacy/message-handling-evolution.md
+++ b/docs/architecture/legacy/message-handling-evolution.md
@@ -1,0 +1,78 @@
+# Legacy: Monolithic Message Handler → 5-Stage Pipeline
+
+> **Status:** superseded. The pipeline is the default path. The legacy handler still ships behind the
+> `USE_LEGACY_HANDLER` feature flag (`src/message/handlers/messageHandler.ts`) as a fallback and
+> reference. New work targets the pipeline.
+
+## What it was
+
+Originally, every inbound message from every platform funneled into a single function —
+`handleMessage()` in `src/message/handlers/messageHandler.ts`. One function owned the entire
+lifecycle: filtering bot/self messages, deciding whether to respond, fetching channel history and
+memory, building the prompt, calling the LLM, post-processing, and sending the reply (plus typing
+indicators, dedup, audit, and idle scheduling along the way).
+
+```
+inbound message ──▶ handleMessage()  ──▶ reply
+                    └─ everything inline ─┘
+```
+
+## Why it existed
+
+For a single bot on a single platform it was the simplest thing that worked: one place to read, one
+place to change. Control flow was easy to follow top-to-bottom, and there were no stage boundaries to
+coordinate.
+
+## Why it changed
+
+As the project grew toward **many bots across many platforms**, the monolith strained:
+
+- **Untestable in isolation** — "should this bot respond?" couldn't be exercised without also running
+  history fetch, LLM inference, and sending. Each concern was entangled with the next.
+- **No place to observe decisions** — the response/skip choice (the heart of selective engagement)
+  was a branch deep inside one function, with nowhere to attach tracing, metrics, or a pause point.
+- **Hard to extend** — adding content filtering, semantic guardrails, MCP tool calls, or activity
+  recording meant editing the one big function and risking everything else.
+- **Cross-cutting features had no seams** — typing, dedup, audit, and idle handling were sprinkled
+  inline rather than living at well-defined boundaries.
+
+## What replaced it
+
+A **5-stage pipeline** (`src/pipeline/createPipeline.ts`), where each stage is a small, independently
+testable unit with explicit inputs and outputs:
+
+```
+Receive ─▶ Decision ─▶ Enrich ─▶ Inference ─▶ Send
+   │           │           │          │          │
+ normalize   should we   history +  call the   post-process
+ inbound     respond?    memory +   LLM         + deliver
+ message     (relevance, context              + typing/dedup
+             crowding,
+             mentions)
+```
+
+| Stage | File | Responsibility |
+|---|---|---|
+| Receive | `src/pipeline/ReceiveStage.ts` | Normalize the platform message into the internal shape; drop bot/self/ignored. |
+| Decision | `src/pipeline/DecisionStage.ts` | Selective engagement — relevance, direct address, momentum, crowding; records the decision. |
+| Enrich | `src/pipeline/EnrichStage.ts` | Gather channel history and memory; assemble context. |
+| Inference | `src/pipeline/InferenceStage.ts` | Call the LLM (function/tool calling, streaming where supported). |
+| Send | `src/pipeline/SendStage.ts` | Post-process, deliver, handle typing/dedup, record activity. |
+
+The win isn't just tidiness: each stage is a natural attachment point for the things the monolith had
+nowhere to put — **decision tracing**, **per-stage metrics**, a **pipeline debugger pause point**, and
+**activity recording** that feeds the WebUI's live feed.
+
+## What still remains
+
+- `USE_LEGACY_HANDLER=true` reverts to `handleMessage()`. It is kept as a fallback and a reference
+  implementation, **not** the supported path — the pipeline is the default and where features land.
+- Some helpers are shared between the two paths; over time the legacy-only code is expected to be
+  retired once the pipeline reaches full parity (a few cross-cutting stages — content filtering,
+  semantic guardrail, command handling — are tracked toward parity in [ROADMAP.md](../../../ROADMAP.md)).
+
+## See also
+
+- Current design: [Architecture Overview](../overview.md), [Layered Overview](../layered-overview.md)
+- Forward plan / parity gaps: [ROADMAP.md](../../../ROADMAP.md)
+- Per-feature audit: [FEATURE_STATUS.md](../../FEATURE_STATUS.md)

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,5 +1,8 @@
 # Open-Hivemind Architecture
 
+> New here? Read the [Vision](../VISION.md) first for *why* the system is shaped this way, and the
+> [Legacy Architecture](legacy/README.md) section for designs this one replaced.
+
 ## System Overview
 
 Open-Hivemind is a full-stack monorepo with a React frontend, Express.js backend, and plugin-based provider architecture.

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -94,4 +94,4 @@ DEBUG=app:BotConfigurationManager npm run dev
 
 For deeper dives into multi-instance orchestration, read
 [`multi-instance-setup.md`](multi-instance-setup.md) and the
-[`PACKAGE.md`](../../PACKAGE.md) capability matrix.
+[`package.md`](../reference/package.md) capability matrix.

--- a/docs/operations/file-locations.md
+++ b/docs/operations/file-locations.md
@@ -1,0 +1,54 @@
+# File & Directory Locations
+
+Where Open-Hivemind reads and writes data at runtime — what to back up, what's disposable, and how to
+relocate it. This is the single source of truth for paths; other docs link here rather than repeat it.
+
+## Where things live today
+
+All runtime paths resolve **relative to the working directory of the server process** (`process.cwd()`)
+unless an environment override is set. There is no central path resolver yet — see
+[Proposed: XDG support](#proposed-xdg-base-directory-support).
+
+| Purpose | Default location | Override | Back up? |
+|---|---|---|---|
+| App config (convict + per-provider config) | `config/` | `NODE_CONFIG_DIR` | yes |
+| User-editable config (bots, personas) | `config/user/` — `custom-bots.json`, `custom-personas.json`, `persona-order.json` | — | **yes** |
+| Database (SQLite) | `data/hivemind.db` | `DATABASE_PATH` (absolute or cwd-relative) | **yes** |
+| Other state | `data/` — `greeting-state.json`, `agents.json`, onboarding data | — | yes |
+| Config backups | `config/backups/` | — | (these *are* the backups) |
+| Logs | `logs/` | — | optional |
+| Runtime cache | _none on disk_ — caching is in-memory only (e.g. `SwarmCoordinator`'s TTL cache) | — | n/a |
+| Bundled program assets | `src/client/dist`, `packages/`, `specs/` | — | no — install-relative program files, not data |
+
+### Operational gotcha
+
+Because most paths are resolved from `process.cwd()` (not the install directory), **run the server
+from the project root** — or set `DATABASE_PATH` / `NODE_CONFIG_DIR` to absolute paths — so config and
+data resolve consistently across restarts and deployment methods. In Docker, mount a volume over
+`data/` (and `config/` if you edit config on disk) to persist across container rebuilds.
+
+## Proposed: XDG Base Directory support
+
+> **Status: proposed, not yet implemented.** Today the paths above are cwd-relative. This section
+> records the intended direction; track it in [ROADMAP.md](../../ROADMAP.md).
+
+For system-service / per-user daemon deployments on Linux, writing into the install/working directory
+is awkward (the install dir may be read-only). The plan is a single path resolver with this
+precedence — **explicit env override → XDG → cwd-relative default** — so existing dev and Docker
+setups keep working unchanged while XDG becomes available opt-in:
+
+| Concern | XDG base | Example |
+|---|---|---|
+| Config (`config/`, `config/user/`) | `$XDG_CONFIG_HOME` | `~/.config/open-hivemind/` |
+| State (DB, logs, backups) | `$XDG_STATE_HOME` | `~/.local/state/open-hivemind/` |
+| Disposable cache (future) | `$XDG_CACHE_HOME` | `~/.cache/open-hivemind/` |
+
+The DB, logs, and backups are treated as machine-local **state** rather than portable data. Adopting
+this would also consolidate the ~30 scattered `process.cwd()` call sites behind one module — the
+larger maintainability win independent of XDG itself.
+
+## See also
+
+- [Backups & System Data](../admin/export.md) — creating/restoring backups via the WebUI
+- [Maintenance Guide](maintenance.md) — operational routines
+- [Configuration Overview](../configuration/overview.md) — what the config values mean


### PR DESCRIPTION
Reorients the documentation to lead with **vision** and an **honest built-vs-remaining assessment**, and adds an **archived/legacy architecture** section — per the project's honesty commitment.

## Landed
- **docs/VISION.md** — the front door: the thesis (a community of AI personas; selective engagement; operator control without code), what we build toward, design principles, and a truthful status snapshot sourced from FEATURE_STATUS.md (218 complete / 64 partial / 20 stub / 5 planned / 0 broken). States plainly what's shipped and what's honestly partial, with a standing 'if the docs out-claim the code, that's a bug' commitment.
- **docs/architecture/legacy/** — new section preserving superseded designs. Index + a full write-up of the **monolithic `handleMessage()` → 5-stage pipeline** (Receive · Decision · Enrich · Inference · Send): what it was, why it existed, why it changed, what replaced it, and that the legacy handler still ships behind `USE_LEGACY_HANDLER`.
- **README.md / docs/README.md** — Vision surfaced front and centre; legacy section linked under Architecture.

## In progress (autonomous doc loop, every 30 min)
Expanding the documentation set incrementally — each a small, verified, committed change:
- [ ] Persona-storage legacy write-up (legacy `/api/agents/personas` store → `PersonaManager`)
- [ ] Pre-unified-server legacy write-up (separate frontend/backend → single `tsx` process)
- [ ] Tighten any remaining doc claims against FEATURE_STATUS (no over-claims)
- [ ] Cross-link vision/status from more entry points; verify all relative links resolve

All claims are grounded in the code audit; verified links resolve. Not for merge until reviewed.