### PR TITLE
fix(serverless): writable upload dir — Netlify/Vercel 502 hotfix

### DIFF
--- a/src/server/routes/importExport.ts
+++ b/src/server/routes/importExport.ts
@@ -33,9 +33,23 @@ type _AuthMulterRequest = AuthMiddlewareRequest & { file?: MulterFile };
 const router = Router();
 const logger = createLogger('importExportRouter');
 
-// Configure multer for file uploads
+// Configure multer for file uploads.
+// The dest is resolved at module load (multer mkdir's it in its constructor),
+// so it must be writable in whatever runtime imports this module. On
+// serverless platforms the working dir is read-only and only /tmp is writable;
+// detect those via runtime-provided env vars (set before module load, unlike
+// applyServerlessEnvDefaults which runs later) and fall back to /tmp/uploads.
+// UPLOAD_DIR overrides everything for explicit configuration.
+const UPLOAD_DIR =
+  process.env.UPLOAD_DIR ||
+  (process.env.LAMBDA_TASK_ROOT ||
+  process.env.AWS_LAMBDA_FUNCTION_NAME ||
+  process.env.VERCEL ||
+  process.env.NETLIFY
+    ? '/tmp/uploads'
+    : 'config/uploads/');
 const upload = multer({
-  dest: 'config/uploads/',
+  dest: UPLOAD_DIR,
   limits: {
     fileSize: 50 * 1024 * 1024, // 50MB limit
   },


### PR DESCRIPTION
## Production-down hotfix

The live Netlify function (discord-llm-bot) and Vercel deploy were **502ing on every request** — `/api/health`, `/api/dashboard/status`, etc. — so every admin page (e.g. /admin/settings) errored.

### Root cause (from the live function log)
```
ENOENT: no such file or directory, mkdir 'config/uploads/'
  at new DiskStorage ... at new Multer
```
`src/server/routes/importExport.ts` configured `multer({ dest: 'config/uploads/' })` at **module load**. Multer's DiskStorage `mkdirSync`'s its dest in its constructor, but on serverless the working dir is read-only (only `/tmp` is writable) → cold-start crash → entire `/api/*` surface down. `applyServerlessEnvDefaults()` can't help: it runs *after* the route module is already imported.

### Fix
Resolve the upload dir at module load: honor `UPLOAD_DIR`, else detect a serverless runtime via platform env vars (`LAMBDA_TASK_ROOT` / `AWS_LAMBDA_FUNCTION_NAME` / `VERCEL` / `NETLIFY`, all set by the runtime *before* module load) → `/tmp/uploads`; otherwise keep `config/uploads/` unchanged for normal server runs.

### Verification
- Built the Netlify bundle with the fix; draft-deployed via the authed CLI. The **ENOENT mkdir crash is gone** (the function now boots past it).
- The draft then surfaced a `bcrypt` native-arch error — an **artifact of deploying a locally-built bundle** (my machine's native binary ≠ Lambda's). Production's *original* error was the mkdir ENOENT (not bcrypt), confirming Netlify's own build compiles bcrypt correctly. **Merging → Netlify builds on its runtime is the definitive verification.**

No new deps; no architecture change; normal-server behavior unchanged.