### PR TITLE
test/ui hardening (round 2)

### DIFF
--- a/src/server/middleware/csrf.ts
+++ b/src/server/middleware/csrf.ts
@@ -62,6 +62,9 @@ function startCleanupInterval() {
     },
     60 * 60 * 1000
   ); // Clean up every hour
+  // Don't let this hourly background timer keep the process alive (e.g. Jest
+  // open-handle leaks that force --forceExit and mask real teardown issues).
+  cleanupInterval?.unref?.();
 }
 
 startCleanupInterval();

--- a/src/utils/TimerRegistry.ts
+++ b/src/utils/TimerRegistry.ts
@@ -114,6 +114,8 @@ export class TimerRegistry {
     this.enforceMaxTimers();
 
     const handle = setInterval(callback, intervalMs);
+    // Registered intervals shouldn't keep the process alive on their own.
+    handle.unref?.();
 
     const record: TimerRecord = {
       id,
@@ -268,6 +270,7 @@ export class TimerRegistry {
     this.cleanupInterval = setInterval(() => {
       this.cleanupOldTimers();
     }, this.CLEANUP_INTERVAL_MS);
+    this.cleanupInterval?.unref?.();
   }
 
   /**


### PR DESCRIPTION
Incremental hardening, one verified change per commit.

## Done
- [x] **unref CSRF + TimerRegistry background intervals** — these periodic cleanup timers kept the event loop alive (Jest open handles forcing --forceExit). `unref()`'d; verified via --detectOpenHandles that the csrf.ts:49 / TimerRegistry.ts:116 handles are gone and csrfWiring.test passes 4/4. Behavior unchanged.

## Queued (from .hardening-backlog.md)
- [ ] unref 2 more leak sources found this pass: BotManager.scheduleStatusReports (BotManager.ts:69), RealTimeValidationService.setupEventHandlers (:131)
- [ ] Health-page self-contradiction (AdminHealthPage)
- [ ] 429 surfaced 3x (toast + inline + navbar)
- [ ] smoke coverage for /admin/{about,plugin-security,health/providers}
- [ ] client crash hotspots (SpecDetailPage spec.tags, AnalyticsDashboard/MemoryProvidersPage unguarded data)

Not for merge until reviewed.