### PR TITLE
fix(serverless): ephemeral DATABASE_ENCRYPTION_KEY (Vercel 500 fix)

### DIFF
--- a/src/server/serverlessEnv.ts
+++ b/src/server/serverlessEnv.ts
@@ -19,6 +19,7 @@
  * don't need this pre-import timing.
  */
 import fs from 'fs';
+import crypto from 'crypto';
 
 const isServerless = !!(
   process.env.LAMBDA_TASK_ROOT ||
@@ -29,6 +30,12 @@ const isServerless = !!(
 
 if (isServerless) {
   const base = process.env.OH_SERVERLESS_BASE || '/tmp/open-hivemind';
+  // EncryptionService throws FATAL at module load when NODE_ENV=production and
+  // no key is set (Vercel sets NODE_ENV=production). Mint an ephemeral key for
+  // the stateless demo (the /tmp DB is wiped on cold start anyway); any value
+  // works (it is sha256-normalized). A real configured key always wins.
+  process.env.DATABASE_ENCRYPTION_KEY =
+    process.env.DATABASE_ENCRYPTION_KEY || crypto.randomBytes(32).toString('hex');
   try {
     for (const sub of ['', '/config', '/config/providers', '/config/user', '/data', '/uploads', '/logs']) {
       fs.mkdirSync(`${base}${sub}`, { recursive: true });


### PR DESCRIPTION
Third serverless boot-crash layer (after #3052 multer + #3053 /tmp). On Vercel `NODE_ENV=production`, so `EncryptionService` threw FATAL at module load with no `DATABASE_ENCRYPTION_KEY` → 500. (Netlify unaffected — NODE_ENV not production there.) `serverlessEnv.ts` now mints an ephemeral key (pre-import timing); any value works (sha256-normalized), real key wins, /tmp DB is ephemeral anyway. Verified: Netlify runs identical code green; Vercel build Ready (function-level verify blocked by Vercel deployment-protection).