### PR TITLE
💎 Hone: UX Engineering Refactor [Structural Polish & State Integrity]

### DIFF
--- a/src/client/src/components/DaisyUI/Accordion.tsx
+++ b/src/client/src/components/DaisyUI/Accordion.tsx
@@ -123,9 +123,9 @@ const Accordion: React.FC<AccordionProps> = ({
               className="peer"
             />
 
-            <div
-              className={getTitleClasses()}
-              role="button"
+            <button
+              type="button"
+              className={getTitleClasses() + ' w-full text-left'}
               tabIndex={isDisabled ? -1 : 0}
               onClick={() => !isDisabled && handleToggle(item.id)}
               onKeyDown={(e) => {
@@ -136,7 +136,7 @@ const Accordion: React.FC<AccordionProps> = ({
               }}
               aria-expanded={isOpen}
               aria-controls={`accordion-content-${item.id}`}
-              aria-disabled={isDisabled}
+              disabled={isDisabled}
             >
               <div className={`flex items-center gap-2 ${iconPosition === 'right' ? 'justify-between' : ''}`}>
                 {iconPosition === 'left' && item.icon && (
@@ -147,7 +147,7 @@ const Accordion: React.FC<AccordionProps> = ({
                   <span className="text-2xl" aria-hidden="true">{item.icon}</span>
                 )}
               </div>
-            </div>
+            </button>
 
             <div
               className={getContentClasses()}

--- a/src/client/src/components/DaisyUI/DataTable.tsx
+++ b/src/client/src/components/DaisyUI/DataTable.tsx
@@ -525,7 +525,15 @@ const DataTable = <T extends Record<string, any>>({
 
                 {/* Actions as button group */}
                 {actions && actions.length > 0 && (
-                  <div className="card-actions justify-end mt-2 pt-2 border-t border-base-200" onClick={e => e.stopPropagation()}>
+                  <div
+                    className="card-actions justify-end mt-2 pt-2 border-t border-base-200"
+                    onClick={e => e.stopPropagation()}
+                    onKeyDown={e => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.stopPropagation();
+                      }
+                    }}
+                  >
                     {renderActions(row, idx, true)}
                   </div>
                 )}

--- a/src/client/src/components/DaisyUI/DetailDrawer.tsx
+++ b/src/client/src/components/DaisyUI/DetailDrawer.tsx
@@ -52,13 +52,13 @@ const DetailDrawer: React.FC<DetailDrawerProps> = ({
 
   // Prevent body scroll when drawer is open
   useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = '';
-    }
+    if (!isOpen) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
     return () => {
-      document.body.style.overflow = '';
+      document.body.style.overflow = previousOverflow;
     };
   }, [isOpen]);
 

--- a/src/client/src/components/DaisyUI/Dropdown.tsx
+++ b/src/client/src/components/DaisyUI/Dropdown.tsx
@@ -106,9 +106,9 @@ const Dropdown: React.FC<DropdownProps> = ({
 
   return (
     <div className={`dropdown ${positionClasses[position]} ${className}`} ref={dropdownRef}>
-      <div
+      <button
+        type="button"
         tabIndex={disabled ? -1 : 0}
-        role="button"
         className={`btn ${sizeClasses[size]} ${colorClasses[color]} ${disabled ? 'btn-disabled opacity-50' : ''} ${triggerClassName}`}
         onClick={handleToggle}
         onKeyDown={handleKeyDown}
@@ -119,7 +119,7 @@ const Dropdown: React.FC<DropdownProps> = ({
       >
         {trigger}
         {!hideArrow && <ChevronDownIcon className="h-5 w-5" aria-hidden="true" />}
-      </div>
+      </button>
       {isOpen && (
         <ul id={menuId} tabIndex={0} className={`dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52 z-50 ${contentClassName}`} role="menu">
           {children}

--- a/src/client/src/components/DaisyUI/HamburgerMenu.tsx
+++ b/src/client/src/components/DaisyUI/HamburgerMenu.tsx
@@ -49,10 +49,10 @@ const HamburgerMenu: React.FC<HamburgerMenuProps> = ({
   className = '',
 }) => {
   return (
-    <div
+    <button
+      type="button"
       className={`btn btn-ghost btn-circle lg:hidden min-h-[44px] min-w-[44px] ${className}`}
       onClick={onClick}
-      role="button"
       tabIndex={0}
       aria-label={isOpen ? 'Close menu' : 'Open menu'}
       aria-expanded={isOpen}
@@ -65,7 +65,7 @@ const HamburgerMenu: React.FC<HamburgerMenuProps> = ({
         variant="rotate"
         className="swap-active-inherit"
       />
-    </div>
+    </button>
   );
 };
 

--- a/src/client/src/components/DaisyUI/ThemeDropdown.tsx
+++ b/src/client/src/components/DaisyUI/ThemeDropdown.tsx
@@ -36,20 +36,20 @@ const ThemeDropdown: React.FC<ThemeDropdownProps> = ({
   if (!mounted) {
     return (
       <div className={dropdownClass}>
-        <div tabIndex={0} role="button" className="btn btn-ghost btn-sm btn-circle" aria-label="Theme menu">
+        <button type="button" tabIndex={0} className="btn btn-ghost btn-sm btn-circle" aria-label="Theme menu">
           <Palette className="w-4 h-4" />
-        </div>
+        </button>
       </div>
     );
   }
 
   return (
     <div className={dropdownClass}>
-      <div tabIndex={0} role="button" className="btn btn-ghost btn-sm gap-1" aria-label="Theme switcher">
+      <button type="button" tabIndex={0} className="btn btn-ghost btn-sm gap-1" aria-label="Theme switcher">
         <Palette className="w-4 h-4" />
         <span className="hidden sm:inline">Theme</span>
         <ChevronDown className="w-3 h-3 opacity-60" />
-      </div>
+      </button>
       <ul tabIndex={0} className="dropdown-content bg-base-300 rounded-box z-[1] w-56 p-2 shadow-2xl max-h-[calc(100vh-10rem)] overflow-y-auto mt-2 mb-2">
         {AVAILABLE_THEMES.map((t) => (
           <li key={t}>

--- a/src/client/src/components/Dashboard.tsx
+++ b/src/client/src/components/Dashboard.tsx
@@ -105,6 +105,7 @@ const Dashboard: React.FC = () => {
 
   const fetchData = useCallback(async () => {
     try {
+      setLoading(true);
       setError(null);
       const [botsResult, statusResult, healthResult, profilesResult] = await Promise.allSettled([
         apiService.getBots(),

--- a/src/client/src/pages/SpecDetailPage.tsx
+++ b/src/client/src/pages/SpecDetailPage.tsx
@@ -127,11 +127,12 @@ ${spec.content.replace(/^/gm, '  ')}
                   </Button>
                   <Dropdown
                     trigger={
-                      <Button className="btn-primary">
+                      <>
                         <Download className="w-4 h-4 mr-2" />
                         Export
-                      </Button>
+                      </>
                     }
+                    color="primary"
                   >
                     {exportItems.map((item) => (
                       <li key={item.label}><a onClick={item.onClick}>{item.label}</a></li>


### PR DESCRIPTION
### 💎 Hone: UX Engineering Refactor [Structural Polish & State Integrity]

This PR delivers three significant systemic UX and accessibility refactors driven by the Hone agent's exhaustive repository audit.

#### 🎯 What & Why

**COMPONENT A: Architectural UX (Semantic HTML5 Overhaul)**
- **What:** Refactored `<div role="button">` wrappers to native `<button type="button">` in `ThemeDropdown.tsx`, `Dropdown.tsx`, `HamburgerMenu.tsx`, and `Accordion.tsx`. Correctly configured the `DataTable.tsx` inner row actions container to stop keyboard event propagation on `Enter`/`Space`. Also refactored `SpecDetailPage.tsx` to supply a Fragment instead of a nested `Button` inside `Dropdown.tsx` to prevent invalid nested `<button>` hydration.
- **Why:** To enforce semantic structural integrity across DaisyUI wrappers and fix focus, activation, and screen reader event bubbling issues.

**COMPONENT B: State Machine Integrity (`Dashboard.tsx`)**
- **What:** Hardened the `fetchData` network callback within `src/client/src/components/Dashboard.tsx`. Explicitly implemented `setLoading(true)` on every manual trigger (like the refresh interaction).
- **Why:** Restores deterministic async state transitions. Solves the issue where manual re-fetches would not provide a "loading" state to the UI, leading to potentially brittle states or race-condition-like flashes when data takes longer to return.

**COMPONENT C: Structural Polish & Scroll Management (`DetailDrawer.tsx`)**
- **What:** Replaced the blind scroll-lock clearing (`document.body.style.overflow = ''`) with robust closure management that stores and dynamically restores the `previousOverflow` state.
- **Why:** Fixes a critical scroll-lock bug that gets triggered when unmounting nested dialogs or overlays that also fight to manage `body` overflow.

#### 🚦 CI Validation
- **Total Tests Passed:** All frontend and Vitest regressions passed successfully (`537 passed (537)`).
- **Lint Cleanliness:** Clean run with zero new regressions on `src/client` (`check-types` and `lint`).
- **Build Success:** Validated.
- **Documentation:** Logged insights to `.jules/hone.md`.

---
*PR created automatically by Jules for task [2520709508715279101](https://jules.google.com/task/2520709508715279101) started by @matthewhand*